### PR TITLE
Add Git repo awareness to GPG/Pass credential store

### DIFF
--- a/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
@@ -96,12 +96,12 @@ namespace Atlassian.Bitbucket
                 var cmdArgs = new StringBuilder("userpass");
                 if (!BitbucketHostProvider.IsBitbucketOrg(targetUri))
                 {
-                    cmdArgs.AppendFormat(" --url {0}", QuoteCmdArg(targetUri.ToString()));
+                    cmdArgs.AppendFormat(" --url {0}", QuoteUtils.QuoteCmdArg(targetUri.ToString()));
                 }
 
                 if (!string.IsNullOrWhiteSpace(userName))
                 {
-                    cmdArgs.AppendFormat(" --username {0}", QuoteCmdArg(userName));
+                    cmdArgs.AppendFormat(" --username {0}", QuoteUtils.QuoteCmdArg(userName));
                 }
 
                 if ((modes & AuthenticationModes.OAuth) != 0)

--- a/src/shared/Core.Tests/GitTests.cs
+++ b/src/shared/Core.Tests/GitTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using GitCredentialManager.Tests.Objects;
@@ -188,6 +189,18 @@ namespace GitCredentialManager.Tests
             GitVersion version = git.Version;
 
             Assert.NotEqual(new GitVersion(), version);
+        }
+
+        [Fact]
+        public void Git_GitPath_ReturnsGitPath()
+        {
+            string gitPath = GetGitPath();
+            var trace = new NullTrace();
+            var env = new TestEnvironment();
+
+            var git = new GitProcess(trace, env, gitPath, Path.GetTempPath());
+
+            Assert.Equal(gitPath, git.GitPath);
         }
 
         #region Test Helpers

--- a/src/shared/Core.Tests/Interop/Posix/GnuPassCredentialStoreTests.cs
+++ b/src/shared/Core.Tests/Interop/Posix/GnuPassCredentialStoreTests.cs
@@ -14,11 +14,12 @@ namespace GitCredentialManager.Tests.Interop.Posix
         [PlatformFact(Platforms.Posix)]
         public void GnuPassCredentialStore_ReadWriteDelete()
         {
+            var trace = new NullTrace();
             var fs = new TestFileSystem();
             var gpg = new TestGpg(fs);
             string storeRoot = InitializePasswordStore(fs, gpg);
 
-            var collection = new GpgPassCredentialStore(fs, gpg, storeRoot, TestNamespace);
+            var collection = new GpgPassCredentialStore(trace, fs, gpg, storeRoot, TestNamespace);
 
             // Create a service that is guaranteed to be unique
             string uniqueGuid = Guid.NewGuid().ToString("N");
@@ -57,11 +58,12 @@ namespace GitCredentialManager.Tests.Interop.Posix
         [PlatformFact(Platforms.Posix)]
         public void GnuPassCredentialStore_Get_NotFound_ReturnsNull()
         {
+            var trace = new NullTrace();
             var fs = new TestFileSystem();
             var gpg = new TestGpg(fs);
             string storeRoot = InitializePasswordStore(fs, gpg);
 
-            var collection = new GpgPassCredentialStore(fs, gpg, storeRoot, TestNamespace);
+            var collection = new GpgPassCredentialStore(trace, fs, gpg, storeRoot, TestNamespace);
 
             // Unique service; guaranteed not to exist!
             string service = $"https://example.com/{Guid.NewGuid():N}";
@@ -73,11 +75,12 @@ namespace GitCredentialManager.Tests.Interop.Posix
         [PlatformFact(Platforms.Posix)]
         public void GnuPassCredentialStore_Remove_NotFound_ReturnsFalse()
         {
+            var trace = new NullTrace();
             var fs = new TestFileSystem();
             var gpg = new TestGpg(fs);
             string storeRoot = InitializePasswordStore(fs, gpg);
 
-            var collection = new GpgPassCredentialStore(fs, gpg, storeRoot, TestNamespace);
+            var collection = new GpgPassCredentialStore(trace, fs, gpg, storeRoot, TestNamespace);
 
             // Unique service; guaranteed not to exist!
             string service = $"https://example.com/{Guid.NewGuid():N}";

--- a/src/shared/Core.Tests/Interop/Posix/GnuPassCredentialStoreTests.cs
+++ b/src/shared/Core.Tests/Interop/Posix/GnuPassCredentialStoreTests.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Xunit;
 using GitCredentialManager.Interop.Posix;
 using GitCredentialManager.Tests.Objects;
+using Moq;
 
 namespace GitCredentialManager.Tests.Interop.Posix
 {
@@ -19,7 +20,7 @@ namespace GitCredentialManager.Tests.Interop.Posix
             var gpg = new TestGpg(fs);
             string storeRoot = InitializePasswordStore(fs, gpg);
 
-            var collection = new GpgPassCredentialStore(trace, fs, gpg, storeRoot, TestNamespace);
+            var collection = new GpgPassCredentialStore(trace, fs, gpg, null, storeRoot, TestNamespace);
 
             // Create a service that is guaranteed to be unique
             string uniqueGuid = Guid.NewGuid().ToString("N");
@@ -63,7 +64,7 @@ namespace GitCredentialManager.Tests.Interop.Posix
             var gpg = new TestGpg(fs);
             string storeRoot = InitializePasswordStore(fs, gpg);
 
-            var collection = new GpgPassCredentialStore(trace, fs, gpg, storeRoot, TestNamespace);
+            var collection = new GpgPassCredentialStore(trace, fs, gpg, null, storeRoot, TestNamespace);
 
             // Unique service; guaranteed not to exist!
             string service = $"https://example.com/{Guid.NewGuid():N}";
@@ -80,7 +81,7 @@ namespace GitCredentialManager.Tests.Interop.Posix
             var gpg = new TestGpg(fs);
             string storeRoot = InitializePasswordStore(fs, gpg);
 
-            var collection = new GpgPassCredentialStore(trace, fs, gpg, storeRoot, TestNamespace);
+            var collection = new GpgPassCredentialStore(trace, fs, gpg, null, storeRoot, TestNamespace);
 
             // Unique service; guaranteed not to exist!
             string service = $"https://example.com/{Guid.NewGuid():N}";
@@ -89,7 +90,105 @@ namespace GitCredentialManager.Tests.Interop.Posix
             Assert.False(result);
         }
 
-        private static string InitializePasswordStore(TestFileSystem fs, TestGpg gpg)
+        [PlatformFact(Platforms.Posix)]
+        public void GnuPassCredentialStore_ReadWriteDelete_GitRepo()
+        {
+            var trace = new NullTrace();
+            var fs = new TestFileSystem();
+            var gpg = new TestGpg(fs);
+            string storeRoot = InitializePasswordStore(fs, gpg, gitInit: true);
+
+            var mockGit = new Mock<IGit>();
+            IGit GitFactory(string path) => mockGit.Object;
+
+            var collection = new GpgPassCredentialStore(trace, fs, gpg, GitFactory, storeRoot, TestNamespace);
+
+            // Create a service that is guaranteed to be unique
+            string uniqueGuid = Guid.NewGuid().ToString("N");
+            string service = $"https://example.com/{uniqueGuid}";
+            const string userName = "john.doe";
+            const string password = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
+
+            string expectedSlug = $"{TestNamespace}/https/example.com/{uniqueGuid}/{userName}.gpg";
+            string expectedFilePath = Path.Combine(storeRoot, expectedSlug);
+            string expectedFileContents = password + Environment.NewLine +
+                                          $"service={service}" + Environment.NewLine +
+                                          $"account={userName}" + Environment.NewLine;
+            byte[] expectedFileBytes = Encoding.UTF8.GetBytes(expectedFileContents);
+
+            mockGit.Setup(x => x.AddFile(expectedFilePath));
+            mockGit.Setup(x => x.Commit(It.IsAny<string>()));
+
+            try
+            {
+                // Write
+                collection.AddOrUpdate(service, userName, password);
+
+                mockGit.Verify(x => x.AddFile(expectedFilePath), Times.Once);
+                mockGit.Verify(x => x.Commit(It.IsAny<string>()), Times.Once);
+                mockGit.Reset();
+
+                // Read
+                ICredential outCredential = collection.Get(service, userName);
+
+                Assert.NotNull(outCredential);
+                Assert.Equal(userName, userName);
+                Assert.Equal(password, outCredential.Password);
+                Assert.True(fs.Files.ContainsKey(expectedFilePath));
+                Assert.Equal(expectedFileBytes, fs.Files[expectedFilePath]);
+            }
+            finally
+            {
+                // Ensure we clean up after ourselves even in case of 'get' failures
+                collection.Remove(service, userName);
+                mockGit.Verify(x => x.AddFile(expectedFilePath), Times.Once);
+                mockGit.Verify(x => x.Commit(It.IsAny<string>()), Times.Once);
+            }
+        }
+
+        [PlatformFact(Platforms.Posix)]
+        public void GnuPassCredentialStore_Get_GitRepo_NotFound_ReturnsNull()
+        {
+            var trace = new NullTrace();
+            var fs = new TestFileSystem();
+            var gpg = new TestGpg(fs);
+            string storeRoot = InitializePasswordStore(fs, gpg, gitInit: true);
+
+            var mockGit = new Mock<IGit>();
+            IGit GitFactory(string path) => mockGit.Object;
+
+            var collection = new GpgPassCredentialStore(trace, fs, gpg, GitFactory, storeRoot, TestNamespace);
+
+            // Unique service; guaranteed not to exist!
+            string service = $"https://example.com/{Guid.NewGuid():N}";
+
+            ICredential credential = collection.Get(service, null);
+            Assert.Null(credential);
+            mockGit.VerifyNoOtherCalls();
+        }
+
+        [PlatformFact(Platforms.Posix)]
+        public void GnuPassCredentialStore_Remove_GitRepo_NotFound_ReturnsFalse()
+        {
+            var trace = new NullTrace();
+            var fs = new TestFileSystem();
+            var gpg = new TestGpg(fs);
+            string storeRoot = InitializePasswordStore(fs, gpg, gitInit: true);
+
+            var mockGit = new Mock<IGit>();
+            IGit GitFactory(string path) => mockGit.Object;
+
+            var collection = new GpgPassCredentialStore(trace, fs, gpg, GitFactory, storeRoot, TestNamespace);
+
+            // Unique service; guaranteed not to exist!
+            string service = $"https://example.com/{Guid.NewGuid():N}";
+
+            bool result = collection.Remove(service, account: null);
+            Assert.False(result);
+            mockGit.VerifyNoOtherCalls();
+        }
+
+        private static string InitializePasswordStore(TestFileSystem fs, TestGpg gpg, bool gitInit = false)
         {
             string homePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             string storePath = Path.Combine(homePath, ".password-store");
@@ -102,6 +201,13 @@ namespace GitCredentialManager.Tests.Interop.Posix
             // Init the password store
             fs.Directories.Add(storePath);
             fs.Files[gpgIdPath] = Encoding.UTF8.GetBytes(userId);
+
+            // Init the Git repository
+            if (gitInit)
+            {
+                string gitDir = Path.Combine(storePath, ".git");
+                fs.Directories.Add(gitDir);
+            }
 
             return storePath;
         }

--- a/src/shared/Core.Tests/Interop/Windows/DpapiCredentialStoreTests.cs
+++ b/src/shared/Core.Tests/Interop/Windows/DpapiCredentialStoreTests.cs
@@ -16,8 +16,9 @@ namespace GitCredentialManager.Tests.Interop.Windows
         [PlatformFact(Platforms.Windows)]
         public void DpapiCredentialStore_AddOrUpdate_CreatesUTF8ProtectedFile()
         {
+            var trace = new NullTrace();
             var fs = new TestFileSystem();
-            var store = new DpapiCredentialStore(fs, TestStoreRoot, TestNamespace);
+            var store = new DpapiCredentialStore(trace, fs, TestStoreRoot, TestNamespace);
 
             string service = "https://example.com";
             const string userName = "john.doe";
@@ -52,8 +53,9 @@ namespace GitCredentialManager.Tests.Interop.Windows
         [PlatformFact(Platforms.Windows)]
         public void DpapiCredentialStore_Get_KeyNotFound_ReturnsNull()
         {
+            var trace = new NullTrace();
             var fs = new TestFileSystem();
-            var store = new DpapiCredentialStore(fs, TestStoreRoot, TestNamespace);
+            var store = new DpapiCredentialStore(trace, fs, TestStoreRoot, TestNamespace);
 
             // Unique service; guaranteed not to exist!
             string service = Guid.NewGuid().ToString("N");
@@ -65,8 +67,9 @@ namespace GitCredentialManager.Tests.Interop.Windows
         [PlatformFact(Platforms.Windows)]
         public void DpapiCredentialStore_Get_ReadProtectedFile()
         {
+            var trace = new NullTrace();
             var fs = new TestFileSystem();
-            var store = new DpapiCredentialStore(fs, TestStoreRoot, TestNamespace);
+            var store = new DpapiCredentialStore(trace, fs, TestStoreRoot, TestNamespace);
 
             string service = "https://example.com";
             const string userName = "john.doe";
@@ -100,8 +103,9 @@ namespace GitCredentialManager.Tests.Interop.Windows
         [PlatformFact(Platforms.Windows)]
         public void DpapiCredentialStore_Remove_KeyNotFound_ReturnsFalse()
         {
+            var trace = new NullTrace();
             var fs = new TestFileSystem();
-            var store = new DpapiCredentialStore(fs, TestStoreRoot, TestNamespace);
+            var store = new DpapiCredentialStore(trace, fs, TestStoreRoot, TestNamespace);
 
             // Unique service; guaranteed not to exist!
             string service = Guid.NewGuid().ToString("N");

--- a/src/shared/Core.Tests/PlaintextCredentialStoreTests.cs
+++ b/src/shared/Core.Tests/PlaintextCredentialStoreTests.cs
@@ -14,9 +14,10 @@ namespace GitCredentialManager.Tests
         [Fact]
         public void PlaintextCredentialStore_ReadWriteDelete()
         {
+            var trace = new NullTrace();
             var fs = new TestFileSystem();
 
-            var collection = new PlaintextCredentialStore(fs, StoreRoot, TestNamespace);
+            var collection = new PlaintextCredentialStore(trace, fs, StoreRoot, TestNamespace);
 
             // Create a service that is guaranteed to be unique
             string uniqueGuid = Guid.NewGuid().ToString("N");
@@ -60,9 +61,10 @@ namespace GitCredentialManager.Tests
         [Fact]
         public void PlaintextCredentialStore_Get_NotFound_ReturnsNull()
         {
+            var trace = new NullTrace();
             var fs = new TestFileSystem();
 
-            var collection = new PlaintextCredentialStore(fs, StoreRoot, TestNamespace);
+            var collection = new PlaintextCredentialStore(trace, fs, StoreRoot, TestNamespace);
 
             // Unique service; guaranteed not to exist!
             string service = $"https://example.com/{Guid.NewGuid():N}";
@@ -74,9 +76,10 @@ namespace GitCredentialManager.Tests
         [Fact]
         public void PlaintextCredentialStore_Remove_NotFound_ReturnsFalse()
         {
+            var trace = new NullTrace();
             var fs = new TestFileSystem();
 
-            var collection = new PlaintextCredentialStore(fs, StoreRoot, TestNamespace);
+            var collection = new PlaintextCredentialStore(trace, fs, StoreRoot, TestNamespace);
 
             // Unique service; guaranteed not to exist!
             string service = $"https://example.com/{Guid.NewGuid():N}";

--- a/src/shared/Core.Tests/QuoteUtilsTests.cs
+++ b/src/shared/Core.Tests/QuoteUtilsTests.cs
@@ -1,9 +1,8 @@
-using GitCredentialManager.Authentication;
 using Xunit;
 
-namespace GitCredentialManager.Tests.Authentication
+namespace GitCredentialManager.Tests
 {
-    public class AuthenticationBaseTests
+    public class QuoteUtilsTests
     {
         [Theory]
         [InlineData("foo", "foo")]
@@ -16,9 +15,9 @@ namespace GitCredentialManager.Tests.Authentication
         [InlineData("\"foo", "\"\\\"foo\"")]
         [InlineData("foo\\", "\"foo\\\\\"")]
         [InlineData("foo\\\"", "\"foo\\\\\\\"\"")]
-        public void AuthenticationBase_QuoteCmdArg(string input, string expected)
+        public void QuoteUtils_QuoteCmdArg(string input, string expected)
         {
-            string actual = AuthenticationBase.QuoteCmdArg(input);
+            string actual = QuoteUtils.QuoteCmdArg(input);
             Assert.Equal(expected, actual);
         }
     }

--- a/src/shared/Core/Authentication/AuthenticationBase.cs
+++ b/src/shared/Core/Authentication/AuthenticationBase.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -157,23 +156,6 @@ namespace GitCredentialManager.Authentication
             }
 
             return true;
-        }
-
-        public static string QuoteCmdArg(string str)
-        {
-            char[] needsQuoteChars = {'"', ' ', '\\', '\n', '\r', '\t'};
-            bool needsQuotes = str.Any(x => needsQuoteChars.Contains(x));
-
-            if (!needsQuotes)
-            {
-                return str;
-            }
-
-            // Replace all '\' characters with an escaped '\\', and all '"' with '\"'
-            string escapedStr = str.Replace("\\", "\\\\").Replace("\"", "\\\"");
-
-            // Bookend the escaped string with double-quotes '"'
-            return $"\"{escapedStr}\"";
         }
     }
 }

--- a/src/shared/Core/CredentialStore.cs
+++ b/src/shared/Core/CredentialStore.cs
@@ -64,7 +64,7 @@ namespace GitCredentialManager
 
                 case StoreNames.Dpapi:
                     ValidateDpapi(out string dpapiStoreRoot);
-                    _backingStore = new DpapiCredentialStore(_context.FileSystem, dpapiStoreRoot, ns);
+                    _backingStore = new DpapiCredentialStore(_context.Trace, _context.FileSystem, dpapiStoreRoot, ns);
                     break;
 
                 case StoreNames.MacOSKeychain:
@@ -80,7 +80,7 @@ namespace GitCredentialManager
                 case StoreNames.Gpg:
                     ValidateGpgPass(out string gpgStoreRoot, out string gpgExec);
                     IGpg gpg = new Gpg(gpgExec, _context.SessionManager);
-                    _backingStore = new GpgPassCredentialStore(_context.FileSystem, gpg, gpgStoreRoot, ns);
+                    _backingStore = new GpgPassCredentialStore(_context.Trace, _context.FileSystem, gpg, gpgStoreRoot, ns);
                     break;
 
                 case StoreNames.Cache:
@@ -90,7 +90,7 @@ namespace GitCredentialManager
 
                 case StoreNames.Plaintext:
                     ValidatePlaintext(out string plainStoreRoot);
-                    _backingStore = new PlaintextCredentialStore(_context.FileSystem, plainStoreRoot, ns);
+                    _backingStore = new PlaintextCredentialStore(_context.Trace, _context.FileSystem, plainStoreRoot, ns);
                     break;
 
                 default:

--- a/src/shared/Core/CredentialStore.cs
+++ b/src/shared/Core/CredentialStore.cs
@@ -79,8 +79,10 @@ namespace GitCredentialManager
 
                 case StoreNames.Gpg:
                     ValidateGpgPass(out string gpgStoreRoot, out string gpgExec);
+                    GitProcess GitFactory(string workDir) =>
+                        new GitProcess(_context.Trace, _context.Environment, _context.Git.GitPath, workDir);
                     IGpg gpg = new Gpg(gpgExec, _context.SessionManager);
-                    _backingStore = new GpgPassCredentialStore(_context.Trace, _context.FileSystem, gpg, gpgStoreRoot, ns);
+                    _backingStore = new GpgPassCredentialStore(_context.Trace, _context.FileSystem, gpg, GitFactory, gpgStoreRoot, ns);
                     break;
 
                 case StoreNames.Cache:

--- a/src/shared/Core/Git.cs
+++ b/src/shared/Core/Git.cs
@@ -9,6 +9,11 @@ namespace GitCredentialManager
     public interface IGit
     {
         /// <summary>
+        /// Path to Git executable tied to this instance.
+        /// </summary>
+        string GitPath { get; }
+
+        /// <summary>
         /// The version of the Git executable tied to this instance.
         /// </summary>
         GitVersion Version { get; }
@@ -80,6 +85,8 @@ namespace GitCredentialManager
             _gitPath = gitPath;
             _workingDirectory = workingDirectory;
         }
+
+        public string GitPath => _gitPath;
 
         private GitVersion _version;
         public GitVersion Version

--- a/src/shared/Core/Interop/Posix/GpgPassCredentialStore.cs
+++ b/src/shared/Core/Interop/Posix/GpgPassCredentialStore.cs
@@ -11,8 +11,8 @@ namespace GitCredentialManager.Interop.Posix
 
         private readonly IGpg _gpg;
 
-        public GpgPassCredentialStore(IFileSystem fileSystem, IGpg gpg, string storeRoot, string @namespace = null)
-            : base(fileSystem, storeRoot, @namespace)
+        public GpgPassCredentialStore(ITrace trace, IFileSystem fileSystem, IGpg gpg, string storeRoot, string @namespace = null)
+            : base(trace, fileSystem, storeRoot, @namespace)
         {
             PlatformUtils.EnsurePosix();
             EnsureArgument.NotNull(gpg, nameof(gpg));

--- a/src/shared/Core/Interop/Windows/DpapiCredentialStore.cs
+++ b/src/shared/Core/Interop/Windows/DpapiCredentialStore.cs
@@ -8,8 +8,8 @@ namespace GitCredentialManager.Interop.Windows
 {
     public class DpapiCredentialStore : PlaintextCredentialStore
     {
-        public DpapiCredentialStore(IFileSystem fileSystem, string storeRoot, string @namespace = null)
-            : base(fileSystem, storeRoot, @namespace)
+        public DpapiCredentialStore(ITrace trace, IFileSystem fileSystem, string storeRoot, string @namespace = null)
+            : base(trace, fileSystem, storeRoot, @namespace)
         {
             PlatformUtils.EnsureWindows();
         }

--- a/src/shared/Core/PlaintextCredentialStore.cs
+++ b/src/shared/Core/PlaintextCredentialStore.cs
@@ -8,16 +8,19 @@ namespace GitCredentialManager
 {
     public class PlaintextCredentialStore : ICredentialStore
     {
-        public PlaintextCredentialStore(IFileSystem fileSystem, string storeRoot, string @namespace = null)
+        public PlaintextCredentialStore(ITrace trace, IFileSystem fileSystem, string storeRoot, string @namespace = null)
         {
+            EnsureArgument.NotNull(trace, nameof(trace));
             EnsureArgument.NotNull(fileSystem, nameof(fileSystem));
             EnsureArgument.NotNullOrWhiteSpace(storeRoot, nameof(storeRoot));
 
+            Trace = trace;
             FileSystem = fileSystem;
             StoreRoot = storeRoot;
             Namespace = @namespace;
         }
 
+        protected ITrace Trace { get; }
         protected IFileSystem FileSystem { get; }
         protected string StoreRoot { get; }
         protected string Namespace { get; }

--- a/src/shared/Core/PlaintextCredentialStore.cs
+++ b/src/shared/Core/PlaintextCredentialStore.cs
@@ -64,8 +64,7 @@ namespace GitCredentialManager
             foreach (FileCredential credential in Enumerate(service, account))
             {
                 // Only delete the first match
-                FileSystem.DeleteFile(credential.FullPath);
-                return true;
+                return DestroyCredential(credential);
             }
 
             return false;
@@ -152,6 +151,13 @@ namespace GitCredentialManager
                     }
                 }
             }
+        }
+
+        protected virtual bool DestroyCredential(FileCredential credential)
+        {
+            // Delete the credential file
+            FileSystem.DeleteFile(credential.FullPath);
+            return true;
         }
 
         /// <summary>

--- a/src/shared/Core/QuoteUtils.cs
+++ b/src/shared/Core/QuoteUtils.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+
+namespace GitCredentialManager
+{
+    public static class QuoteUtils
+    {
+        public static string QuoteCmdArg(string str)
+        {
+            char[] needsQuoteChars = {'"', ' ', '\\', '\n', '\r', '\t'};
+            bool needsQuotes = str.Any(x => needsQuoteChars.Contains(x));
+
+            if (!needsQuotes)
+            {
+                return str;
+            }
+
+            // Replace all '\' characters with an escaped '\\', and all '"' with '\"'
+            string escapedStr = str.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+            // Bookend the escaped string with double-quotes '"'
+            return $"\"{escapedStr}\"";
+        }
+    }
+}

--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -101,8 +101,8 @@ namespace GitHub
                     if ((modes & AuthenticationModes.Device)  != 0) promptArgs.Append(" --device");
                     if ((modes & AuthenticationModes.Pat)     != 0) promptArgs.Append(" --pat");
                 }
-                if (!GitHubHostProvider.IsGitHubDotCom(targetUri)) promptArgs.AppendFormat(" --enterprise-url {0}", QuoteCmdArg(targetUri.ToString()));
-                if (!string.IsNullOrWhiteSpace(userName)) promptArgs.AppendFormat(" --username {0}", QuoteCmdArg(userName));
+                if (!GitHubHostProvider.IsGitHubDotCom(targetUri)) promptArgs.AppendFormat(" --enterprise-url {0}", QuoteUtils.QuoteCmdArg(targetUri.ToString()));
+                if (!string.IsNullOrWhiteSpace(userName)) promptArgs.AppendFormat(" --username {0}", QuoteUtils.QuoteCmdArg(userName));
 
                 IDictionary<string, string> resultDict = await InvokeHelperAsync(helperPath, promptArgs.ToString(), null);
 
@@ -289,8 +289,8 @@ namespace GitHub
                 TryFindHelperExecutablePath(out string helperPath))
             {
                 var args = new StringBuilder("device");
-                args.AppendFormat(" --code {0} ", QuoteCmdArg(dcr.UserCode));
-                args.AppendFormat(" --url {0}", QuoteCmdArg(dcr.VerificationUri.ToString()));
+                args.AppendFormat(" --code {0} ", QuoteUtils.QuoteCmdArg(dcr.UserCode));
+                args.AppendFormat(" --url {0}", QuoteUtils.QuoteCmdArg(dcr.VerificationUri.ToString()));
 
                 var promptCts = new CancellationTokenSource();
                 var tokenCts = new CancellationTokenSource();

--- a/src/shared/GitLab/GitLabAuthentication.cs
+++ b/src/shared/GitLab/GitLabAuthentication.cs
@@ -73,10 +73,10 @@ namespace GitLab
                 var cmdArgs = new StringBuilder("prompt");
                 if (!string.IsNullOrWhiteSpace(userName))
                 {
-                    cmdArgs.AppendFormat(" --username {0}", QuoteCmdArg(userName));
+                    cmdArgs.AppendFormat(" --username {0}", QuoteUtils.QuoteCmdArg(userName));
                 }
 
-                cmdArgs.AppendFormat(" --url {0}", QuoteCmdArg(targetUri.ToString()));
+                cmdArgs.AppendFormat(" --url {0}", QuoteUtils.QuoteCmdArg(targetUri.ToString()));
 
                 if ((modes & AuthenticationModes.Basic) != 0)   cmdArgs.Append(" --basic");
                 if ((modes & AuthenticationModes.Browser) != 0) cmdArgs.Append(" --browser");

--- a/src/shared/TestInfrastructure/Objects/TestGit.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGit.cs
@@ -46,6 +46,11 @@ namespace GitCredentialManager.Tests.Objects
             throw new NotImplementedException();
         }
 
+        void IGit.Commit(string message)
+        {
+            throw new NotImplementedException();
+        }
+
         IGitConfiguration IGit.GetConfiguration() => Configuration;
 
         Task<IDictionary<string, string>> IGit.InvokeHelperAsync(string args, IDictionary<string, string> standardInput)

--- a/src/shared/TestInfrastructure/Objects/TestGit.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGit.cs
@@ -41,6 +41,11 @@ namespace GitCredentialManager.Tests.Objects
 
         IEnumerable<GitRemote> IGit.GetRemotes() => Remotes;
 
+        void IGit.AddFile(string filePath)
+        {
+            throw new NotImplementedException();
+        }
+
         IGitConfiguration IGit.GetConfiguration() => Configuration;
 
         Task<IDictionary<string, string>> IGit.InvokeHelperAsync(string args, IDictionary<string, string> standardInput)

--- a/src/shared/TestInfrastructure/Objects/TestGit.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGit.cs
@@ -8,6 +8,8 @@ namespace GitCredentialManager.Tests.Objects
 {
     public class TestGit : IGit
     {
+        public string GitPath { get; set; } = "/usr/local/bin/git";
+
         public GitVersion Version { get; set; } = new GitVersion("2.32.0.test.0");
 
         public string CurrentRepository { get; set; }
@@ -25,6 +27,8 @@ namespace GitCredentialManager.Tests.Objects
         }
 
         #region IGit
+
+        string IGit.GitPath => GitPath;
 
         GitVersion IGit.Version => Version;
 


### PR DESCRIPTION
Update the GPG/Pass credential store to be aware of stores that are also Git repositories.

Like the `pass` command-line tool, if and when a credential file is edited (add/update/delete) and the store has been initialised as a Git repository, GCM will now add the file change and create a commit.

We make sure we don't fail the store/remove operation if the Git action fails - this is a best effort.

Should also help fix #657 along side with #739