### PR TITLE
Add first support for Linux arm64

### DIFF
--- a/.azure-pipelines/templates/linux/compile.yml
+++ b/.azure-pipelines/templates/linux/compile.yml
@@ -10,7 +10,7 @@ steps:
     inputs:
       command: build
       projects: 'Git-Credential-Manager.sln'
-      arguments: '--configuration=Linux$(configuration) -r linux-amd64'
+      arguments: '--configuration=Linux$(configuration) -r linux-x64'
     
   - task: DotNetCoreCLI@2
     displayName: Compile common code (arm64)

--- a/.azure-pipelines/templates/linux/compile.yml
+++ b/.azure-pipelines/templates/linux/compile.yml
@@ -6,11 +6,18 @@ steps:
       version: 3.1.x
 
   - task: DotNetCoreCLI@2
-    displayName: Compile common code
+    displayName: Compile common code (amd64)
     inputs:
       command: build
       projects: 'Git-Credential-Manager.sln'
-      arguments: '--configuration=Linux$(configuration)'
+      arguments: '--configuration=Linux$(configuration) -r linux-amd64'
+    
+  - task: DotNetCoreCLI@2
+    displayName: Compile common code (arm64)
+    inputs:
+      command: build
+      projects: 'Git-Credential-Manager.sln'
+      arguments: '--configuration=Linux$(configuration) -r linux-arm64'
 
   - task: DotNetCoreCLI@2
     displayName: Run common unit tests

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Build Linux Payloads
       run: |
-        dotnet build -c Release -r linux-amd64 src/linux/Packaging.Linux/Packaging.Linux.csproj 
+        dotnet build -c Release -r linux-x64 src/linux/Packaging.Linux/Packaging.Linux.csproj 
         dotnet build -c Release -r linux-arm64 src/linux/Packaging.Linux/Packaging.Linux.csproj 
 
     - name: Upload Installers

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -26,7 +26,9 @@ jobs:
       run: dotnet restore --force
 
     - name: Build Linux Payloads
-      run: dotnet build -c Release src/linux/Packaging.Linux/Packaging.Linux.csproj
+      run: |
+        dotnet build -c Release -r linux-amd64 src/linux/Packaging.Linux/Packaging.Linux.csproj 
+        dotnet build -c Release -r linux-arm64 src/linux/Packaging.Linux/Packaging.Linux.csproj 
 
     - name: Upload Installers
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build-signed-deb.yml
+++ b/.github/workflows/build-signed-deb.yml
@@ -23,7 +23,9 @@ jobs:
       run: dotnet restore --force
 
     - name: Build Linux Payloads
-      run: dotnet build -c Release src/linux/Packaging.Linux/Packaging.Linux.csproj
+      run: |
+        dotnet build -c Release -r linux-amd64 src/linux/Packaging.Linux/Packaging.Linux.csproj
+        dotnet build -c Release -r linux-arm64 src/linux/Packaging.Linux/Packaging.Linux.csproj
 
     - name: Upload Installers
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build-signed-deb.yml
+++ b/.github/workflows/build-signed-deb.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Build Linux Payloads
       run: |
-        dotnet build -c Release -r linux-amd64 src/linux/Packaging.Linux/Packaging.Linux.csproj
+        dotnet build -c Release -r linux-x64 src/linux/Packaging.Linux/Packaging.Linux.csproj
         dotnet build -c Release -r linux-arm64 src/linux/Packaging.Linux/Packaging.Linux.csproj
 
     - name: Upload Installers

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Build Linux
       if: contains(matrix.os, 'ubuntu')
       run: |
-        dotnet build --configuration LinuxRelease -r linux-amd64
+        dotnet build --configuration LinuxRelease -r linux-x64
         dotnet build --configuration LinuxRelease -r linux-arm64
 
     - name: Build macOS

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,7 +35,9 @@ jobs:
 
     - name: Build Linux
       if: contains(matrix.os, 'ubuntu')
-      run: dotnet build --configuration LinuxRelease
+      run: |
+        dotnet build --configuration LinuxRelease -r linux-amd64
+        dotnet build --configuration LinuxRelease -r linux-arm64
 
     - name: Build macOS
       if: contains(matrix.os, 'macos')

--- a/docs/development.md
+++ b/docs/development.md
@@ -49,6 +49,12 @@ To build from the command line, run:
 dotnet build -c LinuxDebug
 ```
 
+If you want to build for a specific architecture, you can provide `linux-amd64` or `linux-arm64` as the runtime:
+
+```shell
+dotnet build -c LinuxDebug -r linux-arm64
+```
+
 You can find a copy of the Debian package (.deb) file in `out/linux/Packaging.Linux/deb/Debug`.
 
 The flat binaries can also be found in `out/linux/Packaging.Linux/payload/Debug`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -49,7 +49,7 @@ To build from the command line, run:
 dotnet build -c LinuxDebug
 ```
 
-If you want to build for a specific architecture, you can provide `linux-amd64` or `linux-arm64` as the runtime:
+If you want to build for a specific architecture, you can provide `linux-x64` or `linux-arm64` as the runtime:
 
 ```shell
 dotnet build -c LinuxDebug -r linux-arm64

--- a/src/linux/Packaging.Linux/Packaging.Linux.csproj
+++ b/src/linux/Packaging.Linux/Packaging.Linux.csproj
@@ -19,8 +19,8 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
   <Target Name="CoreCompile" DependsOnTargets="GetBuildVersion" Condition="'$(OSPlatform)'=='linux'">
-    <Message Text="$(MSBuildProjectDirectory)\build.sh --configuration='$(Configuration)' --version='$(BuildVersion)'" Importance="High" />
-    <Exec Command="$(MSBuildProjectDirectory)\build.sh --configuration='$(Configuration)' --version='$(BuildVersion)'" />
+    <Message Text="$(MSBuildProjectDirectory)\build.sh --configuration='$(Configuration)' --version='$(BuildVersion)' --runtime='$(RuntimeIdentifier)'" Importance="High" />
+    <Exec Command="$(MSBuildProjectDirectory)\build.sh --configuration='$(Configuration)' --version='$(BuildVersion)' --runtime='$(RuntimeIdentifier)'" />
   </Target>
 
   <Target Name="CoreClean">

--- a/src/linux/Packaging.Linux/build.sh
+++ b/src/linux/Packaging.Linux/build.sh
@@ -71,7 +71,7 @@ PROJ_OUT="$OUT/linux/Packaging.Linux"
 FRAMEWORK=netcoreapp3.1
 case $RUNTIME in
     linux-x64)
-        ARCH="x64"
+        ARCH="amd64"
         ;;
     linux-arm64)
         ARCH="arm64"

--- a/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
+++ b/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net461;netcoreapp3.1</TargetFrameworks>
-    <RuntimeIdentifiers>win-x86;osx-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;osx-x64;linux-x64;linux-arm64</RuntimeIdentifiers>
     <PlatformTarget Condition="'$(OSPlatform)'=='windows'">x86</PlatformTarget>
     <AssemblyName>git-credential-manager-core</AssemblyName>
     <RootNamespace>Microsoft.Git.CredentialManager</RootNamespace>


### PR DESCRIPTION
Currently, trying to install Git Credential Manager Core on Linux arm64 (e.g. WSL2 on the Surface Pro X or Raspberry Pi 4) results in the following error:

```shell
dennis@DESKTOP-8HTP3NV:~/repos$ sudo dpkg -i gmcore.deb
dpkg: error processing archive gmcore.deb (--install):
 package architecture (amd64) does not match system (arm64)
Errors were encountered while processing:
 gmcore.deb
```
 
This PR adds support for Linux arm64 builds, both when building natively on arm64 or while cross-compiling from an x86 host (in which case you can now run `dotnet build -c LinuxDebug -r linux-arm64`).

Can confirm it works on my arm64 Surface Pro X through WSL2 Ubuntu :tada::

```shell
dennis@DESKTOP-8HTP3NV:~/repos/gmcoretest$ sudo dpkg -i gcmcore-linux_arm64.2.0.301.22928.deb
[sudo] password for dennis:
Selecting previously unselected package gcmcore.
(Reading database ... 40440 files and directories currently installed.)
Preparing to unpack gcmcore-linux_arm64.2.0.301.22928.deb ...
Unpacking gcmcore (2.0.301.22928) ...
Setting up gcmcore (2.0.301.22928) ...
```
```shell
dennis@DESKTOP-8HTP3NV:~/repos/gmcoretest$ git-credential-manager-core --version
Git Credential Manager version 2.0.301-beta+90596ecdf4 (Linux, .NET Core 3.1.10)
```

Things that still need to happen AFAIK:
- Add support for signing multiple `.deb` files at once in `.github/run_esrp_signing.py`, it currently only looks at the first `.deb` file it finds. How does that sound?
- Running tests on arm64. This is possible e.g. with Travis (https://docs.travis-ci.com/user/multi-cpu-architectures/#multi-cpu-availaibility); please let me know if only running tests on amd64 is enough for now or whether you'd like me to set up a Travis config for running tests on arm64 as well.