### PR TITLE
Add VS Code config to enable build, test and debug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": "Git Credential Manager (get)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/git-credential-manager/bin/Debug/netcoreapp2.1/git-credential-manager.dll",
+            "args": ["get"],
+            "cwd": "${workspaceFolder}/src/git-credential-manager",
+            "console": "integratedTerminal",
+            "stopAtEntry": false,
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,36 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "group":{
+                "kind": "build",
+                "isDefault": true
+            },
+            "args": [
+                "build",
+                "${workspaceFolder}/src/git-credential-manager/git-credential-manager.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "test",
+            "command": "dotnet",
+            "type": "shell",
+            "group":{
+                "kind": "test",
+                "isDefault": true
+            },
+            "args": [
+                "test",
+                "${workspaceFolder}/tests/**/*.csproj"
+            ],
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Add launch.json and tasks.json files for building, running unit tests and debugging GCM in Visual Studio Code.

You can execute a build using the `Run Build Task` command (default shortcut Mac: <kbd>Shift+Command+B</kbd>, Windows: <kbd>Ctrl+Shift+B</kbd>) and run all tests with the `Run Test Task` command.

There are two debug launch configurations: one to attach to an existing GCM process (such as one launched with `GCM_DEBUG=1`), and one to start a new GCM process with the `get` verb.

These additions should provide a slighter nicer than basic development experience outside of Visual Studio (full/non-Code).