### PR TITLE
Remove auto-detection progress/info message

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/HostProviderRegistry.cs
+++ b/src/shared/Microsoft.Git.CredentialManager/HostProviderRegistry.cs
@@ -173,7 +173,6 @@ namespace Microsoft.Git.CredentialManager
                         if (probeResponse is null)
                         {
                             _context.Trace.WriteLine("Querying remote URL for host provider auto-detection.");
-                            _context.Streams.Error.WriteLine($"info: detecting host provider for '{uri}'...");
 
                             using (HttpClient client = _context.HttpClientFactory.CreateClient())
                             {


### PR DESCRIPTION
Remove the "info: detecting host provider for 'URL'..." message that is only causing noise for users.

Fixes #492