### PR TITLE
Fix the MSAuthHelper on macOS to trace ADAL logs and return correct exit codes

### DIFF
--- a/common/src/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
+++ b/common/src/Microsoft.Git.CredentialManager/Authentication/MicrosoftAuthentication.cs
@@ -53,9 +53,13 @@ namespace Microsoft.Git.CredentialManager.Authentication
             {
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
-                RedirectStandardError = true,
+                RedirectStandardError = false, // Do not redirect stderr as tracing might be enabled
                 UseShellExecute = false
             };
+
+            // We flush the trace writers here so that the we don't stomp over the
+            // authentication helper's messages.
+            _context.Trace.Flush();
 
             var process = Process.Start(procStartInfo);
 

--- a/common/src/Microsoft.Git.CredentialManager/Constants.cs
+++ b/common/src/Microsoft.Git.CredentialManager/Constants.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Git.CredentialManager
         {
             public const string GcmTrace           = "GCM_TRACE";
             public const string GcmTraceSecrets    = "GCM_TRACE_SECRETS";
+            public const string GcmTraceMsAuth     = "GCM_TRACE_MSAUTH";
             public const string GcmDebug           = "GCM_DEBUG";
             public const string GitTerminalPrompts = "GIT_TERMINAL_PROMPT";
         }

--- a/macos/Microsoft.Authentication.Helper/Podfile
+++ b/macos/Microsoft.Authentication.Helper/Podfile
@@ -1,5 +1,5 @@
 platform :osx, '10.11'
 
 target 'Microsoft.Authentication.Helper' do
-  pod 'ADAL', '~> 2.5.1'
+  pod 'ADAL', '~> 4.0.0'
 end

--- a/macos/Microsoft.Authentication.Helper/Podfile.lock
+++ b/macos/Microsoft.Authentication.Helper/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
-  - ADAL (2.5.4):
-    - ADAL/app-lib (= 2.5.4)
-  - ADAL/app-lib (2.5.4):
+  - ADAL (4.0.0):
+    - ADAL/app-lib (= 4.0.0)
+  - ADAL/app-lib (4.0.0):
     - ADAL/tokencacheheader
 
 DEPENDENCIES:
-  - ADAL (~> 2.5.1)
+  - ADAL (~> 4.0.0)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - ADAL
 
 SPEC CHECKSUMS:
-  ADAL: e7e5aca957d6c67e88cdd68ee3d0c4c4af55e874
+  ADAL: 2f09070fb5a7095172e34409459eca3f3f1d0d23
 
-PODFILE CHECKSUM: aea86594216c71aff5d22f8947aea9501e7ece3f
+PODFILE CHECKSUM: f7b3f5867bd6bb83186e92dedf7b8183795ffc5d
 
 COCOAPODS: 1.5.3

--- a/macos/Microsoft.Authentication.Helper/Source/Core/AHAppDelegate.h
+++ b/macos/Microsoft.Authentication.Helper/Source/Core/AHAppDelegate.h
@@ -14,7 +14,6 @@ typedef void(^AHAppWorkBlock) (void);
 
 @property (retain, nonatomic) NSApplication* application;
 @property (retain, nonatomic) NSError* error;
-@property (assign, nonatomic) BOOL userLoggingAllowed;
 
 -(id)initWithBlock:(AHAppWorkBlock)block logger:(AHLogger*)logger;
 

--- a/macos/Microsoft.Authentication.Helper/Source/Core/AHAppDelegate.m
+++ b/macos/Microsoft.Authentication.Helper/Source/Core/AHAppDelegate.m
@@ -26,10 +26,7 @@ extern const NSString* kErrorDomain;
     [application setDelegate:self];
     [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
 
-    if ([self userLoggingAllowed])
-    {
-        [_logger log:@"Creating application context for authentication prompt"];
-    }
+    AHLOG(_logger, @"Creating application context for authentication prompt");
 
     [NSApp run];
 }

--- a/macos/Microsoft.Authentication.Helper/Source/Core/AHGenerateAccessToken.m
+++ b/macos/Microsoft.Authentication.Helper/Source/Core/AHGenerateAccessToken.m
@@ -28,7 +28,15 @@
 
         ADAuthenticationCallback completionBlock = ^(ADAuthenticationResult *result)
         {
-            accessToken = result.accessToken;
+            if (result.status == AD_SUCCEEDED)
+            {
+                accessToken = result.accessToken;
+            }
+            else // AD_FAILED or AD_USER_CANCELLED
+            {
+                [appDelegate setError:result.error];
+            }
+
             [appDelegate stop];
         };
 

--- a/macos/Microsoft.Authentication.Helper/Source/Core/AHLogger.h
+++ b/macos/Microsoft.Authentication.Helper/Source/Core/AHLogger.h
@@ -4,6 +4,9 @@
 #import <Foundation/Foundation.h>
 #import "AHLogWriter.h"
 
+#define AHLOG(LOGGER,MSG) [LOGGER log:(MSG) fileName:@__FILE__ lineNum:__LINE__]
+#define AHLOG_SECRET(LOGGER,MSG,SECRET) [LOGGER log:(MSG) secretMsg:(SECRET) fileName:@__FILE__ lineNum:__LINE__]
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface AHLogger : NSObject
@@ -12,9 +15,17 @@ NS_ASSUME_NONNULL_BEGIN
     NSDateFormatter *dateFormatter;
 }
 
+@property BOOL enableSecretTracing;
+
 - (instancetype) init;
 - (void) addWriter:(NSObject<AHLogWriter> *) writer;
-- (void) log:(NSString*)message;
+- (void) log:(NSString*)message
+    fileName:(NSString*)fileName
+     lineNum:(int)lineNum;
+- (void) log:(NSString*)message
+   secretMsg:(NSString*)secretMsg
+    fileName:(NSString*)fileName
+    lineNum:(int)lineNum;
 
 @end
 

--- a/macos/Microsoft.Authentication.Helper/Source/main.m
+++ b/macos/Microsoft.Authentication.Helper/Source/main.m
@@ -7,6 +7,7 @@
 #import "AHLogger.h"
 #import "AHFileLogWriter.h"
 #import "AHStdErrorLogWriter.h"
+#import <ADAL/ADAL.h>
 
 BOOL isTruthy(NSString* value) {
     if (value == nil) {
@@ -24,13 +25,19 @@ BOOL isLocalFilePath(NSString *path) {
 }
 
 int main(int argc, const char * argv[]) {
+
     @autoreleasepool {
+        int exitCode;
         NSError* error;
 
         AHLogger *logger = [[AHLogger alloc] init];
 
-        NSString* traceEnvar = [[[NSProcessInfo processInfo] environment] objectForKey:@"GCM_TRACE"];
+        // Configure the application logger based on the common GCM tracing environment variables
+        NSString* traceEnvar        = [[[NSProcessInfo processInfo] environment] objectForKey:@"GCM_TRACE"];
+        NSString* traceSecretsEnvar = [[[NSProcessInfo processInfo] environment] objectForKey:@"GCM_TRACE_SECRETS"];
+        NSString* traceMsAuthEnvar  = [[[NSProcessInfo processInfo] environment] objectForKey:@"GCM_TRACE_MSAUTH"];
 
+        // Enable tracing
         if (isTruthy(traceEnvar)) {
             [logger addWriter:[[AHStdErrorLogWriter alloc] init]];
         }
@@ -38,14 +45,57 @@ int main(int argc, const char * argv[]) {
             [logger addWriter:[[AHFileLogWriter alloc] initWithPath:traceEnvar]];
         }
 
-        [logger log:@"Running Microsoft Authentication helper for macOS"];
+        // Enable tracing of secret/sensitive information
+        if (isTruthy(traceSecretsEnvar)) {
+            [logger setEnableSecretTracing:YES];
+
+            // Also enable PII logging in ADAL
+            [ADLogger setPiiEnabled:YES];
+        }
+
+        // Always disable ADAL from logging to NSLog which prints to stderror directly
+        [ADLogger setNSLogging:NO];
+
+        // Register a callback in ADAL for our logger if GCM_TRACE_MSAUTH is enabled
+        if (isTruthy(traceMsAuthEnvar))
+        {
+            // We try and capture everything we can as this can help with diagnosing
+            // the most complicated authentication problems.
+            [ADLogger setLevel:ADAL_LOG_LEVEL_VERBOSE];
+
+            [ADLogger setLoggerCallback:^(ADAL_LOG_LEVEL logLevel, NSString *message, BOOL containsPii) {
+
+                NSString* logLevelName;
+                switch (logLevel) {
+                    case ADAL_LOG_LEVEL_ERROR:
+                        logLevelName = @"Error";
+                        break;
+                    case ADAL_LOG_LEVEL_WARN:
+                        logLevelName = @"Warning";
+                        break;
+                    case ADAL_LOG_LEVEL_INFO:
+                        logLevelName = @"Info";
+                        break;
+                    case ADAL_LOG_LEVEL_VERBOSE:
+                        logLevelName = @"Verbose";
+                        break;
+                    default:
+                        logLevelName = @"Unknown";
+                        break;
+                }
+
+                [logger log:[NSString stringWithFormat:@"[ADAL] [%@] %@", logLevelName, message] fileName:@"ADAL" lineNum:0];
+            }];
+        }
+
+        AHLOG(logger, @"Running Microsoft Authentication helper for macOS");
 
         NSMutableDictionary<NSString *, NSString *> *configs = [NSMutableDictionary dictionaryFromFileHandle:[NSFileHandle fileHandleWithStandardInput]];
 
         // Extract expected parameters from input
-        NSString* authority = [configs objectForKey:@"authority"];
-        NSString* clientId = [configs objectForKey:@"clientId"];
-        NSString* resource = [configs objectForKey:@"resource"];
+        NSString* authority   = [configs objectForKey:@"authority"];
+        NSString* clientId    = [configs objectForKey:@"clientId"];
+        NSString* resource    = [configs objectForKey:@"resource"];
         NSString* redirectUri = [configs objectForKey:@"redirectUri"];
 
         NSString *accessToken = [AHGenerateAccessToken generateAccessTokenWithAuthority:authority
@@ -55,9 +105,20 @@ int main(int argc, const char * argv[]) {
                                                                                   error:&error
                                                                                  logger:logger];
 
-        NSString* output = [NSString stringWithFormat:@"accessToken=%@\n", accessToken];
-        [output writeToFile:@"/dev/stdout" atomically:NO encoding:NSUTF8StringEncoding error:&error];
-    }
+        NSString* output;
 
-    return 0;
+        if (error == nil && accessToken != nil)
+        {
+            output = [NSString stringWithFormat:@"accessToken=%@\n", accessToken];
+            exitCode = 0;
+        }
+        else
+        {
+            output = [NSString stringWithFormat:@"error=%@\n", [error description]];
+            exitCode = -1;
+        }
+
+        [output writeToFile:@"/dev/stdout" atomically:NO encoding:NSUTF8StringEncoding error:&error];
+        return exitCode;
+    }
 }

--- a/windows/src/Microsoft.Authentication.Helper/Application.cs
+++ b/windows/src/Microsoft.Authentication.Helper/Application.cs
@@ -17,9 +17,10 @@ namespace Microsoft.Authentication.Helper
         {
             try
             {
-                // Listen to ADAL logs if GCM tracing is enabled
-                if (Context.Trace.HasListeners)
+                // Listen to ADAL logs if GCM_TRACE_MSAUTH is set
+                if (Context.IsEnvironmentVariableTruthy(Constants.EnvironmentVariables.GcmTraceMsAuth, false))
                 {
+                    LoggerCallbackHandler.UseDefaultLogging = false;
                     LoggerCallbackHandler.LogCallback = OnAdalLogMessage;
                 }
 


### PR DESCRIPTION
Enable the Microsoft Authentication helper on macOS to include ADAL logging information in the trace output when GCM_TRACE is set. Also respects PII or sensitive information tracing setting GCM_TRACE_SECRETS.

Upgrade to ADAL 4.0.0 which has now fixed the problem of being noisy and writing to NSLog/stderr.

Update the AHLogger trace format output to be consistent with that of the main GCM application and Git's own output.

Correctly return a non-zero exit code and error message on failure.

Fixes #20