### PR TITLE
Update contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@
 [fork]: https://github.com/GitCredentialManager/git-credential-manager/fork
 [pr]: https://github.com/GitCredentialManager/git-credential-manager/compare
 [code-of-conduct]: CODE_OF_CONDUCT.md
+[commits]: https://www.youtube.com/watch?v=4qLtKx9S9a8
 
 Hi there! We're thrilled that you'd like to contribute to GCM :tada:. Your help is essential for keeping it great.
 
@@ -29,6 +30,7 @@ This helps us coordinate and reduce duplication.
     - `GitHub.UI.Avalonia`
     - `Atlassian.Bitbucket.UI.Windows`
     - `GitHub.UI.Windows`
+1. Organize your changes into one or more [logical, descriptive commits][commits].
 1. Push to your fork and [submit a pull request][pr]
 1. Pat your self on the back and wait for your pull request to be reviewed and merged.
 
@@ -37,7 +39,6 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Match existing code style.
 - Write tests.
 - Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
-- Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 
 ## Resources
 


### PR DESCRIPTION
Update CONTRIBUTING.md with a link to Victoria Dye's recent talk on
crafting logical, well-ordered commit messages. Move this link into the
'Submitting a pull request' section so that new contributors are more
likely to see it while following the prescribed steps. Do some additional
cleanup of the file to customize it for GCM and link to the 'New Issue'
page.