### PR TITLE
Unlink the Java GCM from Homebrew if installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Basic HTTP authentication support|&#10003;|&#10003;|&#10003;
 
 To use GCM Core, you can download the [latest installer](https://github.com/Microsoft/Git-Credential-Manager-Core/releases/latest) for your platform. To install, double-click installation package and follow the instructions presented.
 
+### Git Credential Manager for Mac and Linux (Java-based GCM)
+
+If you have an existing installation of the 'Java GCM' on macOS and you have installed this using Homebrew, this installation will be unlinked (`brew unlink git-credential-manager`) when GCM Core is installed. Additionally any symlinks or files previously located at `/usr/local/bin/git-credential-manager` will be replaced with a GCM Core symlink.
+
 ## How to use
 
 You don't! GCM gets called when Git needs credentials for an operation. For example, when pushing (`git push`) to [Azure DevOps](https://dev.azure.com), it automatically opens a window and initializes an OAuth2 flow to get your personal access token.

--- a/src/osx/Installer.Mac/scripts/postinstall
+++ b/src/osx/Installer.Mac/scripts/postinstall
@@ -1,11 +1,30 @@
 #!/bin/bash
 set -e
 
-# Make symlink to GCM in /usr/local/bin
-if [ ! -e /usr/local/bin/git-credential-manager ]
+function IsBrewPkgInstalled
+{
+    # Check if Homebrew is installed
+    /usr/bin/which brew > /dev/null
+    if [ $? -eq 0 ]
+    then
+        # Check if the package has been installed
+        brew ls --versions $1 > /dev/null
+        if [ $? -eq 0 ]
+        then
+            return 0
+        fi
+    fi
+    return 1
+}
+
+# Check if Java GCM is present on this system and unlink it should it exist
+if [ -L /usr/local/bin/git-credential-manager && IsBrewPkgInstalled "git-credential-manager" ]
 then
-    /bin/ln -s /usr/local/share/gcm-core/git-credential-manager /usr/local/bin/git-credential-manager
+    brew unlink git-credential-manager
 fi
+
+# Create symlink to GCM in /usr/local/bin
+/bin/ln -Fs /usr/local/share/gcm-core/git-credential-manager /usr/local/bin/git-credential-manager
 
 # Set system gitconfig for the current user
 USER_ID=`id -u "${USER}"`


### PR DESCRIPTION
If the Java GCM is installed via Homebrew, attempt to unlink it before creating the GCM Core symlink in `/usr/local/bin`.

Also include the `-F` option when creating the symlink for good measure to force overwriting whatever file might already be there. Technically we only need to do this step and not the `brew unlink` but we should try and let Homebrew remove the links it placed rather than just walking over them.

Fixes #44 