### PR TITLE
Ensure macOS build does pod repo update

### DIFF
--- a/build/templates/build-and-test.macos.yml
+++ b/build/templates/build-and-test.macos.yml
@@ -26,6 +26,7 @@ steps:
   displayName: Install CocoaPods for Microsoft Authentication helper
   inputs:
     projectDirectory: 'macos/Microsoft.Authentication.Helper'
+    forceRepoUpdate: true
 
 - task: Xcode@5
   displayName: Compile Microsoft Authentication helper


### PR DESCRIPTION
When we want to consume a newly published CocoaPod we need to ensure the local pod repo is updated before running `pod install`.

Example of a build failure because we're using ADAL 4 that was only recently published:
```
Analyzing dependencies
[!] CocoaPods could not find compatible versions for pod "ADAL":
  In snapshot (Podfile.lock):
    ADAL (= 4.0.0, ~> 4.0.0)

  In Podfile:
    ADAL (~> 4.0.0)

None of your spec sources contain a spec satisfying the dependencies: `ADAL (~> 4.0.0), ADAL (= 4.0.0, ~> 4.0.0)`.

You have either:
 * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.

Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.
```