### PR TITLE
Exclude Windows Server 2016 from WAM support

### DIFF
--- a/src/shared/Core/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Core/Authentication/MicrosoftAuthentication.cs
@@ -55,7 +55,7 @@ namespace GitCredentialManager.Authentication
             IsBrokerInitialized = true;
 
             // Broker is only supported on Windows 10 and later
-            if (!PlatformUtils.IsWindows10OrGreater())
+            if (!PlatformUtils.IsWindowsBrokerSupported())
             {
                 return;
             }
@@ -288,7 +288,7 @@ namespace GitCredentialManager.Authentication
             }
 
             // On Windows 10+ & .NET Framework try and use the WAM broker
-            if (enableBroker && PlatformUtils.IsWindows10OrGreater())
+            if (enableBroker && PlatformUtils.IsWindowsBrokerSupported())
             {
 #if NETFRAMEWORK
                 appBuilder.WithExperimentalFeatures();
@@ -459,8 +459,8 @@ namespace GitCredentialManager.Authentication
         public static bool CanUseBroker(ICommandContext context)
         {
 #if NETFRAMEWORK
-            // We only support the broker on Windows 10 and require an interactive session
-            if (!context.SessionManager.IsDesktopSession || !PlatformUtils.IsWindows10OrGreater())
+            // We only support the broker on Windows 10+ and in an interactive session
+            if (!context.SessionManager.IsDesktopSession || !PlatformUtils.IsWindowsBrokerSupported())
             {
                 return false;
             }


### PR DESCRIPTION
Windows Server 2016 does not support WAM, so we should not try to enable the broker unless we're on Server 2019 and later.

Also update the Windows (client; non-server) version checks to be tighter. Previously any major version of 10 or greater was considered "supported", but this is wrong. Windows 10 build 15063 was the first to support WAM.

Fixes #487