### PR TITLE
Add GitHub host provider (with basic TTY credential prompts)

### DIFF
--- a/Git-Credential-Manager.sln
+++ b/Git-Credential-Manager.sln
@@ -27,6 +27,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{DD8B847B
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestInfrastructure", "common\tests\TestInfrastructure\TestInfrastructure.csproj", "{5A7D9E8B-C1D2-4C5C-BE98-648C41D1F8BD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitHub", "common\src\GitHub\GitHub.csproj", "{3C840B06-A595-4FD9-9A76-56CD45B14780}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitHub.Tests", "common\tests\GitHub.Tests\GitHub.Tests.csproj", "{03B9B82B-7DCA-4554-97AB-C98FF18FB385}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,6 +87,22 @@ Global
 		{5A7D9E8B-C1D2-4C5C-BE98-648C41D1F8BD}.WindowsDebug|Any CPU.Build.0 = Debug|Any CPU
 		{5A7D9E8B-C1D2-4C5C-BE98-648C41D1F8BD}.WindowsRelease|Any CPU.ActiveCfg = Release|Any CPU
 		{5A7D9E8B-C1D2-4C5C-BE98-648C41D1F8BD}.WindowsRelease|Any CPU.Build.0 = Release|Any CPU
+		{3C840B06-A595-4FD9-9A76-56CD45B14780}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C840B06-A595-4FD9-9A76-56CD45B14780}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C840B06-A595-4FD9-9A76-56CD45B14780}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C840B06-A595-4FD9-9A76-56CD45B14780}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C840B06-A595-4FD9-9A76-56CD45B14780}.WindowsDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C840B06-A595-4FD9-9A76-56CD45B14780}.WindowsDebug|Any CPU.Build.0 = Debug|Any CPU
+		{3C840B06-A595-4FD9-9A76-56CD45B14780}.WindowsRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{3C840B06-A595-4FD9-9A76-56CD45B14780}.WindowsRelease|Any CPU.Build.0 = Release|Any CPU
+		{03B9B82B-7DCA-4554-97AB-C98FF18FB385}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03B9B82B-7DCA-4554-97AB-C98FF18FB385}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03B9B82B-7DCA-4554-97AB-C98FF18FB385}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03B9B82B-7DCA-4554-97AB-C98FF18FB385}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03B9B82B-7DCA-4554-97AB-C98FF18FB385}.WindowsDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03B9B82B-7DCA-4554-97AB-C98FF18FB385}.WindowsDebug|Any CPU.Build.0 = Debug|Any CPU
+		{03B9B82B-7DCA-4554-97AB-C98FF18FB385}.WindowsRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{03B9B82B-7DCA-4554-97AB-C98FF18FB385}.WindowsRelease|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -98,6 +118,8 @@ Global
 		{1229E443-E66C-402F-8AA4-5AE6A207D3C7} = {66722747-1B61-40E4-A89B-1AC8E6D62EA9}
 		{DD8B847B-286B-4928-867B-E09C6C90DA1F} = {66722747-1B61-40E4-A89B-1AC8E6D62EA9}
 		{5A7D9E8B-C1D2-4C5C-BE98-648C41D1F8BD} = {4B305AC9-153F-4EA3-822F-3E5023BABAF1}
+		{3C840B06-A595-4FD9-9A76-56CD45B14780} = {A7FC1234-95E3-4496-B5F7-4306F41E6A0E}
+		{03B9B82B-7DCA-4554-97AB-C98FF18FB385} = {4B305AC9-153F-4EA3-822F-3E5023BABAF1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0EF9FC65-E6BA-45D4-A455-262A9EA4366B}

--- a/common/src/Git-Credential-Manager/Git-Credential-Manager.csproj
+++ b/common/src/Git-Credential-Manager/Git-Credential-Manager.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\GitHub\GitHub.csproj" />
     <ProjectReference Include="..\Microsoft.AzureRepos\Microsoft.AzureRepos.csproj" />
     <ProjectReference Include="..\Microsoft.Git.CredentialManager\Microsoft.Git.CredentialManager.csproj" />
   </ItemGroup>

--- a/common/src/Git-Credential-Manager/Program.cs
+++ b/common/src/Git-Credential-Manager/Program.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 using System;
+using GitHub;
 using Microsoft.AzureRepos;
 
 namespace Microsoft.Git.CredentialManager
@@ -15,6 +16,7 @@ namespace Microsoft.Git.CredentialManager
                 // Register all supported host providers
                 app.ProviderRegistry.Register(
                     new AzureReposHostProvider(context),
+                    new GitHubHostProvider(context),
                     new GenericHostProvider(context)
                 );
 

--- a/common/src/GitHub/AuthenticationResult.cs
+++ b/common/src/GitHub/AuthenticationResult.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using Microsoft.Git.CredentialManager;
+
+namespace GitHub
+{
+    public struct AuthenticationResult
+    {
+        public AuthenticationResult(GitHubAuthenticationResultType type)
+        {
+            Type = type;
+            Token = null;
+        }
+
+        public AuthenticationResult(GitHubAuthenticationResultType type, GitCredential token)
+        {
+            Type = type;
+            Token = token;
+        }
+
+        public GitHubAuthenticationResultType Type { get; }
+
+        public GitCredential Token { get; }
+    }
+
+    public enum GitHubAuthenticationResultType
+    {
+        Success,
+        Failure,
+        TwoFactorApp,
+        TwoFactorSms,
+    }
+}

--- a/common/src/GitHub/GitHub.csproj
+++ b/common/src/GitHub/GitHub.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <RootNamespace>GitHub</RootNamespace>
+        <AssemblyName>GitHub</AssemblyName>
+        <IsTestProject>false</IsTestProject>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Microsoft.Git.CredentialManager\Microsoft.Git.CredentialManager.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/common/src/GitHub/GitHubAuthentication.cs
+++ b/common/src/GitHub/GitHubAuthentication.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using Microsoft.Git.CredentialManager;
+
+namespace GitHub
+{
+    public interface IGitHubAuthentication
+    {
+        bool TryGetCredentials(Uri targetUri, out string userName, out string password);
+
+        bool TryGetAuthenticationCode(Uri targetUri, bool isSms, out string authenticationCode);
+    }
+
+    public class TtyGitHubPromptAuthentication : IGitHubAuthentication
+    {
+        private readonly ICommandContext _context;
+
+        public TtyGitHubPromptAuthentication(ICommandContext context)
+        {
+            EnsureArgument.NotNull(context, nameof(context));
+
+            _context = context;
+        }
+
+        public bool TryGetCredentials(Uri targetUri, out string userName, out string password)
+        {
+            EnsureTerminalPromptsEnabled();
+
+            _context.StdError.WriteLine("Enter credentials for '{0}'...", targetUri);
+
+            userName = _context.Prompt("Username");
+            password = _context.PromptSecret("Password");
+
+            return !string.IsNullOrWhiteSpace(userName) && !string.IsNullOrWhiteSpace(password);
+        }
+
+        public bool TryGetAuthenticationCode(Uri targetUri, bool isSms, out string authenticationCode)
+        {
+            EnsureTerminalPromptsEnabled();
+
+            _context.StdError.WriteLine("Two-factor authentication is enabled and an authentication code is required.");
+
+            if (isSms)
+            {
+                _context.StdError.WriteLine("An SMS containing the authentication code has been sent to your registered device.");
+            }
+            else
+            {
+                _context.StdError.WriteLine("Use your registered authentication app to generate an authentication code.");
+            }
+
+            authenticationCode = _context.Prompt("Authentication code");
+            return !string.IsNullOrWhiteSpace(authenticationCode);
+        }
+
+        private void EnsureTerminalPromptsEnabled()
+        {
+            if (_context.TryGetEnvironmentVariable(
+                    Constants.EnvironmentVariables.GitTerminalPrompts, out string envarPrompts)
+                && envarPrompts == "0")
+            {
+                _context.Trace.WriteLine($"{Constants.EnvironmentVariables.GitTerminalPrompts} is 0; terminal prompts have been disabled.");
+
+                throw new InvalidOperationException("Cannot show GitHub credential prompt because terminal prompts have been disabled.");
+            }
+        }
+    }
+}

--- a/common/src/GitHub/GitHubConstants.cs
+++ b/common/src/GitHub/GitHubConstants.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+namespace GitHub
+{
+    public static class GitHubConstants
+    {
+        public const string GitHubBaseUrlHost = "github.com";
+        public const string GistBaseUrlHost = "gist." + GitHubBaseUrlHost;
+
+        /// <summary>
+        /// The GitHub required HTTP accepts header value
+        /// </summary>
+        public const string GitHubApiAcceptsHeaderValue = "application/vnd.github.v3+json";
+        public const string GitHubOptHeader = "X-GitHub-OTP";
+
+        public static class TokenScopes
+        {
+            public const string Gist = "gist";
+            public const string Repo = "repo";
+        }
+    }
+}

--- a/common/src/GitHub/GitHubHostProvider.cs
+++ b/common/src/GitHub/GitHubHostProvider.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Threading.Tasks;
+using Microsoft.Git.CredentialManager;
+
+namespace GitHub
+{
+    public class GitHubHostProvider : HostProvider
+    {
+        private static readonly string[] GitHubCredentialScopes =
+        {
+            GitHubConstants.TokenScopes.Gist,
+            GitHubConstants.TokenScopes.Repo
+        };
+
+        private readonly IGitHubRestApi _gitHubApi;
+        private readonly IGitHubAuthentication _gitHubAuth;
+
+        public GitHubHostProvider(ICommandContext context)
+            : this(context, new GitHubRestApi(context), new TtyGitHubPromptAuthentication(context)) { }
+
+        public GitHubHostProvider(ICommandContext context, IGitHubRestApi gitHubApi, IGitHubAuthentication gitHubAuth)
+            : base(context)
+        {
+            EnsureArgument.NotNull(gitHubApi, nameof(gitHubApi));
+            EnsureArgument.NotNull(gitHubAuth, nameof(gitHubAuth));
+
+            _gitHubApi = gitHubApi;
+            _gitHubAuth = gitHubAuth;
+        }
+
+        public override string Name => "GitHub";
+
+        public override bool IsSupported(InputArguments input)
+        {
+            // We do not support unencrypted HTTP communications to GitHub,
+            // but we report `true` here for HTTP so that we can show a helpful
+            // error message for the user in `CreateCredentialAsync`.
+            return input != null &&
+                   (StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "http") ||
+                    StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "https")) &&
+                   (StringComparer.OrdinalIgnoreCase.Equals(input.Host, GitHubConstants.GitHubBaseUrlHost) ||
+                    StringComparer.OrdinalIgnoreCase.Equals(input.Host, GitHubConstants.GistBaseUrlHost));
+        }
+
+        public override string GetCredentialKey(InputArguments input)
+        {
+            string url = GetTargetUri(input).AbsoluteUri;
+
+            // Trim trailing slash
+            if (url.EndsWith("/"))
+            {
+                return url.Substring(0, url.Length - 1);
+            }
+
+            return url;
+        }
+
+        public override async Task<GitCredential> CreateCredentialAsync(InputArguments input)
+        {
+            // We should not allow unencrypted communication and should inform the user
+            if (StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "http"))
+            {
+                throw new Exception("Unencrypted HTTP is not supported for GitHub. Ensure the repository remote URL is using HTTPS.");
+            }
+
+            Uri targetUri = GetTargetUri(input);
+
+            if (_gitHubAuth.TryGetCredentials(targetUri, out string username, out string password))
+            {
+                AuthenticationResult result = await _gitHubApi.AcquireTokenAsync(
+                    targetUri, username, password, null, GitHubCredentialScopes);
+
+                if (result.Type == GitHubAuthenticationResultType.Success)
+                {
+                    Context.Trace.WriteLine($"Token acquisition for '{targetUri}' succeeded");
+
+                    return result.Token;
+                }
+
+                if (result.Type == GitHubAuthenticationResultType.TwoFactorApp ||
+                    result.Type == GitHubAuthenticationResultType.TwoFactorSms)
+                {
+                    bool isSms = result.Type == GitHubAuthenticationResultType.TwoFactorSms;
+
+                    if (_gitHubAuth.TryGetAuthenticationCode(targetUri, isSms, out string authenticationCode))
+                    {
+                        result = await _gitHubApi.AcquireTokenAsync(
+                            targetUri, username, password, authenticationCode, GitHubCredentialScopes);
+
+                        if (result.Type == GitHubAuthenticationResultType.Success)
+                        {
+                            Context.Trace.WriteLine($"Token acquisition for '{targetUri}' succeeded.");
+
+                            return result.Token;
+                        }
+                    }
+                }
+            }
+
+            throw new Exception($"Interactive logon for '{targetUri}' failed.");
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _gitHubApi.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        #region Private Methods
+
+        private static Uri NormalizeUri(Uri targetUri)
+        {
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
+
+            // Special case for gist.github.com which are git backed repositories under the hood.
+            // Credentials for these repositories are the same as the one stored with "github.com"
+            if (targetUri.DnsSafeHost.Equals(GitHubConstants.GistBaseUrlHost, StringComparison.OrdinalIgnoreCase))
+            {
+                return new Uri("https://" + GitHubConstants.GitHubBaseUrlHost);
+            }
+
+            return targetUri;
+        }
+
+        private static Uri GetTargetUri(InputArguments input)
+        {
+            Uri uri = new UriBuilder
+            {
+                Scheme = input.Protocol,
+                Host = input.Host,
+            }.Uri;
+
+            return NormalizeUri(uri);
+        }
+
+        #endregion
+    }
+}

--- a/common/src/GitHub/GitHubRestApi.cs
+++ b/common/src/GitHub/GitHubRestApi.cs
@@ -1,0 +1,228 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.Git.CredentialManager;
+
+namespace GitHub
+{
+    public interface IGitHubRestApi : IDisposable
+    {
+        Task<AuthenticationResult> AcquireTokenAsync(
+            Uri targetUri,
+            string username,
+            string password,
+            string authenticationCode,
+            IEnumerable<string> scopes);
+    }
+
+    public class GitHubRestApi : IGitHubRestApi
+    {
+        /// <summary>
+        /// The maximum wait time for a network request before timing out
+        /// </summary>
+        private const int RequestTimeout = 15 * 1000; // 15 second limit
+
+        private readonly ICommandContext _context;
+        private readonly IHttpClientFactory _httpFactory;
+
+        public GitHubRestApi(ICommandContext context)
+            : this(context, new HttpClientFactory()) { }
+
+        public GitHubRestApi(ICommandContext context, IHttpClientFactory httpFactory)
+        {
+            EnsureArgument.NotNull(context, nameof(context));
+            EnsureArgument.NotNull(httpFactory, nameof(httpFactory));
+
+            _context = context;
+            _httpFactory = httpFactory;
+        }
+
+        #region IGitHubApi
+
+        public async Task<AuthenticationResult> AcquireTokenAsync(Uri targetUri, string username, string password, string authenticationCode, IEnumerable<string> scopes)
+        {
+            EnsureArgument.AbsoluteUri(targetUri, nameof(targetUri));
+            EnsureArgument.NotNull(scopes, nameof(scopes));
+
+            string base64Cred = new GitCredential(username, password).ToBase64String();
+
+            Uri requestUri = GetAuthenticationRequestUri(targetUri);
+
+            _context.Trace.WriteLine($"HTTP: POST {requestUri}");
+            using (HttpContent content = GetTokenJsonContent(targetUri, scopes))
+            using (var request = new HttpRequestMessage(HttpMethod.Post, requestUri))
+            {
+                // Set the request content as well as auth and 2FA headers
+                request.Content = content;
+                request.Headers.Authorization = new AuthenticationHeaderValue(Constants.Http.WwwAuthenticateBasicScheme, base64Cred);
+                if (!string.IsNullOrWhiteSpace(authenticationCode))
+                {
+                    request.Headers.Add(GitHubConstants.GitHubOptHeader, authenticationCode);
+                }
+
+                // Send the request!
+                using (HttpResponseMessage response = await HttpClient.SendAsync(request))
+                {
+                    _context.Trace.WriteLine($"HTTP: Response {(int) response.StatusCode} [{response.StatusCode}]");
+
+                    switch (response.StatusCode)
+                    {
+                        case HttpStatusCode.OK:
+                        case HttpStatusCode.Created:
+                            return await ParseSuccessResponseAsync(targetUri, response);
+
+                        case HttpStatusCode.Unauthorized:
+                            return ParseUnauthorizedResponse(targetUri, authenticationCode, response);
+
+                        case HttpStatusCode.Forbidden:
+                            return await ParseForbiddenResponseAsync(targetUri, password, response);
+
+                        default:
+                            _context.Trace.WriteLine($"Authentication failed for '{targetUri}'.");
+                            return new AuthenticationResult(GitHubAuthenticationResultType.Failure);
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private async Task<AuthenticationResult> ParseForbiddenResponseAsync(Uri targetUri, string password, HttpResponseMessage response)
+        {
+            // This API only supports Basic authentication. If a valid OAuth token is supplied
+            // as the password, then a Forbidden response is returned instead of an Unauthorized.
+            // In that case, the supplied password is an OAuth token and is valid and we don't need
+            // to create a new personal access token.
+            var contentBody = await response.Content.ReadAsStringAsync();
+            if (contentBody.Contains("This API can only be accessed with username and password Basic Auth"))
+            {
+                _context.Trace.WriteLine($"Authentication success: user supplied personal access token for '{targetUri}'.");
+
+                return new AuthenticationResult(GitHubAuthenticationResultType.Success,
+                    new GitCredential(Constants.PersonalAccessTokenUserName, password));
+            }
+
+            _context.Trace.WriteLine($"Authentication failed for '{targetUri}'.");
+            return new AuthenticationResult(GitHubAuthenticationResultType.Failure);
+        }
+
+        private AuthenticationResult ParseUnauthorizedResponse(Uri targetUri, string authenticationCode, HttpResponseMessage response)
+        {
+            if (string.IsNullOrWhiteSpace(authenticationCode)
+                && response.Headers.Any(x => StringComparer.OrdinalIgnoreCase.Equals(GitHubConstants.GitHubOptHeader, x.Key)))
+            {
+                var mfakvp = response.Headers.First(x =>
+                    StringComparer.OrdinalIgnoreCase.Equals(GitHubConstants.GitHubOptHeader, x.Key) &&
+                    x.Value != null && x.Value.Any());
+
+                if (mfakvp.Value.First().Contains("app"))
+                {
+                    _context.Trace.WriteLine($"Two-factor app authentication code required for '{targetUri}'.");
+                    return new AuthenticationResult(GitHubAuthenticationResultType.TwoFactorApp);
+                }
+                else
+                {
+                    _context.Trace.WriteLine($"Two-factor SMS authentication code required for '{targetUri}'.");
+                    return new AuthenticationResult(GitHubAuthenticationResultType.TwoFactorSms);
+                }
+            }
+            else
+            {
+                _context.Trace.WriteLine($"Authentication failed for '{targetUri}'.");
+                return new AuthenticationResult(GitHubAuthenticationResultType.Failure);
+            }
+        }
+
+        private async Task<AuthenticationResult> ParseSuccessResponseAsync(Uri targetUri, HttpResponseMessage response)
+        {
+            GitCredential token = null;
+            string responseText = await response.Content.ReadAsStringAsync();
+
+            Match tokenMatch;
+            if ((tokenMatch = Regex.Match(responseText, @"\s*""token""\s*:\s*""([^""]+)""\s*",
+                    RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)).Success
+                && tokenMatch.Groups.Count > 1)
+            {
+                string tokenText = tokenMatch.Groups[1].Value;
+                token = new GitCredential(Constants.PersonalAccessTokenUserName, tokenText);
+            }
+
+            if (token == null)
+            {
+                _context.Trace.WriteLine($"Authentication for '{targetUri}' failed.");
+                return new AuthenticationResult(GitHubAuthenticationResultType.Failure);
+            }
+            else
+            {
+                _context.Trace.WriteLine($"Authentication success: new personal access token for '{targetUri}' created.");
+                return new AuthenticationResult(GitHubAuthenticationResultType.Success, token);
+            }
+        }
+
+        private Uri GetAuthenticationRequestUri(Uri targetUri)
+        {
+            if (targetUri.DnsSafeHost.Equals(GitHubConstants.GitHubBaseUrlHost, StringComparison.OrdinalIgnoreCase))
+            {
+                return new Uri("https://api.github.com/authorizations");
+            }
+            else
+            {
+                // If we're here, it's GitHub Enterprise via a configured authority
+                var baseUrl = targetUri.GetLeftPart(UriPartial.Authority);
+                return new Uri(baseUrl + "/api/v3/authorizations");
+            }
+        }
+
+        private HttpContent GetTokenJsonContent(Uri targetUri, IEnumerable<string> scopes)
+        {
+            const string HttpJsonContentType = "application/x-www-form-urlencoded";
+            const string JsonContentFormat = @"{{ ""scopes"": {0}, ""note"": ""git: {1} on {2} at {3:dd-MMM-yyyy HH:mm}"" }}";
+
+            var quotedScopes = scopes.Select(x => $"\"{x}\"");
+            string scopesJson = $"[{string.Join(", ", quotedScopes)}]";
+
+            string jsonContent = string.Format(JsonContentFormat, scopesJson, targetUri, Environment.MachineName, DateTime.Now);
+
+            return new StringContent(jsonContent, Encoding.UTF8, HttpJsonContentType);
+        }
+
+        private HttpClient _httpClient;
+        private HttpClient HttpClient
+        {
+            get
+            {
+                if (_httpClient is null)
+                {
+                    _httpClient = _httpFactory.CreateClient();
+
+                    // Set the common headers and timeout
+                    _httpClient.Timeout = TimeSpan.FromMilliseconds(RequestTimeout);
+                    _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(GitHubConstants.GitHubApiAcceptsHeaderValue));
+                }
+
+                return _httpClient;
+            }
+        }
+
+        #endregion
+
+        #region IDisposable
+
+        public void Dispose()
+        {
+            _httpClient?.Dispose();
+        }
+
+        #endregion
+    }
+}

--- a/common/src/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/common/src/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AzureRepos
             // We should not allow unencrypted communication and should inform the user
             if (StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "http"))
             {
-                throw new Exception("Unencrypted HTTP is not supported for Azure Repos - ensure you are using HTTPS.");
+                throw new Exception("Unencrypted HTTP is not supported for Azure Repos. Ensure the repository remote URL is using HTTPS.");
             }
 
             Uri orgUri = UriHelpers.CreateOrganizationUri(input);

--- a/common/tests/GitHub.Tests/GitHub.Tests.csproj
+++ b/common/tests/GitHub.Tests/GitHub.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+        <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\GitHub\GitHub.csproj" />
+      <ProjectReference Include="..\TestInfrastructure\TestInfrastructure.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/common/tests/GitHub.Tests/GitHubHostProviderTests.cs
+++ b/common/tests/GitHub.Tests/GitHubHostProviderTests.cs
@@ -1,0 +1,238 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Git.CredentialManager;
+using Microsoft.Git.CredentialManager.Tests.Objects;
+using Moq;
+using Xunit;
+
+namespace GitHub.Tests
+{
+    public class GitHubHostProviderTests
+    {
+        [Fact]
+        public void GitHubProvider_IsSupported_GitHubHost_UnencryptedHttp_ReturnsTrue()
+        {
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "http",
+                ["host"] = "github.com",
+            });
+
+            var provider = new GitHubHostProvider(new TestCommandContext());
+
+            // We report that we support unencrypted HTTP here so that we can fail and
+            // show a helpful error message in the call to `CreateCredentialAsync` instead.
+            Assert.True(provider.IsSupported(input));
+        }
+
+        [Fact]
+        public void GitHubProvider_IsSupported_GistHost_UnencryptedHttp_ReturnsTrue()
+        {
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "http",
+                ["host"] = "gist.github.com",
+            });
+
+            var provider = new GitHubHostProvider(new TestCommandContext());
+
+            // We report that we support unencrypted HTTP here so that we can fail and
+            // show a helpful error message in the call to `CreateCredentialAsync` instead.
+            Assert.True(provider.IsSupported(input));
+        }
+
+        [Fact]
+        public void GitHubProvider_IsSupported_GitHubHost_Https_ReturnsTrue()
+        {
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"] = "github.com",
+            });
+
+            var provider = new GitHubHostProvider(new TestCommandContext());
+
+            Assert.True(provider.IsSupported(input));
+        }
+
+        [Fact]
+        public void GitHubProvider_IsSupported_GistHost_Https_ReturnsTrue()
+        {
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"] = "gist.github.com",
+            });
+
+            var provider = new GitHubHostProvider(new TestCommandContext());
+
+            Assert.True(provider.IsSupported(input));
+        }
+
+        [Fact]
+        public void GitHubProvider_IsSupported_NonHttpHttps_ReturnsTrue()
+        {
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "ssh",
+                ["host"] = "github.com",
+            });
+
+            var provider = new GitHubHostProvider(new TestCommandContext());
+
+            Assert.False(provider.IsSupported(input));
+        }
+
+        [Fact]
+        public void GitHubProvider_IsSupported_NonGitHub_ReturnsFalse()
+        {
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"] = "example.com",
+            });
+
+            var provider = new GitHubHostProvider(new TestCommandContext());
+            Assert.False(provider.IsSupported(input));
+        }
+
+        [Fact]
+        public void GitHubProvider_GetCredentialKey_GitHubHost_ReturnsCorrectKey()
+        {
+            const string expectedKey = "https://github.com";
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"] = "github.com",
+            });
+
+            var provider = new GitHubHostProvider(new TestCommandContext());
+            string actualKey = provider.GetCredentialKey(input);
+            Assert.Equal(expectedKey, actualKey);
+        }
+
+        [Fact]
+        public void GitHubProvider_GetCredentialKey_GistHost_ReturnsCorrectKey()
+        {
+            const string expectedKey = "https://github.com";
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"] = "gist.github.com",
+            });
+
+            var provider = new GitHubHostProvider(new TestCommandContext());
+            string actualKey = provider.GetCredentialKey(input);
+            Assert.Equal(expectedKey, actualKey);
+        }
+
+        [Fact]
+        public async Task GitHubProvider_CreateCredentialAsync_UnencryptedHttp_ThrowsException()
+        {
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "http",
+                ["host"] = "github.com",
+            });
+
+            var context = new TestCommandContext();
+            var ghApi = Mock.Of<IGitHubRestApi>();
+            var ghAuth = Mock.Of<IGitHubAuthentication>();
+
+            var provider = new GitHubHostProvider(context, ghApi, ghAuth);
+
+            await Assert.ThrowsAsync<Exception>(() => provider.CreateCredentialAsync(input));
+        }
+
+        [Fact]
+        public async Task GitHubProvider_CreateCredentialAsync_1FAOnly_ReturnsCredential()
+        {
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"] = "github.com",
+            });
+
+            var expectedTargetUri = new Uri("https://github.com/");
+            var expectedUserName = "john.doe";
+            var expectedPassword = "letmein123";
+            IEnumerable<string> expectedPatScopes = new[]
+            {
+                GitHubConstants.TokenScopes.Repo,
+                GitHubConstants.TokenScopes.Gist
+            };
+
+            var patValue = "PERSONAL-ACCESS-TOKEN";
+            var pat = new GitCredential(Constants.PersonalAccessTokenUserName, patValue);
+            var response = new AuthenticationResult(GitHubAuthenticationResultType.Success, pat);
+
+            var context = new TestCommandContext();
+
+            var ghAuthMock = new Mock<IGitHubAuthentication>(MockBehavior.Strict);
+            ghAuthMock.Setup(x => x.TryGetCredentials(expectedTargetUri, out expectedUserName, out expectedPassword))
+                      .Returns(true);
+
+            var ghApiMock = new Mock<IGitHubRestApi>(MockBehavior.Strict);
+            ghApiMock.Setup(x => x.AcquireTokenAsync(expectedTargetUri, expectedUserName, expectedPassword, null, It.IsAny<IEnumerable<string>>()))
+                     .ReturnsAsync(response);
+
+            var provider = new GitHubHostProvider(context, ghApiMock.Object, ghAuthMock.Object);
+
+            GitCredential credential = await provider.CreateCredentialAsync(input);
+
+            Assert.NotNull(credential);
+            Assert.Equal(Constants.PersonalAccessTokenUserName, credential.UserName);
+            Assert.Equal(patValue, credential.Password);
+        }
+
+        [Fact]
+        public async Task GitHubProvider_CreateCredentialAsync_2FARequired_ReturnsCredential()
+        {
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"] = "github.com",
+            });
+
+            var expectedTargetUri = new Uri("https://github.com/");
+            var expectedUserName = "john.doe";
+            var expectedPassword = "letmein123";
+            var expectedAuthCode = "123456";
+            IEnumerable<string> expectedPatScopes = new[]
+            {
+                GitHubConstants.TokenScopes.Repo,
+                GitHubConstants.TokenScopes.Gist
+            };
+
+            var patValue = "PERSONAL-ACCESS-TOKEN";
+            var pat = new GitCredential(Constants.PersonalAccessTokenUserName, patValue);
+            var response1 = new AuthenticationResult(GitHubAuthenticationResultType.TwoFactorApp);
+            var response2 = new AuthenticationResult(GitHubAuthenticationResultType.Success, pat);
+
+            var context = new TestCommandContext();
+
+            var ghAuthMock = new Mock<IGitHubAuthentication>(MockBehavior.Strict);
+            ghAuthMock.Setup(x => x.TryGetCredentials(expectedTargetUri, out expectedUserName, out expectedPassword))
+                      .Returns(true);
+            ghAuthMock.Setup(x => x.TryGetAuthenticationCode(expectedTargetUri, false, out expectedAuthCode))
+                      .Returns(true);
+
+            var ghApiMock = new Mock<IGitHubRestApi>(MockBehavior.Strict);
+            ghApiMock.Setup(x => x.AcquireTokenAsync(expectedTargetUri, expectedUserName, expectedPassword, null, It.IsAny<IEnumerable<string>>()))
+                        .ReturnsAsync(response1);
+            ghApiMock.Setup(x => x.AcquireTokenAsync(expectedTargetUri, expectedUserName, expectedPassword, expectedAuthCode, It.IsAny<IEnumerable<string>>()))
+                        .ReturnsAsync(response2);
+
+            var provider = new GitHubHostProvider(context, ghApiMock.Object, ghAuthMock.Object);
+
+            GitCredential credential = await provider.CreateCredentialAsync(input);
+
+            Assert.NotNull(credential);
+            Assert.Equal(Constants.PersonalAccessTokenUserName, credential.UserName);
+            Assert.Equal(patValue, credential.Password);
+        }
+    }
+}

--- a/common/tests/GitHub.Tests/GitHubRestApiTests.cs
+++ b/common/tests/GitHub.Tests/GitHubRestApiTests.cs
@@ -1,0 +1,408 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.Git.CredentialManager;
+using Microsoft.Git.CredentialManager.Tests.Objects;
+using Xunit;
+
+namespace GitHub.Tests
+{
+    public class GitHubRestApiTests
+    {
+        [Fact]
+        public async Task GitHubRestApi_AcquireTokenAsync_NullUri_ThrowsException()
+        {
+            const string testUserName = "john.doe";
+            const string testPassword = "letmein123";
+            const string testAuthCode = "1234";
+            string[] testScopes = { "scope1", "scope2" };
+
+            var context = new TestCommandContext();
+            var api = new GitHubRestApi(context);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => api.AcquireTokenAsync(null, testUserName, testPassword, testAuthCode, testScopes)
+            );
+        }
+
+        [Fact]
+        public async Task GitHubRestApi_AcquireTokenAsync_NoNetwork_ThrowsException()
+        {
+            const string testUserName = "john.doe";
+            const string testPassword = "letmein123";
+            const string testAuthCode = "1234";
+            string[] testScopes = { "scope1", "scope2" };
+
+            var context = new TestCommandContext();
+            var uri = new Uri("https://example.com");
+
+            var httpHandler = new TestHttpMessageHandler {SimulateNoNetwork = true};
+
+            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
+            var api = new GitHubRestApi(context, httpFactory);
+
+            await Assert.ThrowsAsync<HttpRequestException>(
+                () => api.AcquireTokenAsync(uri, testUserName, testPassword, testAuthCode, testScopes)
+            );
+        }
+
+        [Fact]
+        public async Task GitHubRestApi_AcquireTokenAsync_ValidRequestOK_ReturnsToken()
+        {
+            const string testUserName = "john.doe";
+            const string testPassword = "letmein123";
+            const string testAuthCode = "1234";
+            string[] testScopes = { "scope1", "scope2" };
+
+            var context = new TestCommandContext();
+            var uri = new Uri("https://github.com");
+
+            var expectedRequestUri = new Uri("https://api.github.com/authorizations");
+
+            const string expectedTokenValue = "GITHUB_TOKEN_VALUE";
+            string tokenResponseJson = $"{{ \"token\": \"{expectedTokenValue}\" }}";
+
+            var httpResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(tokenResponseJson)
+            };
+
+            var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
+            httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
+            {
+                AssertBasicAuth(request, testUserName, testPassword);
+                AssertAuthCode(request, testAuthCode);
+                return httpResponse;
+            });
+
+            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
+            var api = new GitHubRestApi(context, httpFactory);
+
+            AuthenticationResult authResult = await api.AcquireTokenAsync(
+                uri, testUserName, testPassword, testAuthCode, testScopes);
+
+            Assert.Equal(GitHubAuthenticationResultType.Success, authResult.Type);
+            Assert.NotNull(authResult.Token);
+            Assert.Equal(expectedTokenValue, authResult.Token.Password);
+        }
+
+        [Fact]
+        public async Task GitHubRestApi_AcquireTokenAsync_ValidRequestOKBadJson_ReturnsFailure()
+        {
+            const string testUserName = "john.doe";
+            const string testPassword = "letmein123";
+            const string testAuthCode = "1234";
+            string[] testScopes = { "scope1", "scope2" };
+
+            var context = new TestCommandContext();
+            var uri = new Uri("https://github.com");
+
+            var expectedRequestUri = new Uri("https://api.github.com/authorizations");
+
+            const string tokenResponseJson = "ThisIsBadJSON";
+
+            var httpResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(tokenResponseJson)
+            };
+
+            var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
+            httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
+            {
+                AssertBasicAuth(request, testUserName, testPassword);
+                AssertAuthCode(request, testAuthCode);
+                return httpResponse;
+            });
+
+            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
+            var api = new GitHubRestApi(context, httpFactory);
+
+            AuthenticationResult authResult = await api.AcquireTokenAsync(
+                uri, testUserName, testPassword, testAuthCode, testScopes);
+
+            Assert.Equal(GitHubAuthenticationResultType.Failure, authResult.Type);
+        }
+
+        [Fact]
+        public async Task GitHubRestApi_AcquireTokenAsync_ValidRequestCreated_ReturnsToken()
+        {
+            const string testUserName = "john.doe";
+            const string testPassword = "letmein123";
+            const string testAuthCode = "1234";
+            string[] testScopes = { "scope1", "scope2" };
+
+            var context = new TestCommandContext();
+            var uri = new Uri("https://github.com");
+
+            var expectedRequestUri = new Uri("https://api.github.com/authorizations");
+
+            const string expectedTokenValue = "GITHUB_TOKEN_VALUE";
+            string tokenResponseJson = $"{{ \"token\": \"{expectedTokenValue}\" }}";
+
+            var httpResponse = new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent(tokenResponseJson)
+            };
+
+            var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
+            httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
+            {
+                AssertBasicAuth(request, testUserName, testPassword);
+                AssertAuthCode(request, testAuthCode);
+                return httpResponse;
+            });
+
+            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
+            var api = new GitHubRestApi(context, httpFactory);
+
+            AuthenticationResult authResult = await api.AcquireTokenAsync(
+                uri, testUserName, testPassword, testAuthCode, testScopes);
+
+            Assert.Equal(GitHubAuthenticationResultType.Success, authResult.Type);
+            Assert.NotNull(authResult.Token);
+            Assert.Equal(expectedTokenValue, authResult.Token.Password);
+        }
+
+        [Fact]
+        public async Task GitHubRestApi_AcquireTokenAsync_Valid1FANoAppAuthCode_ReturnsApp2FARequired()
+        {
+            const string testUserName = "john.doe";
+            const string testPassword = "letmein123";
+            string[] testScopes = { "scope1", "scope2" };
+
+            var context = new TestCommandContext();
+            var uri = new Uri("https://github.com");
+
+            var expectedRequestUri = new Uri("https://api.github.com/authorizations");
+
+            var httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+            httpResponse.Headers.Add(GitHubConstants.GitHubOptHeader, "app");
+
+            var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
+            httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
+            {
+                AssertBasicAuth(request, testUserName, testPassword);
+                AssertAuthCode(request, null);
+                return httpResponse;
+            });
+
+            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
+            var api = new GitHubRestApi(context, httpFactory);
+
+            AuthenticationResult authResult = await api.AcquireTokenAsync(
+                uri, testUserName, testPassword, null, testScopes);
+
+            Assert.Equal(GitHubAuthenticationResultType.TwoFactorApp, authResult.Type);
+        }
+
+        [Fact]
+        public async Task GitHubRestApi_AcquireTokenAsync_Valid1FANoSmsAuthCode_ReturnsSms2FARequired()
+        {
+            const string testUserName = "john.doe";
+            const string testPassword = "letmein123";
+            string[] testScopes = { "scope1", "scope2" };
+
+            var context = new TestCommandContext();
+            var uri = new Uri("https://github.com");
+
+            var expectedRequestUri = new Uri("https://api.github.com/authorizations");
+
+            var httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+            httpResponse.Headers.Add(GitHubConstants.GitHubOptHeader, "sms");
+
+            var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
+            httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
+            {
+                AssertBasicAuth(request, testUserName, testPassword);
+                AssertAuthCode(request, null);
+                return httpResponse;
+            });
+
+            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
+            var api = new GitHubRestApi(context, httpFactory);
+
+            AuthenticationResult authResult = await api.AcquireTokenAsync(
+                uri, testUserName, testPassword, null, testScopes);
+
+            Assert.Equal(GitHubAuthenticationResultType.TwoFactorSms, authResult.Type);
+        }
+
+        [Fact]
+        public async Task GitHubRestApi_AcquireTokenAsync_ValidOAuthToken_ReturnsOAuthToken()
+        {
+            const string testUserName = "john.doe";
+            const string testOAuthToken = "TestOAuthToken";
+            string[] testScopes = { "scope1", "scope2" };
+
+            var context = new TestCommandContext();
+            var uri = new Uri("https://github.com");
+
+            var expectedRequestUri = new Uri("https://api.github.com/authorizations");
+
+            var httpResponse = new HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Content = new StringContent("This API can only be accessed with username and password Basic Auth")
+            };
+
+            var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
+            httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
+            {
+                AssertBasicAuth(request, testUserName, testOAuthToken);
+                AssertAuthCode(request, null);
+                return httpResponse;
+            });
+
+            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
+            var api = new GitHubRestApi(context, httpFactory);
+
+            AuthenticationResult authResult = await api.AcquireTokenAsync(
+                uri, testUserName, testOAuthToken, null, testScopes);
+
+            Assert.Equal(GitHubAuthenticationResultType.Success, authResult.Type);
+            Assert.NotNull(authResult.Token);
+            Assert.Equal(testOAuthToken, authResult.Token.Password);
+        }
+
+        [Fact]
+        public async Task GitHubRestApi_AcquireTokenAsync_Unauthorized_ReturnsFailure()
+        {
+            const string testUserName = "john.doe";
+            const string testPassword = "letmein123";
+            const string testAuthCode = "1234";
+            string[] testScopes = { "scope1", "scope2" };
+
+            var context = new TestCommandContext();
+            var uri = new Uri("https://github.com");
+
+            var expectedRequestUri = new Uri("https://api.github.com/authorizations");
+
+            var httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent(string.Empty)
+            };
+
+            var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
+            httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
+            {
+                AssertBasicAuth(request, testUserName, testPassword);
+                AssertAuthCode(request, testAuthCode);
+                return httpResponse;
+            });
+
+            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
+            var api = new GitHubRestApi(context, httpFactory);
+
+            AuthenticationResult authResult = await api.AcquireTokenAsync(
+                uri, testUserName, testPassword, testAuthCode, testScopes);
+
+            Assert.Equal(GitHubAuthenticationResultType.Failure, authResult.Type);
+        }
+
+        [Fact]
+        public async Task GitHubRestApi_AcquireTokenAsync_Forbidden_ReturnsFailure()
+        {
+            const string testUserName = "john.doe";
+            const string testPassword = "letmein123";
+            const string testAuthCode = "1234";
+            string[] testScopes = { "scope1", "scope2" };
+
+            var context = new TestCommandContext();
+            var uri = new Uri("https://github.com");
+
+            var expectedRequestUri = new Uri("https://api.github.com/authorizations");
+
+            var httpResponse = new HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Content = new StringContent(string.Empty)
+            };
+
+            var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
+            httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
+            {
+                AssertBasicAuth(request, testUserName, testPassword);
+                AssertAuthCode(request, testAuthCode);
+                return httpResponse;
+            });
+
+            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
+            var api = new GitHubRestApi(context, httpFactory);
+
+            AuthenticationResult authResult = await api.AcquireTokenAsync(
+                uri, testUserName, testPassword, testAuthCode, testScopes);
+
+            Assert.Equal(GitHubAuthenticationResultType.Failure, authResult.Type);
+        }
+
+        [Fact]
+        public async Task GitHubRestApi_AcquireTokenAsync_UnknownResponse_ReturnsFailure()
+        {
+            const string testUserName = "john.doe";
+            const string testPassword = "letmein123";
+            const string testAuthCode = "1234";
+            string[] testScopes = { "scope1", "scope2" };
+
+            var context = new TestCommandContext();
+            var uri = new Uri("https://github.com");
+
+            var expectedRequestUri = new Uri("https://api.github.com/authorizations");
+
+            // https://tools.ietf.org/html/rfc2324#section-2.3.2
+            const HttpStatusCode httpIAmATeaPot = (HttpStatusCode) 418;
+            var httpResponse = new HttpResponseMessage(httpIAmATeaPot)
+            {
+                Content = new StringContent("I am a tea pot (short and stout).")
+            };
+
+            var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
+            httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
+            {
+                AssertBasicAuth(request, testUserName, testPassword);
+                AssertAuthCode(request, testAuthCode);
+                return httpResponse;
+            });
+
+            var httpFactory = new TestHttpClientFactory {MessageHandler = httpHandler};
+            var api = new GitHubRestApi(context, httpFactory);
+
+            AuthenticationResult authResult = await api.AcquireTokenAsync(
+                uri, testUserName, testPassword, testAuthCode, testScopes);
+
+            Assert.Equal(GitHubAuthenticationResultType.Failure, authResult.Type);
+        }
+
+        #region Helpers
+
+        private static void AssertBasicAuth(HttpRequestMessage request, string userName, string password)
+        {
+            string expectedBasicValue = new GitCredential(userName, password).ToBase64String();
+
+            AuthenticationHeaderValue authHeader = request.Headers.Authorization;
+            Assert.NotNull(authHeader);
+            Assert.Equal("Basic", authHeader.Scheme);
+            Assert.Equal(expectedBasicValue, authHeader.Parameter);
+        }
+
+        private void AssertAuthCode(HttpRequestMessage request, string authCode)
+        {
+            if (authCode is null)
+            {
+                Assert.False(request.Headers.Contains(GitHubConstants.GitHubOptHeader));
+            }
+            else
+            {
+                Assert.True(request.Headers.TryGetValues(GitHubConstants.GitHubOptHeader, out var values));
+
+                string actualAuthCode = values.Single();
+                Assert.Equal(authCode, actualAuthCode);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/common/tests/Microsoft.AzureRepos.Tests/AzureDevOpsApiTests.cs
+++ b/common/tests/Microsoft.AzureRepos.Tests/AzureDevOpsApiTests.cs
@@ -9,7 +9,6 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager;
 using Microsoft.Git.CredentialManager.Tests.Objects;
-using Moq;
 using Newtonsoft.Json;
 using Xunit;
 


### PR DESCRIPTION
The required web calls and call flow/patterns are based on the original Git Credential Manager GitHub code.

The support for GitHub authentication is by a basic TTY credential prompt (also supporting 2FA). In the future a credential helper which can show GUI to capture the user/pass/auth-code can be added in a similar manner to the Microsoft Authentication Helper.