### PR TITLE
Fix secret tracing to print correct masking characters

### DIFF
--- a/src/Microsoft.Git.CredentialManager/Trace.cs
+++ b/src/Microsoft.Git.CredentialManager/Trace.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Git.CredentialManager
             [System.Runtime.CompilerServices.CallerMemberName] string memberName = "");
     }
 
-    internal class Trace : ITrace, IDisposable
+    public class Trace : ITrace, IDisposable
     {
         private readonly object _writersLock = new object();
         private readonly List<TextWriter> _writers = new List<TextWriter>();
@@ -211,7 +211,7 @@ namespace Microsoft.Git.CredentialManager
         {
             string message = this.EnableSecretTracing
                            ? string.Format(format, secrets)
-                           : string.Format(format, secrets.Select(x => "********"));
+                           : string.Format(format, secrets.Select(_ => (object)"********").ToArray());
 
             WriteLine(message, filePath, lineNumber, memberName);
         }

--- a/src/git-credential-manager/Application.cs
+++ b/src/git-credential-manager/Application.cs
@@ -61,7 +61,8 @@ namespace Microsoft.Git.CredentialManager
             if (context.IsEnvironmentVariableTruthy(Constants.EnvironmentVariables.GcmTraceSecrets, false))
             {
                 context.Trace.EnableSecretTracing = true;
-                context.StdError.WriteLine("Secret tracing is enabled. Trace output may contain sensitive information.");
+                context.StdError.WriteLine(
+                    "warning: Secret tracing is enabled. Trace output may contain sensitive information.");
             }
 
             // Register all supported host providers

--- a/tests/Microsoft.Git.CredentialManager.Tests/TraceTests.cs
+++ b/tests/Microsoft.Git.CredentialManager.Tests/TraceTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Git.CredentialManager.Tests
+{
+    public class TraceTests
+    {
+        [Fact]
+        public void Trace_WriteLineSecrets_SecretTracingEnabled_WritesSecretValues()
+        {
+            const string secret1 = "foo";
+            const string secret2 = "bar";
+            const string secret3 = "test";
+
+            var sb = new StringBuilder();
+            var listener = new StringWriter(sb);
+
+            var trace = new Trace();
+            trace.AddListener(listener);
+            trace.EnableSecretTracing = true;
+
+            trace.WriteLineSecrets("Secrets: {0} {1} {2}", new object[]{ secret1, secret2, secret3 });
+
+            string expectedTraceEnd = $"Secrets: {secret1} {secret2} {secret3}\n";
+            string actualTrace = sb.ToString();
+
+            Assert.EndsWith(expectedTraceEnd, actualTrace, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Trace_WriteLineSecrets_SecretTracingDisabled_WritesMaskedValues()
+        {
+            const string mask = "********";
+            const string secret1 = "foo";
+            const string secret2 = "bar";
+            const string secret3 = "test";
+
+            var sb = new StringBuilder();
+            var listener = new StringWriter(sb);
+
+            var trace = new Trace();
+            trace.AddListener(listener);
+            trace.EnableSecretTracing = false;
+
+            trace.WriteLineSecrets("Secrets: {0} {1} {2}", new object[]{ secret1, secret2, secret3 });
+
+            string expectedTraceEnd = $"Secrets: {mask} {mask} {mask}\n";
+            string actualTrace = sb.ToString();
+
+            Assert.EndsWith(expectedTraceEnd, actualTrace, StringComparison.Ordinal);
+        }
+    }
+}


### PR DESCRIPTION
Fix the secret tracing facility to actually print the masking characters rather than a type name of the 'IEnumerable<string>' or similar text.

Currently when secret tracing is disabled (GCM_TRACE_SECRETS=0) we are printing things like this:
```
This is a secret value: 'System.Linq.Enumerable+SelectArrayIterator`2[System.Object,System.String]'
```

..rather than this:

```
This is a secret value: '******'
```