### PR TITLE
Produce and collect symbols on build

### DIFF
--- a/.azure-pipelines/templates/osx/pack.signed/step1-layout.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step1-layout.yml
@@ -1,5 +1,5 @@
 steps:
-  - script: src/osx/Installer.Mac/layout.sh --configuration='$(configuration)' --output='$(Build.StagingDirectory)/payload'
+  - script: src/osx/Installer.Mac/layout.sh --configuration='$(configuration)' --output='$(Build.StagingDirectory)/payload' --symbol-output='$(Build.StagingDirectory)/symbols'
     displayName: Layout installer payload
 
   - task: PublishPipelineArtifact@0
@@ -7,3 +7,9 @@ steps:
     inputs:
       artifactName: 'tmp.macpayload_unsigned' 
       targetPath: '$(Build.StagingDirectory)/payload'
+
+  - task: PublishPipelineArtifact@0
+    displayName: Upload symbols
+    inputs:
+      artifactName: 'Symbols.Mac'
+      targetPath: '$(Build.StagingDirectory)/symbols'

--- a/src/osx/Microsoft.Authentication.Helper.Mac/Microsoft.Authentication.Helper.xcodeproj/project.pbxproj
+++ b/src/osx/Microsoft.Authentication.Helper.Mac/Microsoft.Authentication.Helper.xcodeproj/project.pbxproj
@@ -368,6 +368,7 @@
 			baseConfigurationReference = D575DD7FD75AFA3F9B59DF88 /* Pods-Microsoft.Authentication.Helper.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -377,6 +378,7 @@
 			baseConfigurationReference = 2617F1D56611A7524A6B795A /* Pods-Microsoft.Authentication.Helper.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/src/osx/Microsoft.Authentication.Helper.Mac/build.sh
+++ b/src/osx/Microsoft.Authentication.Helper.Mac/build.sh
@@ -32,6 +32,7 @@ done
 CONFIGURATION=${CONFIGURATION:=Debug}
 
 MSAUTH_BINOUT=$MSAUTH_OUT/bin/$CONFIGURATION/native
+MSAUTH_SYMOUT=$MSAUTH_OUT/bin/$CONFIGURATION/native.sym
 MSAUTH_OBJOUT=$MSAUTH_OUT/xcodebuild
 
 # Ensure output directories exist
@@ -53,10 +54,16 @@ xcodebuild \
     -configuration $CONFIGURATION \
     -derivedDataPath $MSAUTH_OBJOUT || exit 1
 
+MSAUTH_EXEC=$MSAUTH_OBJOUT/Build/Products/$CONFIGURATION/Microsoft.Authentication.Helper
+
 # Copy binaries
 echo "Copying binaries..."
-MSAUTH_EXEC=$MSAUTH_OBJOUT/Build/Products/$CONFIGURATION/Microsoft.Authentication.Helper
 mkdir -p $MSAUTH_BINOUT || exit 1
 cp $MSAUTH_EXEC $MSAUTH_BINOUT || exit 1
+
+# Copy dSYM symbol files
+echo "Copying symbols..."
+mkdir -p $MSAUTH_SYMOUT || exit 1
+cp -R $MSAUTH_EXEC.dSYM $MSAUTH_SYMOUT || exit 1
 
 echo "Build of Microsoft.Authentication.Helper.Mac complete."


### PR DESCRIPTION
Ensure we are generating symbols (dSYM) for native macOS binaries and collect both managed and native symbols and publish them as a build artefact.

Fixes #28 