### PR TITLE
Refactor to allow `HostProvider`s to override store and erase

### DIFF
--- a/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
+++ b/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
@@ -24,7 +24,7 @@ namespace GitHub.Tests
             var provider = new GitHubHostProvider(new TestCommandContext());
 
             // We report that we support unencrypted HTTP here so that we can fail and
-            // show a helpful error message in the call to `CreateCredentialAsync` instead.
+            // show a helpful error message in the call to `GenerateCredentialAsync` instead.
             Assert.True(provider.IsSupported(input));
         }
 
@@ -40,7 +40,7 @@ namespace GitHub.Tests
             var provider = new GitHubHostProvider(new TestCommandContext());
 
             // We report that we support unencrypted HTTP here so that we can fail and
-            // show a helpful error message in the call to `CreateCredentialAsync` instead.
+            // show a helpful error message in the call to `GenerateCredentialAsync` instead.
             Assert.True(provider.IsSupported(input));
         }
 
@@ -102,7 +102,7 @@ namespace GitHub.Tests
         [Fact]
         public void GitHubHostProvider_GetCredentialKey_GitHubHost_ReturnsCorrectKey()
         {
-            const string expectedKey = "https://github.com";
+            const string expectedKey = "git:https://github.com";
             var input = new InputArguments(new Dictionary<string, string>
             {
                 ["protocol"] = "https",
@@ -117,7 +117,7 @@ namespace GitHub.Tests
         [Fact]
         public void GitHubHostProvider_GetCredentialKey_GistHost_ReturnsCorrectKey()
         {
-            const string expectedKey = "https://github.com";
+            const string expectedKey = "git:https://github.com";
             var input = new InputArguments(new Dictionary<string, string>
             {
                 ["protocol"] = "https",
@@ -130,7 +130,7 @@ namespace GitHub.Tests
         }
 
         [Fact]
-        public async Task GitHubHostProvider_CreateCredentialAsync_UnencryptedHttp_ThrowsException()
+        public async Task GitHubHostProvider_GenerateCredentialAsync_UnencryptedHttp_ThrowsException()
         {
             var input = new InputArguments(new Dictionary<string, string>
             {
@@ -144,11 +144,11 @@ namespace GitHub.Tests
 
             var provider = new GitHubHostProvider(context, ghApi, ghAuth);
 
-            await Assert.ThrowsAsync<Exception>(() => provider.CreateCredentialAsync(input));
+            await Assert.ThrowsAsync<Exception>(() => provider.GenerateCredentialAsync(input));
         }
 
         [Fact]
-        public async Task GitHubHostProvider_CreateCredentialAsync_1FAOnly_ReturnsCredential()
+        public async Task GitHubHostProvider_GenerateCredentialAsync_1FAOnly_ReturnsCredential()
         {
             var input = new InputArguments(new Dictionary<string, string>
             {
@@ -181,7 +181,7 @@ namespace GitHub.Tests
 
             var provider = new GitHubHostProvider(context, ghApiMock.Object, ghAuthMock.Object);
 
-            GitCredential credential = await provider.CreateCredentialAsync(input);
+            ICredential credential = await provider.GenerateCredentialAsync(input);
 
             Assert.NotNull(credential);
             Assert.Equal(Constants.PersonalAccessTokenUserName, credential.UserName);
@@ -189,7 +189,7 @@ namespace GitHub.Tests
         }
 
         [Fact]
-        public async Task GitHubHostProvider_CreateCredentialAsync_2FARequired_ReturnsCredential()
+        public async Task GitHubHostProvider_GenerateCredentialAsync_2FARequired_ReturnsCredential()
         {
             var input = new InputArguments(new Dictionary<string, string>
             {
@@ -228,7 +228,7 @@ namespace GitHub.Tests
 
             var provider = new GitHubHostProvider(context, ghApiMock.Object, ghAuthMock.Object);
 
-            GitCredential credential = await provider.CreateCredentialAsync(input);
+            ICredential credential = await provider.GenerateCredentialAsync(input);
 
             Assert.NotNull(credential);
             Assert.Equal(Constants.PersonalAccessTokenUserName, credential.UserName);

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -51,13 +51,13 @@ namespace GitHub
             // Trim trailing slash
             if (url.EndsWith("/"))
             {
-                return url.Substring(0, url.Length - 1);
+                url = url.Substring(0, url.Length - 1);
             }
 
-            return url;
+            return $"git:{url}";
         }
 
-        public override async Task<GitCredential> CreateCredentialAsync(InputArguments input)
+        public override async Task<ICredential> GenerateCredentialAsync(InputArguments input)
         {
             // We should not allow unencrypted communication and should inform the user
             if (StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "http"))

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Git.CredentialManager;
 using Microsoft.Git.CredentialManager.Authentication;
@@ -17,7 +16,7 @@ namespace Microsoft.AzureRepos
             : this(context, new AzureDevOpsRestApi(context), new MicrosoftAuthentication(context)) { }
 
         public AzureReposHostProvider(ICommandContext context, IAzureDevOpsRestApi azDevOps, IMicrosoftAuthentication msAuth)
-            : base (context)
+            : base(context)
         {
             EnsureArgument.NotNull(azDevOps, nameof(azDevOps));
             EnsureArgument.NotNull(msAuth, nameof(msAuth));
@@ -42,10 +41,10 @@ namespace Microsoft.AzureRepos
 
         public override string GetCredentialKey(InputArguments input)
         {
-            return UriHelpers.CreateOrganizationUri(input).AbsoluteUri;
+            return $"git:{UriHelpers.CreateOrganizationUri(input).AbsoluteUri}";
         }
 
-        public override async Task<GitCredential> CreateCredentialAsync(InputArguments input)
+        public override async Task<ICredential> GenerateCredentialAsync(InputArguments input)
         {
             // We should not allow unencrypted communication and should inform the user
             if (StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "http"))

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/HostProviderCommandBaseTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/Commands/HostProviderCommandBaseTests.cs
@@ -12,11 +12,8 @@ namespace Microsoft.Git.CredentialManager.Tests.Commands
     public class HostProviderCommandBaseTests
     {
         [Fact]
-        public async Task HostProviderCommandBase_ExecuteAsync_CallsExecuteInternalAyncWithCorrectArgs()
+        public async Task HostProviderCommandBase_ExecuteAsync_CallsExecuteInternalAsyncWithCorrectArgs()
         {
-            const string testProviderCredKey = "test-cred-key";
-            const string testFinalCredKey = "git:test-cred-key";
-
             var mockContext = new Mock<ICommandContext>();
             var mockProvider = new Mock<IHostProvider>();
             var mockHostRegistry = new Mock<IHostProviderRegistry>();
@@ -27,8 +24,6 @@ namespace Microsoft.Git.CredentialManager.Tests.Commands
 
             mockProvider.Setup(x => x.IsSupported(It.IsAny<InputArguments>()))
                 .Returns(true);
-            mockProvider.Setup(x => x.GetCredentialKey(It.IsAny<InputArguments>()))
-                .Returns(testProviderCredKey);
 
             string standardIn = "protocol=test\nhost=example.com\npath=a/b/c\n\n";
             TextReader standardInReader = new StringReader(standardIn);
@@ -38,11 +33,10 @@ namespace Microsoft.Git.CredentialManager.Tests.Commands
 
             HostProviderCommandBase testCommand = new TestCommand(mockHostRegistry.Object)
             {
-                VerifyExecuteInternalAsync = (context, input, provider, credentialKey) =>
+                VerifyExecuteInternalAsync = (context, input, provider) =>
                 {
                     Assert.Same(mockContext.Object, context);
                     Assert.Same(mockProvider.Object, provider);
-                    Assert.Equal(testFinalCredKey, credentialKey);
                     Assert.Equal("test", input.Protocol);
                     Assert.Equal("example.com", input.Host);
                     Assert.Equal("a/b/c", input.Path);
@@ -61,14 +55,13 @@ namespace Microsoft.Git.CredentialManager.Tests.Commands
 
             protected override string Name { get; }
 
-            protected override Task ExecuteInternalAsync(ICommandContext context, InputArguments input,
-                IHostProvider provider, string credentialKey)
+            protected override Task ExecuteInternalAsync(ICommandContext context, InputArguments input, IHostProvider provider)
             {
-                VerifyExecuteInternalAsync(context, input, provider, credentialKey);
+                VerifyExecuteInternalAsync(context, input, provider);
                 return Task.CompletedTask;
             }
 
-            public Action<ICommandContext, InputArguments, IHostProvider, string> VerifyExecuteInternalAsync { get; set; }
+            public Action<ICommandContext, InputArguments, IHostProvider> VerifyExecuteInternalAsync { get; set; }
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/GenericProviderTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/GenericProviderTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Git.CredentialManager.Tests
         [Fact]
         public void GenericProvider_GetCredentialKey_ReturnsCorrectKey()
         {
-            const string expectedKey = "https://john.doe@example.com/foo/bar";
+            const string expectedKey = "git:https://john.doe@example.com/foo/bar";
 
             var input = new InputArguments(new Dictionary<string, string>
             {
@@ -96,7 +96,7 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             var provider = new GenericHostProvider(context, basicAuthMock.Object, wiaAuthMock.Object);
 
-            GitCredential credential = await provider.CreateCredentialAsync(input);
+            ICredential credential = await provider.GenerateCredentialAsync(input);
 
             Assert.NotNull(credential);
             Assert.Equal(string.Empty, credential.UserName);
@@ -127,7 +127,7 @@ namespace Microsoft.Git.CredentialManager.Tests
 
             var provider = new GenericHostProvider(context, basicAuthMock.Object, wiaAuthMock.Object);
 
-            GitCredential credential = await provider.CreateCredentialAsync(input);
+            ICredential credential = await provider.GenerateCredentialAsync(input);
 
             Assert.NotNull(credential);
             Assert.Equal(testUserName, credential.UserName);

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/HostProviderRegistryTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/HostProviderRegistryTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
-using Microsoft.Git.CredentialManager.Tests.Objects;
 using Moq;
 using Xunit;
 
@@ -25,15 +24,18 @@ namespace Microsoft.Git.CredentialManager.Tests
             var registry = new HostProviderRegistry();
             var input = new InputArguments(new Dictionary<string, string>());
 
-            var provider1 = new TestHostProvider {IsSupported = false};
-            var provider2 = new TestHostProvider {IsSupported = true};
-            var provider3 = new TestHostProvider {IsSupported = false};
+            var provider1Mock = new Mock<IHostProvider>();
+            var provider2Mock = new Mock<IHostProvider>();
+            var provider3Mock = new Mock<IHostProvider>();
+            provider1Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
+            provider2Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(true);
+            provider3Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(false);
 
-            registry.Register(provider1, provider2, provider3);
+            registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
 
             IHostProvider result = registry.GetProvider(input);
 
-            Assert.Same(provider2, result);
+            Assert.Same(provider2Mock.Object, result);
         }
 
         [Fact]
@@ -42,15 +44,18 @@ namespace Microsoft.Git.CredentialManager.Tests
             var registry = new HostProviderRegistry();
             var input = new InputArguments(new Dictionary<string, string>());
 
-            var provider1 = new TestHostProvider {IsSupported = true};
-            var provider2 = new TestHostProvider {IsSupported = true};
-            var provider3 = new TestHostProvider {IsSupported = true};
+            var provider1Mock = new Mock<IHostProvider>();
+            var provider2Mock = new Mock<IHostProvider>();
+            var provider3Mock = new Mock<IHostProvider>();
+            provider1Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(true);
+            provider2Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(true);
+            provider3Mock.Setup(x => x.IsSupported(It.IsAny<InputArguments>())).Returns(true);
 
-            registry.Register(provider1, provider2, provider3);
+            registry.Register(provider1Mock.Object, provider2Mock.Object, provider3Mock.Object);
 
             IHostProvider result = registry.GetProvider(input);
 
-            Assert.Same(provider1, result);
+            Assert.Same(provider1Mock.Object, result);
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager.Tests/HostProviderTests.cs
+++ b/src/shared/Microsoft.Git.CredentialManager.Tests/HostProviderTests.cs
@@ -1,0 +1,287 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Git.CredentialManager.Tests.Objects;
+using Xunit;
+
+namespace Microsoft.Git.CredentialManager.Tests
+{
+    public class HostProviderTests
+    {
+        #region GetCredentialAsync
+
+        [Fact]
+        public async Task HostProvider_GetCredentialAsync_CredentialExists_ReturnsExistingCredential()
+        {
+            const string testUserName = "john.doe";
+            const string testPassword = "letmein123";
+            const string testCredentialKey = "git:test-cred-key";
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["username"] = testUserName,
+                ["password"] = testPassword,
+            });
+
+            var context = new TestCommandContext
+            {
+                CredentialStore = {[testCredentialKey] = new GitCredential(testUserName, testPassword)}
+            };
+            var provider = new TestHostProvider(context)
+            {
+                IsSupportedFunc = _ => true,
+                CredentialKey = testCredentialKey,
+                GenerateCredentialFunc = _ =>
+                {
+                    Assert.True(false, "Should never be called");
+                    return null;
+                },
+            };
+
+            ICredential actualCredential = await ((IHostProvider) provider).GetCredentialAsync(input);
+
+            Assert.Equal(testUserName, actualCredential.UserName);
+            Assert.Equal(testPassword, actualCredential.Password);
+        }
+
+        [Fact]
+        public async Task HostProvider_GetCredentialAsync_CredentialDoesNotExist_ReturnsNewGeneratedCredential()
+        {
+            const string testUserName = "john.doe";
+            const string testPassword = "letmein123";
+            const string testCredentialKey = "git:test-cred-key";
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["username"] = testUserName,
+                ["password"] = testPassword,
+            });
+
+            bool generateWasCalled = false;
+            var context = new TestCommandContext();
+            var provider = new TestHostProvider(context)
+            {
+                IsSupportedFunc = _ => true,
+                CredentialKey = testCredentialKey,
+                GenerateCredentialFunc = _ =>
+                {
+                    generateWasCalled = true;
+                    return new GitCredential(testUserName, testPassword);
+                },
+            };
+
+            ICredential actualCredential = await ((IHostProvider) provider).GetCredentialAsync(input);
+
+            Assert.True(generateWasCalled);
+            Assert.Equal(testUserName, actualCredential.UserName);
+            Assert.Equal(testPassword, actualCredential.Password);
+        }
+
+
+            #endregion
+
+        #region StoreCredentialAsync
+
+        [Fact]
+        public async Task HostProvider_StoreCredentialAsync_EmptyCredential_DoesNotStoreCredential()
+        {
+            const string emptyUserName = "";
+            const string emptyPassword = "";
+            const string testCredentialKey = "git:test-cred-key";
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["username"] = emptyUserName,
+                ["password"] = emptyPassword,
+            });
+
+            var context = new TestCommandContext();
+            var provider = new TestHostProvider(context) {CredentialKey = testCredentialKey};
+
+            await ((IHostProvider) provider).StoreCredentialAsync(input);
+
+            Assert.Empty(context.CredentialStore);
+        }
+
+        [Fact]
+        public async Task HostProvider_StoreCredentialAsync_NonEmptyCredential_StoresCredential()
+        {
+            const string testUserName = "john.doe";
+            const string testPassword = "letmein123";
+            const string testCredentialKey = "git:test-cred-key";
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["username"] = testUserName,
+                ["password"] = testPassword,
+            });
+
+            var context = new TestCommandContext();
+            var provider = new TestHostProvider(context) {CredentialKey = testCredentialKey};
+
+            await ((IHostProvider) provider).StoreCredentialAsync(input);
+
+            Assert.Single(context.CredentialStore);
+            Assert.True(context.CredentialStore.TryGetValue(testCredentialKey, out ICredential storedCredential));
+            Assert.Equal(testUserName, storedCredential.UserName);
+            Assert.Equal(testPassword, storedCredential.Password);
+        }
+
+        [Fact]
+        public async Task HostProvider_StoreCredentialAsync_NonEmptyCredential_ExistingCredential_UpdatesCredential()
+        {
+            const string testUserName = "john.doe";
+            const string testPasswordOld = "letmein123-old";
+            const string testPasswordNew = "letmein123-new";
+            const string testCredentialKey = "git:test-cred-key";
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["username"] = testUserName,
+                ["password"] = testPasswordNew,
+            });
+
+            var context = new TestCommandContext
+            {
+                CredentialStore = {[testCredentialKey] = new GitCredential(testUserName, testPasswordOld)}
+            };
+            var provider = new TestHostProvider(context) {CredentialKey = testCredentialKey};
+
+            await ((IHostProvider) provider).StoreCredentialAsync(input);
+
+            Assert.Single(context.CredentialStore);
+            Assert.True(context.CredentialStore.TryGetValue(testCredentialKey, out ICredential storedCredential));
+            Assert.Equal(testUserName, storedCredential.UserName);
+            Assert.Equal(testPasswordNew, storedCredential.Password);
+        }
+
+        #endregion
+
+        #region EraseCredentialAsync
+
+        [Fact]
+        public async Task HostProvider_EraseCredentialAsync_NoInputUserPass_CredentialExists_ErasesCredential()
+        {
+            const string testCredentialKey = "git:test-cred-key";
+            const string otherCredentialKey1 = "git:credential1";
+            const string otherCredentialKey2 = "git:credential2";
+            var input = new InputArguments(new Dictionary<string, string>());
+
+            var context = new TestCommandContext
+            {
+                CredentialStore =
+                {
+                    [testCredentialKey] = new GitCredential("john.doe", "letmein123"),
+                    [otherCredentialKey1] = new GitCredential("this.should-1", "not.be.erased-1"),
+                    [otherCredentialKey2] = new GitCredential("this.should-2", "not.be.erased-2")
+                }
+            };
+            var provider = new TestHostProvider(context) {CredentialKey = testCredentialKey};
+
+            await ((IHostProvider) provider).EraseCredentialAsync(input);
+
+            Assert.Equal(2, context.CredentialStore.Count);
+            Assert.False(context.CredentialStore.ContainsKey(testCredentialKey));
+            Assert.True(context.CredentialStore.ContainsKey(otherCredentialKey1));
+            Assert.True(context.CredentialStore.ContainsKey(otherCredentialKey2));
+        }
+
+        [Fact]
+        public async Task HostProvider_EraseCredentialAsync_InputUserPass_CredentialExists_UserNotMatch_DoesNothing()
+        {
+            const string testUserName = "john.doe";
+            const string testPassword = "letmein123";
+            const string testCredentialKey = "git:test-cred-key";
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["username"] = testUserName,
+                ["password"] = testPassword,
+            });
+
+            var context = new TestCommandContext
+            {
+                CredentialStore = {[testCredentialKey] = new GitCredential("different-username", testPassword)}
+            };
+            var provider = new TestHostProvider(context) {CredentialKey = testCredentialKey};
+
+            await ((IHostProvider) provider).EraseCredentialAsync(input);
+
+            Assert.Single(context.CredentialStore);
+            Assert.True(context.CredentialStore.ContainsKey(testCredentialKey));
+        }
+
+        [Fact]
+        public async Task HostProvider_EraseCredentialAsync_InputUserPass_CredentialExists_PassNotMatch_DoesNothing()
+        {
+            const string testUserName = "john.doe";
+            const string testPassword = "letmein123";
+            const string testCredentialKey = "git:test-cred-key";
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["username"] = testUserName,
+                ["password"] = testPassword,
+            });
+
+            var context = new TestCommandContext
+            {
+                CredentialStore =
+                {
+                    [testCredentialKey] = new GitCredential(testUserName, "different-password"),
+                }
+            };
+            var provider = new TestHostProvider(context) {CredentialKey = testCredentialKey};
+
+            await ((IHostProvider) provider).EraseCredentialAsync(input);
+
+            Assert.Single(context.CredentialStore);
+            Assert.True(context.CredentialStore.ContainsKey(testCredentialKey));
+        }
+
+        [Fact]
+        public async Task HostProvider_EraseCredentialAsync_InputUserPass_CredentialExists_UserPassMatch_ErasesCredential()
+        {
+            const string testUserName = "john.doe";
+            const string testPassword = "letmein123";
+            const string testCredentialKey = "git:test-cred-key";
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["username"] = testUserName,
+                ["password"] = testPassword,
+            });
+
+            var context = new TestCommandContext
+            {
+                CredentialStore = {[testCredentialKey] = new GitCredential(testUserName, testPassword)}
+            };
+            var provider = new TestHostProvider(context) {CredentialKey = testCredentialKey};
+
+            await ((IHostProvider) provider).EraseCredentialAsync(input);
+
+            Assert.Empty(context.CredentialStore);
+            Assert.False(context.CredentialStore.ContainsKey(testCredentialKey));
+        }
+
+        [Fact]
+        public async Task HostProvider_EraseCredentialAsync_NoCredential_DoesNothing()
+        {
+            const string testCredentialKey = "git:test-cred-key";
+            const string otherCredentialKey1 = "git:credential1";
+            const string otherCredentialKey2 = "git:credential2";
+            var input = new InputArguments(new Dictionary<string, string>());
+
+            var context = new TestCommandContext
+            {
+                CredentialStore =
+                {
+                    [otherCredentialKey1] = new GitCredential("this.should-1", "not.be.erased-1"),
+                    [otherCredentialKey2] = new GitCredential("this.should-2", "not.be.erased-2")
+                }
+            };
+            var provider = new TestHostProvider(context) {CredentialKey = testCredentialKey};
+
+            await ((IHostProvider) provider).EraseCredentialAsync(input);
+
+            Assert.Equal(2, context.CredentialStore.Count);
+            Assert.True(context.CredentialStore.ContainsKey(otherCredentialKey1));
+            Assert.True(context.CredentialStore.ContainsKey(otherCredentialKey2));
+        }
+
+        #endregion
+    }
+}

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/Command.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/Command.cs
@@ -58,6 +58,8 @@ namespace Microsoft.Git.CredentialManager.Commands
 
         public override async Task ExecuteAsync(ICommandContext context, string[] args)
         {
+            context.Trace.WriteLine($"Start '{Name}' command...");
+
             // Parse standard input arguments
             // git-credential treats the keys as case-sensitive; so should we.
             IDictionary<string, string> inputDict = await context.StdIn.ReadDictionaryAsync(StringComparer.Ordinal);
@@ -69,22 +71,18 @@ namespace Microsoft.Git.CredentialManager.Commands
             IHostProvider provider = _hostProviderRegistry.GetProvider(input);
             context.Trace.WriteLine($"Host provider '{provider.Name}' was selected.");
 
-            // Build the credential identifier
-            string hostProviderKey = provider.GetCredentialKey(input);
-            string credentialKey = $"git:{hostProviderKey}";
-            context.Trace.WriteLine($"Credential key is '{credentialKey}'.");
+            await ExecuteInternalAsync(context, input, provider);
 
-            await ExecuteInternalAsync(context, input, provider, credentialKey);
+            context.Trace.WriteLine($"End '{Name}' command...");
         }
 
         /// <summary>
-        /// Execute the command using the given <see cref="InputArguments"/>, <see cref="IHostProvider"/>, and <see cref="GitCredential"/> key.
+        /// Execute the command using the given <see cref="InputArguments"/> and <see cref="IHostProvider"/>.
         /// </summary>
         /// <param name="context">The current command execution context.</param>
         /// <param name="input">Input arguments of the current Git credential query.</param>
         /// <param name="provider">Host provider for the current <see cref="InputArguments"/>.</param>
-        /// <param name="credentialKey">Unique identifier in the OS secure storage system for a <see cref="GitCredential"/>.</param>
         /// <returns>Awaitable task for the command execution.</returns>
-        protected abstract Task ExecuteInternalAsync(ICommandContext context, InputArguments input, IHostProvider provider, string credentialKey);
+        protected abstract Task ExecuteInternalAsync(ICommandContext context, InputArguments input, IHostProvider provider);
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/EraseCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/EraseCommand.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.Git.CredentialManager.Commands
@@ -15,50 +14,9 @@ namespace Microsoft.Git.CredentialManager.Commands
 
         protected override string Name => "erase";
 
-        protected override Task ExecuteInternalAsync(ICommandContext context, InputArguments input, IHostProvider provider, string credentialKey)
+        protected override Task ExecuteInternalAsync(ICommandContext context, InputArguments input, IHostProvider provider)
         {
-            // Try to locate an existing credential with the computed key
-            context.Trace.WriteLine("Looking for existing credential in store...");
-            ICredential credential = context.CredentialStore.Get(credentialKey);
-            if (credential == null)
-            {
-                context.Trace.WriteLine("No stored credential was found.");
-                return Task.CompletedTask;
-            }
-            else
-            {
-                context.Trace.WriteLine("Existing credential found.");
-            }
-
-            // If we've been given a specific username and/or password we should only proceed
-            // to erase the stored credential if they match exactly
-            if (!string.IsNullOrWhiteSpace(input.UserName) && !StringComparer.Ordinal.Equals(input.UserName, credential.UserName))
-            {
-                context.Trace.WriteLine("Stored username does not match specified username - not erasing credential.");
-                context.Trace.WriteLine($"\tInput  username={input.UserName}");
-                context.Trace.WriteLine($"\tStored username={credential.UserName}");
-                return Task.CompletedTask;
-            }
-
-            if (!string.IsNullOrWhiteSpace(input.Password) && !StringComparer.Ordinal.Equals(input.Password, credential.Password))
-            {
-                context.Trace.WriteLine("Stored password does not match specified password - not erasing credential.");
-                context.Trace.WriteLineSecrets("\tInput  password={0}", new object[] {input.Password});
-                context.Trace.WriteLineSecrets("\tStored password={0}", new object[] {credential.Password});
-                return Task.CompletedTask;
-            }
-
-            context.Trace.WriteLine("Erasing stored credential...");
-            if (context.CredentialStore.Remove(credentialKey))
-            {
-                context.Trace.WriteLine("Credential was successfully erased.");
-            }
-            else
-            {
-                context.Trace.WriteLine("Credential erase failed.");
-            }
-
-            return Task.CompletedTask;
+            return provider.EraseCredentialAsync(input);
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/GetCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/GetCommand.cs
@@ -15,26 +15,9 @@ namespace Microsoft.Git.CredentialManager.Commands
 
         protected override string Name => "get";
 
-        protected override async Task ExecuteInternalAsync(ICommandContext context, InputArguments input, IHostProvider provider, string credentialKey)
+        protected override async Task ExecuteInternalAsync(ICommandContext context, InputArguments input, IHostProvider provider)
         {
-            // Try and locate an existing PAT in the OS credential store
-            context.Trace.WriteLine("Looking for existing credential in store...");
-            ICredential credential = context.CredentialStore.Get(credentialKey);
-
-            if (credential == null)
-            {
-                context.Trace.WriteLine("No existing credential found.");
-
-                // No existing PAT was found.
-                // Create a new one and add this to the store.
-                context.Trace.WriteLine("Creating new credential...");
-                credential = await provider.CreateCredentialAsync(input);
-                context.Trace.WriteLine("Credential created.");
-            }
-            else
-            {
-                context.Trace.WriteLine("Existing credential found.");
-            }
+            ICredential credential = await provider.GetCredentialAsync(input);
 
             var output = new Dictionary<string, string>();
 

--- a/src/shared/Microsoft.Git.CredentialManager/Commands/StoreCommand.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/Commands/StoreCommand.cs
@@ -14,30 +14,9 @@ namespace Microsoft.Git.CredentialManager.Commands
 
         protected override string Name => "store";
 
-        protected override Task ExecuteInternalAsync(ICommandContext context, InputArguments input, IHostProvider provider, string credentialKey)
+        protected override Task ExecuteInternalAsync(ICommandContext context, InputArguments input, IHostProvider provider)
         {
-            // Create the credential based on Git's input
-            string userName = input.UserName;
-            string password = input.Password;
-
-            // NTLM-authentication is signaled to Git as an empty username/password pair
-            // and we will get called to 'store' these NTLM credentials.
-            // We avoid storing empty credentials.
-            if (string.IsNullOrWhiteSpace(userName) && string.IsNullOrWhiteSpace(password))
-            {
-                context.Trace.WriteLine("Not storing empty credential.");
-            }
-            else
-            {
-                var credential = new GitCredential(userName, password);
-
-                // Add or update the credential in the store.
-                context.Trace.WriteLine("Storing credential...");
-                context.CredentialStore.AddOrUpdate(credentialKey, credential);
-                context.Trace.WriteLine("Credential was successfully stored.");
-            }
-
-            return Task.CompletedTask;
+            return provider.StoreCredentialAsync(input);
         }
     }
 }

--- a/src/shared/Microsoft.Git.CredentialManager/GenericHostProvider.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/GenericHostProvider.cs
@@ -36,10 +36,10 @@ namespace Microsoft.Git.CredentialManager
 
         public override string GetCredentialKey(InputArguments input)
         {
-            return GetUriFromInput(input).AbsoluteUri;
+            return $"git:{GetUriFromInput(input).AbsoluteUri}";
         }
 
-        public override async Task<GitCredential> CreateCredentialAsync(InputArguments input)
+        public override async Task<ICredential> GenerateCredentialAsync(InputArguments input)
         {
             Uri uri = GetUriFromInput(input);
 

--- a/src/shared/Microsoft.Git.CredentialManager/HostProvider.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/HostProvider.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-
 using System;
 using System.Threading.Tasks;
 
@@ -24,25 +23,29 @@ namespace Microsoft.Git.CredentialManager
         bool IsSupported(InputArguments input);
 
         /// <summary>
-        /// Return a key that uniquely represents the given Git credential query arguments.
+        /// Get a credential for accessing the remote Git repository on this hosting service.
         /// </summary>
-        /// <remarks>
-        /// This key forms part of the identifier used to retrieve and store credentials from the OS secure
-        /// credential storage system. It is important the returned value is stable over time to avoid any
-        /// potential re-authentication requests.
-        /// </remarks>
         /// <param name="input">Input arguments of a Git credential query.</param>
-        /// <returns></returns>
-        string GetCredentialKey(InputArguments input);
+        /// <returns>A credential Git can use to authenticate to the remote repository.</returns>
+        Task<ICredential> GetCredentialAsync(InputArguments input);
 
         /// <summary>
-        /// Create a new credential for accessing the remote Git repository on this hosting service.
+        /// Store a credential for accessing the remote Git repository on this hosting service.
         /// </summary>
         /// <param name="input">Input arguments of a Git credential query.</param>
-        /// <returns>A new credential Git can use to authenticate to the remote repository.</returns>
-        Task<GitCredential> CreateCredentialAsync(InputArguments input);
+        Task StoreCredentialAsync(InputArguments input);
+
+        /// <summary>
+        /// Erase a stored credential for accessing the remote Git repository on this hosting service.
+        /// </summary>
+        /// <param name="input">Input arguments of a Git credential query.</param>
+        Task EraseCredentialAsync(InputArguments input);
     }
 
+    /// <summary>
+    /// Represents a Git hosting provider where credentials can be stored and recalled in/from the Operating System's
+    /// secure credential store.
+    /// </summary>
     public abstract class HostProvider : IHostProvider
     {
         protected HostProvider(ICommandContext context)
@@ -59,9 +62,122 @@ namespace Microsoft.Git.CredentialManager
 
         public abstract bool IsSupported(InputArguments input);
 
+        /// <summary>
+        /// Return a key that uniquely represents the given Git credential query arguments.
+        /// </summary>
+        /// <remarks>
+        /// This key forms part of the identifier used to retrieve and store credentials from the OS secure
+        /// credential storage system. It is important the returned value is stable over time to avoid any
+        /// potential re-authentication requests.
+        /// </remarks>
+        /// <param name="input">Input arguments of a Git credential query.</param>
+        /// <returns>Stable credential key.</returns>
         public abstract string GetCredentialKey(InputArguments input);
 
-        public abstract Task<GitCredential> CreateCredentialAsync(InputArguments input);
+        /// <summary>
+        /// Create a new credential used for accessing the remote Git repository on this hosting service.
+        /// </summary>
+        /// <param name="input">Input arguments of a Git credential query.</param>
+        /// <returns>A credential Git can use to authenticate to the remote repository.</returns>
+        public abstract Task<ICredential> GenerateCredentialAsync(InputArguments input);
+
+        public virtual async Task<ICredential> GetCredentialAsync(InputArguments input)
+        {
+            // Try and locate an existing PAT in the OS credential store
+            string credentialKey = GetCredentialKey(input);
+            Context.Trace.WriteLine($"Looking for existing credential in store with key '{credentialKey}'...");
+            ICredential credential = Context.CredentialStore.Get(credentialKey);
+
+            if (credential == null)
+            {
+                Context.Trace.WriteLine("No existing credential found.");
+
+                // No existing credential was found, create a new one
+                Context.Trace.WriteLine("Creating new credential...");
+                credential = await GenerateCredentialAsync(input);
+                Context.Trace.WriteLine("Credential created.");
+            }
+            else
+            {
+                Context.Trace.WriteLine("Existing credential found.");
+            }
+
+            return credential;
+        }
+
+        public virtual Task StoreCredentialAsync(InputArguments input)
+        {
+            // Create the credential based on Git's input
+            string userName = input.UserName;
+            string password = input.Password;
+
+            // WIA-authentication is signaled to Git as an empty username/password pair
+            // and we will get called to 'store' these WIA credentials.
+            // We avoid storing empty credentials.
+            if (string.IsNullOrWhiteSpace(userName) && string.IsNullOrWhiteSpace(password))
+            {
+                Context.Trace.WriteLine("Not storing empty credential.");
+            }
+            else
+            {
+                var credential = new GitCredential(userName, password);
+
+                // Add or update the credential in the store.
+                string credentialKey = GetCredentialKey(input);
+                Context.Trace.WriteLine($"Storing credential with key '{credentialKey}'...");
+                Context.CredentialStore.AddOrUpdate(credentialKey, credential);
+                Context.Trace.WriteLine("Credential was successfully stored.");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public virtual Task EraseCredentialAsync(InputArguments input)
+        {
+            // Try to locate an existing credential with the computed key
+            string credentialKey = GetCredentialKey(input);
+            Context.Trace.WriteLine($"Looking for existing credential in store with key '{credentialKey}'...");
+            ICredential credential = Context.CredentialStore.Get(credentialKey);
+            if (credential == null)
+            {
+                Context.Trace.WriteLine("No stored credential was found.");
+                return Task.CompletedTask;
+            }
+            else
+            {
+                Context.Trace.WriteLine("Existing credential found.");
+            }
+
+            // If we've been given a specific username and/or password we should only proceed
+            // to erase the stored credential if they match exactly
+            if (!string.IsNullOrWhiteSpace(input.UserName) && !StringComparer.Ordinal.Equals(input.UserName, credential.UserName))
+            {
+                Context.Trace.WriteLine("Stored username does not match specified username - not erasing credential.");
+                Context.Trace.WriteLine($"\tInput  username={input.UserName}");
+                Context.Trace.WriteLine($"\tStored username={credential.UserName}");
+                return Task.CompletedTask;
+            }
+
+            if (!string.IsNullOrWhiteSpace(input.Password) && !StringComparer.Ordinal.Equals(input.Password, credential.Password))
+            {
+                Context.Trace.WriteLine("Stored password does not match specified password - not erasing credential.");
+                Context.Trace.WriteLineSecrets("\tInput  password={0}", new object[] {input.Password});
+                Context.Trace.WriteLineSecrets("\tStored password={0}", new object[] {credential.Password});
+                return Task.CompletedTask;
+            }
+
+            Context.Trace.WriteLine("Erasing stored credential...");
+            if (Context.CredentialStore.Remove(credentialKey))
+            {
+                Context.Trace.WriteLine("Credential was successfully erased.");
+            }
+            else
+            {
+                Context.Trace.WriteLine("Credential erase failed.");
+            }
+
+            return Task.CompletedTask;
+        }
 
         /// <summary>
         /// Called when the application is being terminated. Clean up and release any resources.

--- a/src/shared/TestInfrastructure/Objects/TestFileSystem.cs
+++ b/src/shared/TestInfrastructure/Objects/TestFileSystem.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
     public class TestFileSystem : IFileSystem
     {
         public IDictionary<string, Stream> Files { get; set; }
-        public IList<string> Directories { get; set; }
+        public ISet<string> Directories { get; set; }
         public string CurrentDirectory { get; set; }
 
         #region IFileSystem
@@ -31,6 +31,11 @@ namespace Microsoft.Git.CredentialManager.Tests.Objects
         Stream IFileSystem.OpenFileStream(string path, FileMode fileMode, FileAccess fileAccess, FileShare fileShare)
         {
             return Files[path];
+        }
+
+        public void CreateDirectory(string path)
+        {
+            Directories.Add(path);
         }
 
         #endregion

--- a/src/shared/TestInfrastructure/Objects/TestHostProvider.cs
+++ b/src/shared/TestInfrastructure/Objects/TestHostProvider.cs
@@ -1,34 +1,36 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.Git.CredentialManager.Tests.Objects
 {
-    public class TestHostProvider : IHostProvider
+    public class TestHostProvider : HostProvider
     {
-        public string Name { get; set; } = "TestProvider";
+        public TestHostProvider(ICommandContext context)
+            : base(context) { }
 
-        public bool IsSupported { get; set; } = true;
+        public Func<InputArguments, bool> IsSupportedFunc { get; set; }
 
         public string CredentialKey { get; set; }
 
-        public GitCredential Credential { get; set; }
+        public Func<InputArguments, ICredential> GenerateCredentialFunc { get; set; }
 
-        #region IHostProvider
+        #region HostProvider
 
-        string IHostProvider.Name => Name;
+        public override string Name { get; } = "TestHostProvider";
 
-        bool IHostProvider.IsSupported(InputArguments input) => IsSupported;
+        public override bool IsSupported(InputArguments input) => IsSupportedFunc(input);
 
-        string IHostProvider.GetCredentialKey(InputArguments input) => CredentialKey;
+        public override string GetCredentialKey(InputArguments input)
+        {
+            return CredentialKey;
+        }
 
-        Task<GitCredential> IHostProvider.CreateCredentialAsync(InputArguments input) => Task.FromResult(Credential);
-
-        #endregion
-
-        #region IDisposable
-
-        public void Dispose() { }
+        public override Task<ICredential> GenerateCredentialAsync(InputArguments input)
+        {
+            return Task.FromResult(GenerateCredentialFunc(input));
+        }
 
         #endregion
     }


### PR DESCRIPTION
Refactor the core commands and host provider types to permit providers to customise how they store and erase credentials. This would allow for providers that do not want to use the OS credential store for example.

This change is required to enable non-PAT-based authentication, such as delegating to ADAL/MSAL and using Azure access tokens directly (where we don't lookup, store, or erase from the system credential store).