### PR TITLE
Add license headers and update LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,22 @@
-    MIT License
+Git Credential Manager Core
+Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Copyright (c) Microsoft Corporation. All rights reserved.
+MIT License
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE

--- a/src/Microsoft.Git.CredentialManager/CommandContext.cs
+++ b/src/Microsoft.Git.CredentialManager/CommandContext.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Microsoft.Git.CredentialManager/Commands/Command.cs
+++ b/src/Microsoft.Git.CredentialManager/Commands/Command.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/Microsoft.Git.CredentialManager/Commands/EraseCommand.cs
+++ b/src/Microsoft.Git.CredentialManager/Commands/EraseCommand.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Threading.Tasks;
 

--- a/src/Microsoft.Git.CredentialManager/Commands/GetCommand.cs
+++ b/src/Microsoft.Git.CredentialManager/Commands/GetCommand.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Threading.Tasks;
 

--- a/src/Microsoft.Git.CredentialManager/Commands/HelpCommand.cs
+++ b/src/Microsoft.Git.CredentialManager/Commands/HelpCommand.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.IO;
 using System.Linq;

--- a/src/Microsoft.Git.CredentialManager/Commands/StoreCommand.cs
+++ b/src/Microsoft.Git.CredentialManager/Commands/StoreCommand.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Threading.Tasks;
 

--- a/src/Microsoft.Git.CredentialManager/Commands/VersionCommand.cs
+++ b/src/Microsoft.Git.CredentialManager/Commands/VersionCommand.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Microsoft.Git.CredentialManager/Constants.cs
+++ b/src/Microsoft.Git.CredentialManager/Constants.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System.Text;
 
 namespace Microsoft.Git.CredentialManager

--- a/src/Microsoft.Git.CredentialManager/EnsureArgument.cs
+++ b/src/Microsoft.Git.CredentialManager/EnsureArgument.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 
 namespace Microsoft.Git.CredentialManager

--- a/src/Microsoft.Git.CredentialManager/FileSystem.cs
+++ b/src/Microsoft.Git.CredentialManager/FileSystem.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System.IO;
 
 namespace Microsoft.Git.CredentialManager

--- a/src/Microsoft.Git.CredentialManager/GitCredential.cs
+++ b/src/Microsoft.Git.CredentialManager/GitCredential.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Globalization;
 using System.Text;

--- a/src/Microsoft.Git.CredentialManager/HostProvider.cs
+++ b/src/Microsoft.Git.CredentialManager/HostProvider.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System.Threading.Tasks;
 
 namespace Microsoft.Git.CredentialManager

--- a/src/Microsoft.Git.CredentialManager/HostProviderRegistry.cs
+++ b/src/Microsoft.Git.CredentialManager/HostProviderRegistry.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.Git.CredentialManager/HttpClientExtensions.cs
+++ b/src/Microsoft.Git.CredentialManager/HttpClientExtensions.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Net.Http;
 using System.Threading;

--- a/src/Microsoft.Git.CredentialManager/HttpClientFactory.cs
+++ b/src/Microsoft.Git.CredentialManager/HttpClientFactory.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;

--- a/src/Microsoft.Git.CredentialManager/InputArguments.cs
+++ b/src/Microsoft.Git.CredentialManager/InputArguments.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/Microsoft.Git.CredentialManager/PlatformUtils.cs
+++ b/src/Microsoft.Git.CredentialManager/PlatformUtils.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/src/Microsoft.Git.CredentialManager/SecureStorage/Credential.cs
+++ b/src/Microsoft.Git.CredentialManager/SecureStorage/Credential.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Git.CredentialManager.SecureStorage
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+namespace Microsoft.Git.CredentialManager.SecureStorage
 {
     /// <summary>
     /// Represents a simple credential; user name and password pair.

--- a/src/Microsoft.Git.CredentialManager/SecureStorage/ICredentialStore.cs
+++ b/src/Microsoft.Git.CredentialManager/SecureStorage/ICredentialStore.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Git.CredentialManager.SecureStorage
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+namespace Microsoft.Git.CredentialManager.SecureStorage
 {
     /// <summary>
     /// Represents a secure storage location for <see cref="ICredential"/>s.

--- a/src/Microsoft.Git.CredentialManager/SecureStorage/MacOSKeychain.cs
+++ b/src/Microsoft.Git.CredentialManager/SecureStorage/MacOSKeychain.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;

--- a/src/Microsoft.Git.CredentialManager/SecureStorage/NativeMethods.Mac.cs
+++ b/src/Microsoft.Git.CredentialManager/SecureStorage/NativeMethods.Mac.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/Microsoft.Git.CredentialManager/SecureStorage/NativeMethods.Windows.cs
+++ b/src/Microsoft.Git.CredentialManager/SecureStorage/NativeMethods.Windows.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;

--- a/src/Microsoft.Git.CredentialManager/SecureStorage/NativeMethods.cs
+++ b/src/Microsoft.Git.CredentialManager/SecureStorage/NativeMethods.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/Microsoft.Git.CredentialManager/SecureStorage/WindowsCredentialManager.cs
+++ b/src/Microsoft.Git.CredentialManager/SecureStorage/WindowsCredentialManager.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/Microsoft.Git.CredentialManager/StreamExtensions.cs
+++ b/src/Microsoft.Git.CredentialManager/StreamExtensions.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Microsoft.Git.CredentialManager/StringExtensions.cs
+++ b/src/Microsoft.Git.CredentialManager/StringExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
 
 namespace Microsoft.Git.CredentialManager
 {

--- a/src/Microsoft.Git.CredentialManager/Trace.cs
+++ b/src/Microsoft.Git.CredentialManager/Trace.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/git-credential-manager/Application.cs
+++ b/src/git-credential-manager/Application.cs
@@ -1,4 +1,6 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/src/git-credential-manager/Program.cs
+++ b/src/git-credential-manager/Program.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 
 namespace Microsoft.Git.CredentialManager

--- a/tests/Microsoft.Git.CredentialManager.Tests/Commands/HostProviderCommandBaseTests.cs
+++ b/tests/Microsoft.Git.CredentialManager.Tests/Commands/HostProviderCommandBaseTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.IO;
 using System.Threading.Tasks;

--- a/tests/Microsoft.Git.CredentialManager.Tests/GitCredentialTests.cs
+++ b/tests/Microsoft.Git.CredentialManager.Tests/GitCredentialTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using Xunit;
 
 namespace Microsoft.Git.CredentialManager.Tests

--- a/tests/Microsoft.Git.CredentialManager.Tests/HostProviderRegistryTests.cs
+++ b/tests/Microsoft.Git.CredentialManager.Tests/HostProviderRegistryTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using Moq;

--- a/tests/Microsoft.Git.CredentialManager.Tests/HttpClientFactoryTests.cs
+++ b/tests/Microsoft.Git.CredentialManager.Tests/HttpClientFactoryTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System.Collections.Generic;
 using System.Net.Http;
 using Xunit;

--- a/tests/Microsoft.Git.CredentialManager.Tests/InputArgumentsTests.cs
+++ b/tests/Microsoft.Git.CredentialManager.Tests/InputArgumentsTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/tests/Microsoft.Git.CredentialManager.Tests/PlatformFactAttribute.cs
+++ b/tests/Microsoft.Git.CredentialManager.Tests/PlatformFactAttribute.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;

--- a/tests/Microsoft.Git.CredentialManager.Tests/SecureStorage/MacOSKeychainTests.cs
+++ b/tests/Microsoft.Git.CredentialManager.Tests/SecureStorage/MacOSKeychainTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using Xunit;
 using Microsoft.Git.CredentialManager.SecureStorage;

--- a/tests/Microsoft.Git.CredentialManager.Tests/SecureStorage/WindowsCredentialManagerTests.cs
+++ b/tests/Microsoft.Git.CredentialManager.Tests/SecureStorage/WindowsCredentialManagerTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using Xunit;
 using Microsoft.Git.CredentialManager.SecureStorage;

--- a/tests/Microsoft.Git.CredentialManager.Tests/StreamExtensionsTests.cs
+++ b/tests/Microsoft.Git.CredentialManager.Tests/StreamExtensionsTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/tests/Microsoft.Git.CredentialManager.Tests/StringExtensionsTests.cs
+++ b/tests/Microsoft.Git.CredentialManager.Tests/StringExtensionsTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 using System.Collections.Generic;
 using Xunit;
 


### PR DESCRIPTION
Per legal requirements received in an internal Microsoft OSS email:

 - Add license & copyright headers to every code file,
 - Update the LICENSE file as given in an internal email:
   - Add the product name,
   - Update ordering of 'copyright' and 'MIT License' lines to match order given in internal email.