### PR TITLE
trace2: add child start and exit events

### DIFF
--- a/src/shared/Atlassian.Bitbucket.UI.Avalonia/Controls/TesterWindow.axaml.cs
+++ b/src/shared/Atlassian.Bitbucket.UI.Avalonia/Controls/TesterWindow.axaml.cs
@@ -24,7 +24,6 @@ namespace Atlassian.Bitbucket.UI.Controls
 #if DEBUG
             this.AttachDevTools();
 #endif
-
             if (PlatformUtils.IsWindows())
             {
                 _environment = new WindowsEnvironment(new WindowsFileSystem());

--- a/src/shared/Atlassian.Bitbucket.UI.Avalonia/Program.cs
+++ b/src/shared/Atlassian.Bitbucket.UI.Avalonia/Program.cs
@@ -45,6 +45,9 @@ namespace Atlassian.Bitbucket.UI
         {
             string[] args = (string[]) o;
 
+            // Set the session id (sid) for the helper process, to be
+            // used when TRACE2 tracing is enabled.
+            SidManager.CreateSid();
             using (var context = new CommandContext(args))
             using (var app = new HelperApplication(context))
             {

--- a/src/shared/Atlassian.Bitbucket.UI.Avalonia/Program.cs
+++ b/src/shared/Atlassian.Bitbucket.UI.Avalonia/Program.cs
@@ -48,9 +48,15 @@ namespace Atlassian.Bitbucket.UI
             // Set the session id (sid) for the helper process, to be
             // used when TRACE2 tracing is enabled.
             SidManager.CreateSid();
-            using (var context = new CommandContext(args))
+            using (var context = new CommandContext())
             using (var app = new HelperApplication(context))
             {
+                // Initialize TRACE2 system
+                context.Trace2.Initialize(DateTimeOffset.UtcNow);
+
+                // Write the start and version events
+                context.Trace2.Start(context.ApplicationPath, args);
+
                 app.RegisterCommand(new CredentialsCommandImpl(context));
 
                 int exitCode = app.RunAsync(args)

--- a/src/shared/Core.Tests/GitConfigurationTests.cs
+++ b/src/shared/Core.Tests/GitConfigurationTests.cs
@@ -48,7 +48,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath);
             var config = git.GetConfiguration();
             Assert.NotNull(config);
         }
@@ -71,7 +72,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, repoPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             var actualVisitedEntries = new List<(string name, string value)>();
@@ -109,7 +111,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, repoPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             var actualVisitedEntries = new List<(string name, string value)>();
@@ -139,7 +142,9 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, repoPath);
+            var processManager = new TestProcessManager();
+
+            var git = new GitProcess(trace, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             bool result = config.TryGet("user.name", false, out string value);
@@ -156,7 +161,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, repoPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             string randomName = $"{Guid.NewGuid():N}.{Guid.NewGuid():N}";
@@ -175,7 +181,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, repoPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             bool result = config.TryGet("example.path", true, out string value);
@@ -193,7 +200,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, repoPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             bool result = config.TryGet("example.path", false, out string value);
@@ -211,7 +219,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, repoPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             bool result = config.TryGet(GitConfigurationLevel.Local, GitConfigurationType.Bool,
@@ -230,7 +239,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, repoPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             bool result = config.TryGet(GitConfigurationLevel.Local, GitConfigurationType.Raw,
@@ -249,7 +259,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, repoPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             string value = config.Get("user.name");
@@ -265,7 +276,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, repoPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             string randomName = $"{Guid.NewGuid():N}.{Guid.NewGuid():N}";
@@ -280,7 +292,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, repoPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             config.Set(GitConfigurationLevel.Local, "core.foobar", "foo123");
@@ -298,7 +311,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, repoPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             Assert.Throws<InvalidOperationException>(() => config.Set(GitConfigurationLevel.All, "core.foobar", "test123"));
@@ -317,7 +331,8 @@ namespace GitCredentialManager.Tests
                 string gitPath = GetGitPath();
                 var trace = new NullTrace();
                 var env = new TestEnvironment();
-                var git = new GitProcess(trace, env, gitPath, repoPath);
+                var processManager = new TestProcessManager();
+                var git = new GitProcess(trace, processManager, gitPath, repoPath);
                 IGitConfiguration config = git.GetConfiguration();
 
                 config.Unset(GitConfigurationLevel.Global, "core.foobar");
@@ -348,7 +363,8 @@ namespace GitCredentialManager.Tests
                 string gitPath = GetGitPath();
                 var trace = new NullTrace();
                 var env = new TestEnvironment();
-                var git = new GitProcess(trace, env, gitPath, repoPath);
+                var processManager = new TestProcessManager();
+                var git = new GitProcess(trace, processManager, gitPath, repoPath);
                 IGitConfiguration config = git.GetConfiguration();
 
                 config.Unset(GitConfigurationLevel.Local, "core.foobar");
@@ -374,7 +390,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, repoPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             Assert.Throws<InvalidOperationException>(() => config.Unset(GitConfigurationLevel.All, "core.foobar"));
@@ -391,7 +408,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, repoPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             config.UnsetAll(GitConfigurationLevel.Local, "core.foobar", "foo*");
@@ -409,7 +427,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, repoPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             Assert.Throws<InvalidOperationException>(() => config.UnsetAll(GitConfigurationLevel.All, "core.foobar", Constants.RegexPatterns.Any));

--- a/src/shared/Core.Tests/GitTests.cs
+++ b/src/shared/Core.Tests/GitTests.cs
@@ -14,7 +14,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, Path.GetTempPath());
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, Path.GetTempPath());
 
             string actual = git.GetCurrentRepository();
 
@@ -29,7 +30,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, workDirPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, workDirPath);
 
             string actual = git.GetCurrentRepository();
 
@@ -42,7 +44,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, Path.GetTempPath());
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, Path.GetTempPath());
 
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
@@ -57,7 +60,8 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
-            var git = new GitProcess(trace, env, gitPath, workDirPath);
+            var processManager = new TestProcessManager();
+            var git = new GitProcess(trace, processManager, gitPath, workDirPath);
 
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
@@ -75,8 +79,9 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
+            var processManager = new TestProcessManager();
 
-            var git = new GitProcess(trace, env, gitPath, workDirPath);
+            var git = new GitProcess(trace, processManager, gitPath, workDirPath);
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
             Assert.Single(remotes);
@@ -96,8 +101,9 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
+            var processManager = new TestProcessManager();
 
-            var git = new GitProcess(trace, env, gitPath, workDirPath);
+            var git = new GitProcess(trace, processManager, gitPath, workDirPath);
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
             Assert.Single(remotes);
@@ -119,8 +125,9 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
+            var processManager = new TestProcessManager();
 
-            var git = new GitProcess(trace, env, gitPath, workDirPath);
+            var git = new GitProcess(trace, processManager, gitPath, workDirPath);
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
             Assert.Single(remotes);
@@ -144,8 +151,9 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
+            var processManager = new TestProcessManager();
 
-            var git = new GitProcess(trace, env, gitPath, workDirPath);
+            var git = new GitProcess(trace, processManager, gitPath, workDirPath);
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
             Assert.Equal(3, remotes.Length);
@@ -168,8 +176,9 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
+            var processManager = new TestProcessManager();
 
-            var git = new GitProcess(trace, env, gitPath, workDirPath);
+            var git = new GitProcess(trace, processManager, gitPath, workDirPath);
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
             Assert.Single(remotes);
@@ -183,8 +192,9 @@ namespace GitCredentialManager.Tests
             string gitPath = GetGitPath();
             var trace = new NullTrace();
             var env = new TestEnvironment();
+            var processManager = new TestProcessManager();
 
-            var git = new GitProcess(trace, env, gitPath, Path.GetTempPath());
+            var git = new GitProcess(trace, processManager, gitPath, Path.GetTempPath());
             GitVersion version = git.Version;
 
             Assert.NotEqual(new GitVersion(), version);

--- a/src/shared/Core.Tests/HttpClientFactoryTests.cs
+++ b/src/shared/Core.Tests/HttpClientFactoryTests.cs
@@ -13,19 +13,19 @@ namespace GitCredentialManager.Tests
         [Fact]
         public void HttpClientFactory_GetClient_SetsDefaultHeaders()
         {
-            var factory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), Mock.Of<ISettings>(), new TestStandardStreams());
+            var factory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), Mock.Of<ITrace2>(), Mock.Of<ISettings>(), new TestStandardStreams());
 
             HttpClient client = factory.CreateClient();
 
             Assert.NotNull(client);
-            Assert.Equal(Constants.GetHttpUserAgent(), client.DefaultRequestHeaders.UserAgent.ToString());
+            Assert.Equal(Constants.GetHttpUserAgent(Mock.Of<ITrace2>()), client.DefaultRequestHeaders.UserAgent.ToString());
             Assert.True(client.DefaultRequestHeaders.CacheControl.NoCache);
         }
 
         [Fact]
         public void HttpClientFactory_GetClient_MultipleCalls_ReturnsNewInstance()
         {
-            var factory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), Mock.Of<ISettings>(), new TestStandardStreams());
+            var factory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), Mock.Of<ITrace2>(), Mock.Of<ISettings>(), new TestStandardStreams());
 
             HttpClient client1 = factory.CreateClient();
             HttpClient client2 = factory.CreateClient();
@@ -45,7 +45,7 @@ namespace GitCredentialManager.Tests
                 RemoteUri = repoRemoteUri,
                 RepositoryPath = repoPath
             };
-            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), Mock.Of<ITrace2>(), settings, Mock.Of<IStandardStreams>());
 
             bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
 
@@ -69,7 +69,7 @@ namespace GitCredentialManager.Tests
                 RepositoryPath = repoPath,
                 ProxyConfiguration = proxyConfig
             };
-            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), Mock.Of<ITrace2>(), settings, Mock.Of<IStandardStreams>());
 
             bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
 
@@ -102,7 +102,7 @@ namespace GitCredentialManager.Tests
                 RepositoryPath = repoPath,
                 ProxyConfiguration = proxyConfig
             };
-            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), Mock.Of<ITrace2>(), settings, Mock.Of<IStandardStreams>());
 
             bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
 
@@ -138,7 +138,7 @@ namespace GitCredentialManager.Tests
                 RepositoryPath = repoPath,
                 ProxyConfiguration = proxyConfig
             };
-            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), Mock.Of<ITrace2>(), settings, Mock.Of<IStandardStreams>());
 
             bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
 
@@ -167,7 +167,7 @@ namespace GitCredentialManager.Tests
                 RepositoryPath = repoPath,
                 ProxyConfiguration = proxyConfig
             };
-            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), Mock.Of<ITrace2>(), settings, Mock.Of<IStandardStreams>());
 
             bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
 
@@ -203,7 +203,7 @@ namespace GitCredentialManager.Tests
                 RepositoryPath = repoPath,
                 ProxyConfiguration = proxyConfig
             };
-            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), Mock.Of<ITrace2>(), settings, Mock.Of<IStandardStreams>());
 
             bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
 
@@ -239,7 +239,7 @@ namespace GitCredentialManager.Tests
                 RepositoryPath = repoPath,
                 ProxyConfiguration = proxyConfig
             };
-            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), Mock.Of<ITrace2>(), settings, Mock.Of<IStandardStreams>());
 
             bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
 
@@ -274,7 +274,7 @@ namespace GitCredentialManager.Tests
                 RepositoryPath = repoPath,
                 ProxyConfiguration = proxyConfig
             };
-            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), settings, Mock.Of<IStandardStreams>());
+            var httpFactory = new HttpClientFactory(Mock.Of<IFileSystem>(), Mock.Of<ITrace>(), Mock.Of<ITrace2>(), settings, Mock.Of<IStandardStreams>());
 
             bool result = httpFactory.TryCreateProxy(out IWebProxy proxy);
 
@@ -304,7 +304,7 @@ namespace GitCredentialManager.Tests
                 UseCustomCertificateBundleWithSchannel = useCustomCertBundleWithSchannel
             };
 
-            var factory = new HttpClientFactory(fileSystemMock.Object, Mock.Of<ITrace>(), settings, new TestStandardStreams());
+            var factory = new HttpClientFactory(fileSystemMock.Object, Mock.Of<ITrace>(), Mock.Of<ITrace2>(), settings, new TestStandardStreams());
 
             HttpClient client = factory.CreateClient();
 

--- a/src/shared/Core.Tests/StringExtensionsTests.cs
+++ b/src/shared/Core.Tests/StringExtensionsTests.cs
@@ -293,5 +293,20 @@ namespace GitCredentialManager.Tests
             string actual = StringExtensions.TrimMiddle(input, trim, comparisonType);
             Assert.Equal(expected, actual);
         }
+
+        [Theory]
+        [InlineData("FooBar", "foo_bar")]
+        [InlineData("fooBar", "foo_bar")]
+        [InlineData("FBBaz", "fb_baz")]
+        [InlineData("Foo", "foo")]
+        [InlineData("Fo", "fo")]
+        [InlineData("fO", "f_o")]
+        [InlineData("OO", "oo")]
+        [InlineData("F", "f")]
+        [InlineData("", "")]
+        public void StringExtensions_ToSnakeCase_Converts_Correctly(string input, string expected)
+        {
+            Assert.Equal(expected, input.ToSnakeCase());
+        }
     }
 }

--- a/src/shared/Core.Tests/TestProcessManager.cs
+++ b/src/shared/Core.Tests/TestProcessManager.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using GitCredentialManager.Tests.Objects;
+using Moq;
+
+namespace GitCredentialManager.Tests;
+
+public class TestProcessManager : IProcessManager
+{
+    public ChildProcess CreateProcess(string path, string args, bool useShellExecute, string workingDirectory)
+    {
+        var psi = new ProcessStartInfo(path, args)
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true, // Ok to redirect stderr for testing
+            UseShellExecute = useShellExecute,
+            WorkingDirectory = workingDirectory ?? string.Empty
+        };
+
+        return CreateProcess(psi);
+    }
+
+    public ChildProcess CreateProcess(ProcessStartInfo psi)
+    {
+        return new ChildProcess(new NullTrace2(), psi);
+    }
+}

--- a/src/shared/Core.Tests/Trace2Tests.cs
+++ b/src/shared/Core.Tests/Trace2Tests.cs
@@ -11,13 +11,9 @@ public class Trace2Tests
     [InlineData("af_unix:foo", "foo")]
     [InlineData("af_unix:stream:foo-bar", "foo-bar")]
     [InlineData("af_unix:dgram:foo-bar-baz", "foo-bar-baz")]
-    public void TryParseEventTarget_Posix_Returns_Expected_Value(string input, string expected)
+    public void TryGetPipeName_Posix_Returns_Expected_Value(string input, string expected)
     {
-        var environment = new TestEnvironment();
-        var settings = new TestSettings();
-
-        var trace2 = new Trace2(environment, settings.GetTrace2Settings(), new []{""}, DateTimeOffset.UtcNow);
-        var isSuccessful = trace2.TryGetPipeName(input, out var actual);
+        var isSuccessful = Trace2.TryGetPipeName(input, out var actual);
 
         Assert.True(isSuccessful);
         Assert.Matches(actual, expected);
@@ -27,13 +23,9 @@ public class Trace2Tests
     [InlineData("\\\\.\\pipe\\git-foo", "git-foo")]
     [InlineData("\\\\.\\pipe\\git-foo-bar", "git-foo-bar")]
     [InlineData("\\\\.\\pipe\\foo\\git-bar", "git-bar")]
-    public void TryParseEventTarget_Windows_Returns_Expected_Value(string input, string expected)
+    public void TryGetPipeName_Windows_Returns_Expected_Value(string input, string expected)
     {
-        var environment = new TestEnvironment();
-        var settings = new TestSettings();
-
-        var trace2 = new Trace2(environment, settings.GetTrace2Settings(), new []{""}, DateTimeOffset.UtcNow);
-        var isSuccessful = trace2.TryGetPipeName(input, out var actual);
+        var isSuccessful = Trace2.TryGetPipeName(input, out var actual);
 
         Assert.True(isSuccessful);
         Assert.Matches(actual, expected);

--- a/src/shared/Core.Tests/Trace2Tests.cs
+++ b/src/shared/Core.Tests/Trace2Tests.cs
@@ -38,21 +38,4 @@ public class Trace2Tests
         Assert.True(isSuccessful);
         Assert.Matches(actual, expected);
     }
-
-    [Theory]
-    [InlineData("20190408T191610.507018Z-H9b68c35f-P000059a8")]
-    [InlineData("")]
-    public void SetSid_Envar_Returns_Expected_Value(string parentSid)
-    {
-        Regex rx = new Regex(@$"{parentSid}\/[\d\w-]*");
-
-        var environment = new TestEnvironment();
-        environment.Variables.Add("GIT_TRACE2_PARENT_SID", parentSid);
-
-        var settings = new TestSettings();
-        var trace2 = new Trace2(environment, settings.GetTrace2Settings(), new []{""}, DateTimeOffset.UtcNow);
-        var sid = trace2.SetSid();
-
-        Assert.Matches(rx, sid);
-    }
 }

--- a/src/shared/Core.Tests/WslUtilsTests.cs
+++ b/src/shared/Core.Tests/WslUtilsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using Moq;
 using Xunit;
 
 namespace GitCredentialManager.Tests
@@ -100,7 +101,7 @@ namespace GitCredentialManager.Tests
             string expectedFileName = WslUtils.GetWslPath();
             string expectedArgs = $"--distribution {distribution} --exec {command}";
 
-            Process process = WslUtils.CreateWslProcess(distribution, command);
+            ChildProcess process = WslUtils.CreateWslProcess(distribution, command, Mock.Of<ITrace2>());
 
             Assert.NotNull(process);
             Assert.Equal(expectedArgs, process.StartInfo.Arguments);
@@ -121,7 +122,7 @@ namespace GitCredentialManager.Tests
             string expectedFileName = WslUtils.GetWslPath();
             string expectedArgs = $"--distribution {distribution} --exec {command}";
 
-            Process process = WslUtils.CreateWslProcess(distribution, command, expectedWorkingDirectory);
+            ChildProcess process = WslUtils.CreateWslProcess(distribution, command, Mock.Of<ITrace2>(), expectedWorkingDirectory);
 
             Assert.NotNull(process);
             Assert.Equal(expectedArgs, process.StartInfo.Arguments);

--- a/src/shared/Core.Tests/WslUtilsTests.cs
+++ b/src/shared/Core.Tests/WslUtilsTests.cs
@@ -107,7 +107,7 @@ namespace GitCredentialManager.Tests
             Assert.Equal(expectedFileName, process.StartInfo.FileName);
             Assert.True(process.StartInfo.RedirectStandardInput);
             Assert.True(process.StartInfo.RedirectStandardOutput);
-            Assert.True(process.StartInfo.RedirectStandardError);
+            Assert.False(process.StartInfo.RedirectStandardError);
             Assert.False(process.StartInfo.UseShellExecute);
         }
 
@@ -128,7 +128,7 @@ namespace GitCredentialManager.Tests
             Assert.Equal(expectedFileName, process.StartInfo.FileName);
             Assert.True(process.StartInfo.RedirectStandardInput);
             Assert.True(process.StartInfo.RedirectStandardOutput);
-            Assert.True(process.StartInfo.RedirectStandardError);
+            Assert.False(process.StartInfo.RedirectStandardError);
             Assert.False(process.StartInfo.UseShellExecute);
             Assert.Equal(expectedWorkingDirectory, process.StartInfo.WorkingDirectory);
         }

--- a/src/shared/Core/Application.cs
+++ b/src/shared/Core/Application.cs
@@ -91,7 +91,7 @@ namespace GitCredentialManager
             }
 
             // Trace the current version, OS, runtime, and program arguments
-            PlatformInformation info = PlatformUtils.GetPlatformInformation();
+            PlatformInformation info = PlatformUtils.GetPlatformInformation(Context.Trace2);
             Context.Trace.WriteLine($"Version: {Constants.GcmVersion}");
             Context.Trace.WriteLine($"Runtime: {info.ClrVersion}");
             Context.Trace.WriteLine($"Platform: {info.OperatingSystemType} ({info.CpuArchitecture})");

--- a/src/shared/Core/ApplicationBase.cs
+++ b/src/shared/Core/ApplicationBase.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Reflection;
-using System.IO.Pipes;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -76,9 +73,6 @@ namespace GitCredentialManager
                 Context.Trace.IsSecretTracingEnabled = true;
                 Context.Trace.WriteLine("Tracing of secrets is enabled. Trace output may contain sensitive information.");
             }
-
-            // Enable TRACE2 tracing
-            Context.Trace2.Start(Context.Streams.Error, Context.FileSystem, Context.ApplicationPath);
 
             return RunInternalAsync(args);
         }

--- a/src/shared/Core/Authentication/AuthenticationBase.cs
+++ b/src/shared/Core/Authentication/AuthenticationBase.cs
@@ -43,7 +43,7 @@ namespace GitCredentialManager.Authentication
             // authentication helper's messages.
             Context.Trace.Flush();
 
-            var process = Process.Start(procStartInfo);
+            var process = ChildProcess.Start(Context.Trace2, procStartInfo);
             if (process is null)
             {
                 throw new Exception($"Failed to start helper process: {path} {args}");

--- a/src/shared/Core/Authentication/AuthenticationBase.cs
+++ b/src/shared/Core/Authentication/AuthenticationBase.cs
@@ -43,7 +43,7 @@ namespace GitCredentialManager.Authentication
             // authentication helper's messages.
             Context.Trace.Flush();
 
-            var process = ChildProcess.Start(Context.Trace2, procStartInfo);
+            var process = ChildProcess.Start(Context.Trace2, procStartInfo, Trace2ProcessClass.UIHelper);
             if (process is null)
             {
                 throw new Exception($"Failed to start helper process: {path} {args}");

--- a/src/shared/Core/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Core/Authentication/MicrosoftAuthentication.cs
@@ -299,7 +299,7 @@ namespace GitCredentialManager.Authentication
             IPublicClientApplication app = appBuilder.Build();
 
             // Register the application token cache
-            await RegisterTokenCacheAsync(app);
+            await RegisterTokenCacheAsync(app, Context.Trace2);
 
             return app;
         }
@@ -308,14 +308,14 @@ namespace GitCredentialManager.Authentication
 
         #region Helpers
 
-        private async Task RegisterTokenCacheAsync(IPublicClientApplication app)
+        private async Task RegisterTokenCacheAsync(IPublicClientApplication app, ITrace2 trace2)
         {
             Context.Trace.WriteLine(
                 "Configuring Microsoft Authentication token cache to instance shared with Microsoft developer tools...");
 
             if (!PlatformUtils.IsWindows() && !PlatformUtils.IsPosix())
             {
-                string osType = PlatformUtils.GetPlatformInformation().OperatingSystemType;
+                string osType = PlatformUtils.GetPlatformInformation(trace2).OperatingSystemType;
                 Context.Trace.WriteLine($"Token cache integration is not supported on {osType}.");
                 return;
             }

--- a/src/shared/Core/BrowserUtils.cs
+++ b/src/shared/Core/BrowserUtils.cs
@@ -71,6 +71,10 @@ namespace GitCredentialManager
                 psi = new ProcessStartInfo(url) {UseShellExecute = true};
             }
 
+            // We purposefully do not use a ChildProcess here, as the purpose of that
+            // class is to allow us to collect child process information using TRACE2.
+            // Since we will not be collecting TRACE2 data from the browser, there
+            // is no need to add the extra overhead associated with ChildProcess here.
             Process.Start(psi);
         }
     }

--- a/src/shared/Core/BrowserUtils.cs
+++ b/src/shared/Core/BrowserUtils.cs
@@ -50,6 +50,7 @@ namespace GitCredentialManager
                         psi = new ProcessStartInfo(shellExecPath, url)
                         {
                             RedirectStandardOutput = true,
+                            // Ok to redirect stderr for non-git-related processes
                             RedirectStandardError = true
                         };
 

--- a/src/shared/Core/ChildProcess.cs
+++ b/src/shared/Core/ChildProcess.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace GitCredentialManager;
+
+public class ChildProcess : DisposableObject
+{
+    private readonly ITrace2 _trace2;
+
+    private DateTimeOffset _startTime;
+    private DateTimeOffset _exitTime => Process.ExitTime;
+
+    private int _id => Process.Id;
+
+    public ProcessStartInfo StartInfo => Process.StartInfo;
+    public Process Process { get; }
+    public StreamWriter StandardInput => Process.StandardInput;
+    public StreamReader StandardOutput => Process.StandardOutput;
+    public StreamReader StandardError => Process.StandardError;
+    public int Id => Process.Id;
+    public int ExitCode => Process.ExitCode;
+
+    public static ChildProcess Start(ITrace2 trace2, ProcessStartInfo startInfo)
+    {
+        var childProc = new ChildProcess(trace2, startInfo);
+        childProc.Start();
+        return childProc;
+    }
+
+    public ChildProcess(ITrace2 trace2, ProcessStartInfo startInfo)
+    {
+        _trace2 = trace2;
+        Process = new Process() { StartInfo = startInfo };
+    }
+
+    public void Start()
+    {
+        ThrowIfDisposed();
+        Process.Start();
+    }
+
+    public void WaitForExit() => Process.WaitForExit();
+
+    public void Kill() => Process.Kill();
+
+    protected override void ReleaseManagedResources()
+    {
+        Process.Dispose();
+        base.ReleaseUnmanagedResources();
+    }
+}

--- a/src/shared/Core/CommandContext.cs
+++ b/src/shared/Core/CommandContext.cs
@@ -85,14 +85,14 @@ namespace GitCredentialManager
     /// </summary>
     public class CommandContext : DisposableObject, ICommandContext
     {
-        public CommandContext(string[] argv)
+        public CommandContext()
         {
-            var applicationStartTime = DateTimeOffset.UtcNow;
             ApplicationPath = GetEntryApplicationPath();
             InstallationDirectory = GetInstallationDirectory();
 
             Streams = new StandardStreams();
             Trace   = new Trace();
+            Trace2  = new Trace2(this);
 
             if (PlatformUtils.IsWindows())
             {
@@ -145,7 +145,6 @@ namespace GitCredentialManager
                 throw new PlatformNotSupportedException();
             }
 
-            Trace2 = new Trace2(Environment, Settings.GetTrace2Settings(), argv, applicationStartTime);
             HttpClientFactory = new HttpClientFactory(FileSystem, Trace, Settings, Streams);
             CredentialStore   = new CredentialStore(this);
         }

--- a/src/shared/Core/CommandContext.cs
+++ b/src/shared/Core/CommandContext.cs
@@ -78,6 +78,11 @@ namespace GitCredentialManager
         /// The current process environment.
         /// </summary>
         IEnvironment Environment { get; }
+
+        /// <summary>
+        /// Process manager.
+        /// </summary>
+        IProcessManager ProcessManager { get; }
     }
 
     /// <summary>
@@ -99,11 +104,12 @@ namespace GitCredentialManager
                 FileSystem        = new WindowsFileSystem();
                 SessionManager    = new WindowsSessionManager();
                 Environment       = new WindowsEnvironment(FileSystem);
+                ProcessManager    = new ProcessManager(Trace2);
                 Terminal          = new WindowsTerminal(Trace);
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(
                                             Trace,
-                                            Environment,
+                                            ProcessManager,
                                             gitPath,
                                             FileSystem.GetCurrentDirectory()
                                         );
@@ -114,11 +120,12 @@ namespace GitCredentialManager
                 FileSystem        = new MacOSFileSystem();
                 SessionManager    = new MacOSSessionManager();
                 Environment       = new MacOSEnvironment(FileSystem);
+                ProcessManager    = new WindowsProcessManager(Trace2);
                 Terminal          = new MacOSTerminal(Trace);
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(
                                             Trace,
-                                            Environment,
+                                            ProcessManager,
                                             gitPath,
                                             FileSystem.GetCurrentDirectory()
                                         );
@@ -130,11 +137,12 @@ namespace GitCredentialManager
                 // TODO: support more than just 'Posix' or X11
                 SessionManager    = new PosixSessionManager();
                 Environment       = new PosixEnvironment(FileSystem);
+                ProcessManager    = new ProcessManager(Trace2);
                 Terminal          = new LinuxTerminal(Trace);
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(
                                             Trace,
-                                            Environment,
+                                            ProcessManager,
                                             gitPath,
                                             FileSystem.GetCurrentDirectory()
                                         );
@@ -145,7 +153,7 @@ namespace GitCredentialManager
                 throw new PlatformNotSupportedException();
             }
 
-            HttpClientFactory = new HttpClientFactory(FileSystem, Trace, Settings, Streams);
+            HttpClientFactory = new HttpClientFactory(FileSystem, Trace, Trace2, Settings, Streams);
             CredentialStore   = new CredentialStore(this);
         }
 
@@ -208,6 +216,8 @@ namespace GitCredentialManager
         public IGit Git { get; }
 
         public IEnvironment Environment { get; }
+
+        public IProcessManager ProcessManager { get; }
 
         #endregion
 

--- a/src/shared/Core/Commands/DiagnoseCommand.cs
+++ b/src/shared/Core/Commands/DiagnoseCommand.cs
@@ -26,11 +26,11 @@ namespace GitCredentialManager.Commands
             _diagnostics = new List<IDiagnostic>
             {
                 // Add standard diagnostics
-                new EnvironmentDiagnostic(context.Environment),
-                new FileSystemDiagnostic(context.FileSystem),
-                new NetworkingDiagnostic(context.HttpClientFactory),
-                new GitDiagnostic(context.Git),
-                new CredentialStoreDiagnostic(context.CredentialStore),
+                new EnvironmentDiagnostic(context),
+                new FileSystemDiagnostic(context),
+                new NetworkingDiagnostic(context),
+                new GitDiagnostic(context),
+                new CredentialStoreDiagnostic(context),
                 new MicrosoftAuthenticationDiagnostic(context)
             };
 

--- a/src/shared/Core/Constants.cs
+++ b/src/shared/Core/Constants.cs
@@ -227,9 +227,9 @@ namespace GitCredentialManager
         /// Get the HTTP user-agent for Git Credential Manager.
         /// </summary>
         /// <returns>User-agent string for HTTP requests.</returns>
-        public static string GetHttpUserAgent()
+        public static string GetHttpUserAgent(ITrace2 trace2)
         {
-            PlatformInformation info = PlatformUtils.GetPlatformInformation();
+            PlatformInformation info = PlatformUtils.GetPlatformInformation(trace2);
             string osType     = info.OperatingSystemType;
             string cpuArch    = info.CpuArchitecture;
             string clrVersion = info.ClrVersion;

--- a/src/shared/Core/CredentialStore.cs
+++ b/src/shared/Core/CredentialStore.cs
@@ -79,7 +79,7 @@ namespace GitCredentialManager
 
                 case StoreNames.Gpg:
                     ValidateGpgPass(out string gpgStoreRoot, out string gpgExec);
-                    IGpg gpg = new Gpg(gpgExec, _context.SessionManager);
+                    IGpg gpg = new Gpg(gpgExec, _context.SessionManager, _context.ProcessManager);
                     _backingStore = new GpgPassCredentialStore(_context.FileSystem, gpg, gpgStoreRoot, ns);
                     break;
 

--- a/src/shared/Core/Diagnostics/CredentialStoreDiagnostic.cs
+++ b/src/shared/Core/Diagnostics/CredentialStoreDiagnostic.cs
@@ -7,19 +7,13 @@ namespace GitCredentialManager.Diagnostics
 {
     public class CredentialStoreDiagnostic : Diagnostic
     {
-        private readonly ICredentialStore _credentialStore;
-
-        public CredentialStoreDiagnostic(ICredentialStore credentialStore)
-            : base("Credential storage")
-        {
-            EnsureArgument.NotNull(credentialStore, nameof(credentialStore));
-
-            _credentialStore = credentialStore;
-        }
+        public CredentialStoreDiagnostic(ICommandContext commandContext)
+            : base("Credential storage", commandContext)
+        { }
 
         protected override Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
         {
-            log.AppendLine($"ICredentialStore instance is of type: {_credentialStore.GetType().Name}");
+            log.AppendLine($"ICredentialStore instance is of type: {CommandContext.CredentialStore.GetType().Name}");
 
             // Create a service that is guaranteed to be unique
             string service = $"https://example.com/{Guid.NewGuid():N}";
@@ -29,11 +23,11 @@ namespace GitCredentialManager.Diagnostics
             try
             {
                 log.Append("Writing test credential...");
-                _credentialStore.AddOrUpdate(service, account, password);
+                CommandContext.CredentialStore.AddOrUpdate(service, account, password);
                 log.AppendLine(" OK");
 
                 log.Append("Reading test credential...");
-                ICredential outCredential = _credentialStore.Get(service, account);
+                ICredential outCredential = CommandContext.CredentialStore.Get(service, account);
                 if (outCredential is null)
                 {
                     log.AppendLine(" Failed");
@@ -62,7 +56,7 @@ namespace GitCredentialManager.Diagnostics
             finally
             {
                 log.Append("Deleting test credential...");
-                _credentialStore.Remove(service, account);
+                CommandContext.CredentialStore.Remove(service, account);
                 log.AppendLine(" OK");
             }
 

--- a/src/shared/Core/Diagnostics/Diagnostic.cs
+++ b/src/shared/Core/Diagnostics/Diagnostic.cs
@@ -16,9 +16,12 @@ namespace GitCredentialManager.Diagnostics
 
     public abstract class Diagnostic : IDiagnostic
     {
-        protected Diagnostic(string name)
+        protected ICommandContext CommandContext;
+
+        protected Diagnostic(string name, ICommandContext commandContext)
         {
             Name = name;
+            CommandContext = commandContext;
         }
 
         public string Name { get; }

--- a/src/shared/Core/Diagnostics/EnvironmentDiagnostic.cs
+++ b/src/shared/Core/Diagnostics/EnvironmentDiagnostic.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -14,7 +15,7 @@ namespace GitCredentialManager.Diagnostics
 
         protected override Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
         {
-            PlatformInformation platformInfo = PlatformUtils.GetPlatformInformation();
+            PlatformInformation platformInfo = PlatformUtils.GetPlatformInformation(CommandContext.Trace2);
             log.AppendLine($"OSType: {platformInfo.OperatingSystemType}");
             log.AppendLine($"OSVersion: {platformInfo.OperatingSystemVersion}");
 

--- a/src/shared/Core/Diagnostics/EnvironmentDiagnostic.cs
+++ b/src/shared/Core/Diagnostics/EnvironmentDiagnostic.cs
@@ -8,15 +8,9 @@ namespace GitCredentialManager.Diagnostics
 {
     public class EnvironmentDiagnostic : Diagnostic
     {
-        private readonly IEnvironment _env;
-
-        public EnvironmentDiagnostic(IEnvironment env)
-            : base("Environment")
-        {
-            EnsureArgument.NotNull(env, nameof(env));
-
-            _env = env;
-        }
+        public EnvironmentDiagnostic(ICommandContext commandContext)
+            : base("Environment", commandContext)
+        { }
 
         protected override Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
         {

--- a/src/shared/Core/Diagnostics/FileSystemDiagnostic.cs
+++ b/src/shared/Core/Diagnostics/FileSystemDiagnostic.cs
@@ -8,15 +8,9 @@ namespace GitCredentialManager.Diagnostics
 {
     public class FileSystemDiagnostic : Diagnostic
     {
-        private readonly IFileSystem _fs;
-
-        public FileSystemDiagnostic(IFileSystem fs)
-            : base("File system")
-        {
-            EnsureArgument.NotNull(fs, nameof(fs));
-
-            _fs = fs;
-        }
+        public FileSystemDiagnostic(ICommandContext commandContext)
+            : base("File system", commandContext)
+        {  }
 
         protected override Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
         {
@@ -49,9 +43,9 @@ namespace GitCredentialManager.Diagnostics
             log.AppendLine(" OK");
 
             log.AppendLine("Testing IFileSystem instance...");
-            log.AppendLine($"UserHomePath: {_fs.UserHomePath}");
-            log.AppendLine($"UserDataDirectoryPath: {_fs.UserDataDirectoryPath}");
-            log.AppendLine($"GetCurrentDirectory(): {_fs.GetCurrentDirectory()}");
+            log.AppendLine($"UserHomePath: {CommandContext.FileSystem.UserHomePath}");
+            log.AppendLine($"UserDataDirectoryPath: {CommandContext.FileSystem.UserDataDirectoryPath}");
+            log.AppendLine($"GetCurrentDirectory(): {CommandContext.FileSystem.GetCurrentDirectory()}");
 
             return Task.FromResult(true);
         }

--- a/src/shared/Core/Diagnostics/GitDiagnostic.cs
+++ b/src/shared/Core/Diagnostics/GitDiagnostic.cs
@@ -25,7 +25,7 @@ namespace GitCredentialManager.Diagnostics
 
             log.Append("Listing all Git configuration...");
             ChildProcess configProc = CommandContext.Git.CreateProcess("config --list --show-origin");
-            configProc.Start();
+            configProc.Start(Trace2ProcessClass.Git);
             // To avoid deadlocks, always read the output stream first and then wait
             // TODO: don't read in all the data at once; stream it
             string gitConfig = configProc.StandardOutput.ReadToEnd().TrimEnd();

--- a/src/shared/Core/Diagnostics/GitDiagnostic.cs
+++ b/src/shared/Core/Diagnostics/GitDiagnostic.cs
@@ -24,7 +24,7 @@ namespace GitCredentialManager.Diagnostics
             log.AppendLine(thisRepo is null ? "Not inside a Git repository." : $"Git repository at '{thisRepo}'");
 
             log.Append("Listing all Git configuration...");
-            Process configProc = CommandContext.Git.CreateProcess("config --list --show-origin");
+            ChildProcess configProc = CommandContext.Git.CreateProcess("config --list --show-origin");
             configProc.Start();
             // To avoid deadlocks, always read the output stream first and then wait
             // TODO: don't read in all the data at once; stream it

--- a/src/shared/Core/Diagnostics/GitDiagnostic.cs
+++ b/src/shared/Core/Diagnostics/GitDiagnostic.cs
@@ -7,30 +7,24 @@ namespace GitCredentialManager.Diagnostics
 {
     public class GitDiagnostic : Diagnostic
     {
-        private readonly IGit _git;
-
-        public GitDiagnostic(IGit git)
-            : base("Git")
-        {
-            EnsureArgument.NotNull(git, nameof(git));
-
-            _git = git;
-        }
+        public GitDiagnostic(ICommandContext commandContext)
+            : base("Git", commandContext)
+        { }
 
         protected override Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
         {
             log.Append("Getting Git version...");
-            GitVersion gitVersion =  _git.Version;
+            GitVersion gitVersion = CommandContext.Git.Version;
             log.AppendLine(" OK");
             log.AppendLine($"Git version is '{gitVersion.OriginalString}'");
 
             log.Append("Locating current repository...");
-            string thisRepo =_git.GetCurrentRepository();
+            string thisRepo =CommandContext.Git.GetCurrentRepository();
             log.AppendLine(" OK");
             log.AppendLine(thisRepo is null ? "Not inside a Git repository." : $"Git repository at '{thisRepo}'");
 
             log.Append("Listing all Git configuration...");
-            Process configProc = _git.CreateProcess("config --list --show-origin");
+            Process configProc = CommandContext.Git.CreateProcess("config --list --show-origin");
             configProc.Start();
             // To avoid deadlocks, always read the output stream first and then wait
             // TODO: don't read in all the data at once; stream it

--- a/src/shared/Core/Diagnostics/MicrosoftAuthenticationDiagnostic.cs
+++ b/src/shared/Core/Diagnostics/MicrosoftAuthenticationDiagnostic.cs
@@ -9,19 +9,13 @@ namespace GitCredentialManager.Diagnostics
 {
     public class MicrosoftAuthenticationDiagnostic : Diagnostic
     {
-        private readonly ICommandContext _context;
-
         public MicrosoftAuthenticationDiagnostic(ICommandContext context)
-            : base("Microsoft authentication (AAD/MSA)")
-        {
-            EnsureArgument.NotNull(context, nameof(context));
-
-            _context = context;
-        }
+            : base("Microsoft authentication (AAD/MSA)", context)
+        { }
 
         protected override async Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
         {
-            if (MicrosoftAuthentication.CanUseBroker(_context))
+            if (MicrosoftAuthentication.CanUseBroker(CommandContext))
             {
                 log.Append("Checking broker initialization state...");
                 if (MicrosoftAuthentication.IsBrokerInitialized)
@@ -41,7 +35,7 @@ namespace GitCredentialManager.Diagnostics
                 log.AppendLine("Broker not supported.");
             }
 
-            var msAuth = new MicrosoftAuthentication(_context);
+            var msAuth = new MicrosoftAuthentication(CommandContext);
             log.AppendLine($"Flow type is: {msAuth.GetFlowType()}");
 
             log.Append("Gathering MSAL token cache data...");

--- a/src/shared/Core/Diagnostics/NetworkingDiagnostic.cs
+++ b/src/shared/Core/Diagnostics/NetworkingDiagnostic.cs
@@ -11,23 +11,18 @@ namespace GitCredentialManager.Diagnostics
 {
     public class NetworkingDiagnostic : Diagnostic
     {
-        private readonly IHttpClientFactory _httpFactory;
         private const string TestHttpUri = "http://example.com";
         private const string TestHttpsUri = "https://example.com";
 
-        public NetworkingDiagnostic(IHttpClientFactory httpFactory)
-            : base("Networking")
-        {
-            EnsureArgument.NotNull(httpFactory, nameof(httpFactory));
-
-            _httpFactory = httpFactory;
-        }
+        public NetworkingDiagnostic(ICommandContext commandContext)
+            : base("Networking", commandContext)
+        { }
 
         protected override async Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
         {
             log.AppendLine("Checking networking and HTTP stack...");
             log.Append("Creating HTTP client...");
-            using var httpClient = _httpFactory.CreateClient();
+            using var httpClient = CommandContext.HttpClientFactory.CreateClient();
             log.AppendLine(" OK");
 
             bool hasNetwork = NetworkInterface.GetIsNetworkAvailable();

--- a/src/shared/Core/EnvironmentBase.cs
+++ b/src/shared/Core/EnvironmentBase.cs
@@ -46,18 +46,6 @@ namespace GitCredentialManager
         bool TryLocateExecutable(string program, out string path);
 
         /// <summary>
-        /// Create a process ready to start, with redirected streams.
-        /// </summary>
-        /// <param name="path">Absolute file path of executable or command to start.</param>
-        /// <param name="args">Command line arguments to pass to executable.</param>
-        /// <param name="useShellExecute">
-        /// True to resolve <paramref name="path"/> using the OS shell, false to use as an absolute file path.
-        /// </param>
-        /// <param name="workingDirectory">Working directory for the new process.</param>
-        /// <returns><see cref="Process"/> object ready to start.</returns>
-        Process CreateProcess(string path, string args, bool useShellExecute, string workingDirectory);
-
-        /// <summary>
         /// Set an environment variable at the specified target level.
         /// </summary>
         /// <param name="variable">Name of the environment variable to set.</param>
@@ -78,8 +66,6 @@ namespace GitCredentialManager
 
         public IReadOnlyDictionary<string, string> Variables { get; protected set; }
 
-        protected ITrace Trace { get; }
-
         protected IFileSystem FileSystem { get; }
 
         public bool IsDirectoryOnPath(string directoryPath)
@@ -98,20 +84,6 @@ namespace GitCredentialManager
         public abstract void RemoveDirectoryFromPath(string directoryPath, EnvironmentVariableTarget target);
 
         protected abstract string[] SplitPathVariable(string value);
-
-        public virtual Process CreateProcess(string path, string args, bool useShellExecute, string workingDirectory)
-        {
-            var psi = new ProcessStartInfo(path, args)
-            {
-                RedirectStandardInput = true,
-                RedirectStandardOutput = true,
-                RedirectStandardError = false, // Do not redirect stderr as tracing might be enabled
-                UseShellExecute = useShellExecute,
-                WorkingDirectory = workingDirectory ?? string.Empty
-            };
-
-            return new Process { StartInfo = psi };
-        }
 
         public virtual bool TryLocateExecutable(string program, out string path)
         {
@@ -178,33 +150,6 @@ namespace GitCredentialManager
             }
 
             throw new Exception($"Failed to locate '{program}' executable on the path.");
-        }
-
-        /// <summary>
-        /// Create a process ready to start, with redirected streams.
-        /// </summary>
-        /// <param name="environment">The <see cref="IEnvironment"/>.</param>
-        /// <param name="path">Absolute file path of executable or command to start.</param>
-        /// <param name="args">Command line arguments to pass to executable.</param>
-        /// <param name="useShellExecute">
-        /// True to resolve <paramref name="path"/> using the OS shell, false to use as an absolute file path.
-        /// </param>
-        /// <returns><see cref="Process"/> object ready to start.</returns>
-        public static Process CreateProcess(this IEnvironment environment, string path, string args, bool useShellExecute)
-        {
-            return environment.CreateProcess(path, args, useShellExecute, string.Empty);
-        }
-
-        /// <summary>
-        /// Create a process ready to start, with redirected streams.
-        /// </summary>
-        /// <param name="environment">The <see cref="IEnvironment"/>.</param>
-        /// <param name="path">Absolute file path of executable to start.</param>
-        /// <param name="args">Command line arguments to pass to executable.</param>
-        /// <returns><see cref="Process"/> object ready to start.</returns>
-        public static Process CreateProcess(this IEnvironment environment, string path, string args)
-        {
-            return environment.CreateProcess(path, args, false, string.Empty);
         }
     }
 }

--- a/src/shared/Core/EnvironmentBase.cs
+++ b/src/shared/Core/EnvironmentBase.cs
@@ -105,7 +105,7 @@ namespace GitCredentialManager
             {
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
-                RedirectStandardError = true,
+                RedirectStandardError = false, // Do not redirect stderr as tracing might be enabled
                 UseShellExecute = useShellExecute,
                 WorkingDirectory = workingDirectory ?? string.Empty
             };

--- a/src/shared/Core/GenericHostProvider.cs
+++ b/src/shared/Core/GenericHostProvider.cs
@@ -100,7 +100,7 @@ namespace GitCredentialManager
                 }
                 else
                 {
-                    string osType = PlatformUtils.GetPlatformInformation().OperatingSystemType;
+                    string osType = PlatformUtils.GetPlatformInformation(Context.Trace2).OperatingSystemType;
                     Context.Trace.WriteLine($"Skipping check for Windows Integrated Authentication on {osType}.");
                 }
             }

--- a/src/shared/Core/Git.cs
+++ b/src/shared/Core/Git.cs
@@ -90,7 +90,7 @@ namespace GitCredentialManager
                 {
                     using (var git = CreateProcess("version"))
                     {
-                        git.Start();
+                        git.Start(Trace2ProcessClass.Git);
 
                         string data = git.StandardOutput.ReadToEnd();
                         git.WaitForExit();
@@ -120,7 +120,7 @@ namespace GitCredentialManager
         {
             using (var git = CreateProcess("rev-parse --absolute-git-dir"))
             {
-                git.Start();
+                git.Start(Trace2ProcessClass.Git);
                 string data = git.StandardOutput.ReadToEnd();
                 git.WaitForExit();
 
@@ -141,7 +141,7 @@ namespace GitCredentialManager
         {
             using (var git = CreateProcess("remote -v show"))
             {
-                git.Start();
+                git.Start(Trace2ProcessClass.Git);
                 // To avoid deadlocks, always read the output stream first and then wait
                 // TODO: don't read in all the data at once; stream it
                 string data = git.StandardOutput.ReadToEnd();

--- a/src/shared/Core/Git.cs
+++ b/src/shared/Core/Git.cs
@@ -18,7 +18,7 @@ namespace GitCredentialManager
         /// </summary>
         /// <param name="args">Arguments to pass to the Git process.</param>
         /// <returns>Process object ready to be started.</returns>
-        Process CreateProcess(string args);
+        ChildProcess CreateProcess(string args);
 
         /// <summary>
         /// Return the path to the current repository, or null if this instance is not
@@ -65,18 +65,18 @@ namespace GitCredentialManager
     public class GitProcess : IGit
     {
         private readonly ITrace _trace;
-        private readonly IEnvironment _environment;
+        private readonly IProcessManager _processManager;
         private readonly string _gitPath;
         private readonly string _workingDirectory;
 
-        public GitProcess(ITrace trace, IEnvironment environment, string gitPath, string workingDirectory = null)
+        public GitProcess(ITrace trace, IProcessManager processManager, string gitPath, string workingDirectory = null)
         {
             EnsureArgument.NotNull(trace, nameof(trace));
-            EnsureArgument.NotNull(environment, nameof(environment));
+            EnsureArgument.NotNull(processManager, nameof(processManager));
             EnsureArgument.NotNullOrWhiteSpace(gitPath, nameof(gitPath));
 
             _trace = trace;
-            _environment = environment;
+            _processManager = processManager;
             _gitPath = gitPath;
             _workingDirectory = workingDirectory;
         }
@@ -121,8 +121,6 @@ namespace GitCredentialManager
             using (var git = CreateProcess("rev-parse --absolute-git-dir"))
             {
                 git.Start();
-                // To avoid deadlocks, always read the output stream first and then wait
-                // TODO: don't read in all the data at once; stream it
                 string data = git.StandardOutput.ReadToEnd();
                 git.WaitForExit();
 
@@ -184,9 +182,9 @@ namespace GitCredentialManager
             }
         }
 
-        public Process CreateProcess(string args)
+        public ChildProcess CreateProcess(string args)
         {
-            return _environment.CreateProcess(_gitPath, args, false, _workingDirectory);
+            return _processManager.CreateProcess(_gitPath, args, false, _workingDirectory);
         }
 
         // This code was originally copied from
@@ -206,7 +204,7 @@ namespace GitCredentialManager
                 UseShellExecute = false
             };
 
-            var process = Process.Start(procStartInfo);
+            var process = _processManager.CreateProcess(procStartInfo);
             if (process is null)
             {
                 throw new Exception($"Failed to start Git helper '{args}'");
@@ -238,7 +236,7 @@ namespace GitCredentialManager
             return resultDict;
         }
 
-        public static GitException CreateGitException(Process git, string message)
+        public static GitException CreateGitException(ChildProcess git, string message)
         {
             string gitMessage = git.StandardError.ReadToEnd();
             throw new GitException(message, gitMessage, git.ExitCode);

--- a/src/shared/Core/GitConfiguration.cs
+++ b/src/shared/Core/GitConfiguration.cs
@@ -127,7 +127,7 @@ namespace GitCredentialManager
         public void Enumerate(GitConfigurationLevel level, GitConfigurationEnumerationCallback cb)
         {
             string levelArg = GetLevelFilterArg(level);
-            using (Process git = _git.CreateProcess($"config --null {levelArg} --list"))
+            using (ChildProcess git = _git.CreateProcess($"config --null {levelArg} --list"))
             {
                 git.Start();
                 // To avoid deadlocks, always read the output stream first and then wait
@@ -196,7 +196,7 @@ namespace GitCredentialManager
         {
             string levelArg = GetLevelFilterArg(level);
             string typeArg = GetCanonicalizeTypeArg(type);
-            using (Process git = _git.CreateProcess($"config --null {levelArg} {typeArg} {QuoteCmdArg(name)}"))
+            using (ChildProcess git = _git.CreateProcess($"config --null {levelArg} {typeArg} {QuoteCmdArg(name)}"))
             {
                 git.Start();
                 // To avoid deadlocks, always read the output stream first and then wait
@@ -234,7 +234,7 @@ namespace GitCredentialManager
             EnsureSpecificLevel(level);
 
             string levelArg = GetLevelFilterArg(level);
-            using (Process git = _git.CreateProcess($"config {levelArg} {QuoteCmdArg(name)} {QuoteCmdArg(value)}"))
+            using (ChildProcess git = _git.CreateProcess($"config {levelArg} {QuoteCmdArg(name)} {QuoteCmdArg(value)}"))
             {
                 git.Start();
                 git.WaitForExit();
@@ -255,7 +255,7 @@ namespace GitCredentialManager
             EnsureSpecificLevel(level);
 
             string levelArg = GetLevelFilterArg(level);
-            using (Process git = _git.CreateProcess($"config {levelArg} --add {QuoteCmdArg(name)} {QuoteCmdArg(value)}"))
+            using (ChildProcess git = _git.CreateProcess($"config {levelArg} --add {QuoteCmdArg(name)} {QuoteCmdArg(value)}"))
             {
                 git.Start();
                 git.WaitForExit();
@@ -276,7 +276,7 @@ namespace GitCredentialManager
             EnsureSpecificLevel(level);
 
             string levelArg = GetLevelFilterArg(level);
-            using (Process git = _git.CreateProcess($"config {levelArg} --unset {QuoteCmdArg(name)}"))
+            using (ChildProcess git = _git.CreateProcess($"config {levelArg} --unset {QuoteCmdArg(name)}"))
             {
                 git.Start();
                 git.WaitForExit();
@@ -300,7 +300,7 @@ namespace GitCredentialManager
 
             var gitArgs = $"config --null {levelArg} {typeArg} --get-all {QuoteCmdArg(name)}";
 
-            using (Process git = _git.CreateProcess(gitArgs))
+            using (ChildProcess git = _git.CreateProcess(gitArgs))
             {
                 git.Start();
                 // To avoid deadlocks, always read the output stream first and then wait
@@ -342,7 +342,7 @@ namespace GitCredentialManager
                 gitArgs += $" {QuoteCmdArg(valueRegex)}";
             }
 
-            using (Process git = _git.CreateProcess(gitArgs))
+            using (ChildProcess git = _git.CreateProcess(gitArgs))
             {
                 git.Start();
                 // To avoid deadlocks, always read the output stream first and then wait
@@ -384,7 +384,7 @@ namespace GitCredentialManager
                 gitArgs += $" {QuoteCmdArg(valueRegex)}";
             }
 
-            using (Process git = _git.CreateProcess(gitArgs))
+            using (ChildProcess git = _git.CreateProcess(gitArgs))
             {
                 git.Start();
                 git.WaitForExit();
@@ -411,7 +411,7 @@ namespace GitCredentialManager
                 gitArgs += $" {QuoteCmdArg(valueRegex)}";
             }
 
-            using (Process git = _git.CreateProcess(gitArgs))
+            using (ChildProcess git = _git.CreateProcess(gitArgs))
             {
                 git.Start();
                 git.WaitForExit();

--- a/src/shared/Core/GitConfiguration.cs
+++ b/src/shared/Core/GitConfiguration.cs
@@ -129,7 +129,7 @@ namespace GitCredentialManager
             string levelArg = GetLevelFilterArg(level);
             using (ChildProcess git = _git.CreateProcess($"config --null {levelArg} --list"))
             {
-                git.Start();
+                git.Start(Trace2ProcessClass.Git);
                 // To avoid deadlocks, always read the output stream first and then wait
                 // TODO: don't read in all the data at once; stream it
                 string data = git.StandardOutput.ReadToEnd();
@@ -198,7 +198,7 @@ namespace GitCredentialManager
             string typeArg = GetCanonicalizeTypeArg(type);
             using (ChildProcess git = _git.CreateProcess($"config --null {levelArg} {typeArg} {QuoteCmdArg(name)}"))
             {
-                git.Start();
+                git.Start(Trace2ProcessClass.Git);
                 // To avoid deadlocks, always read the output stream first and then wait
                 // TODO: don't read in all the data at once; stream it
                 string data = git.StandardOutput.ReadToEnd();
@@ -236,7 +236,7 @@ namespace GitCredentialManager
             string levelArg = GetLevelFilterArg(level);
             using (ChildProcess git = _git.CreateProcess($"config {levelArg} {QuoteCmdArg(name)} {QuoteCmdArg(value)}"))
             {
-                git.Start();
+                git.Start(Trace2ProcessClass.Git);
                 git.WaitForExit();
 
                 switch (git.ExitCode)
@@ -257,7 +257,7 @@ namespace GitCredentialManager
             string levelArg = GetLevelFilterArg(level);
             using (ChildProcess git = _git.CreateProcess($"config {levelArg} --add {QuoteCmdArg(name)} {QuoteCmdArg(value)}"))
             {
-                git.Start();
+                git.Start(Trace2ProcessClass.Git);
                 git.WaitForExit();
 
                 switch (git.ExitCode)
@@ -278,7 +278,7 @@ namespace GitCredentialManager
             string levelArg = GetLevelFilterArg(level);
             using (ChildProcess git = _git.CreateProcess($"config {levelArg} --unset {QuoteCmdArg(name)}"))
             {
-                git.Start();
+                git.Start(Trace2ProcessClass.Git);
                 git.WaitForExit();
 
                 switch (git.ExitCode)
@@ -302,7 +302,7 @@ namespace GitCredentialManager
 
             using (ChildProcess git = _git.CreateProcess(gitArgs))
             {
-                git.Start();
+                git.Start(Trace2ProcessClass.Git);
                 // To avoid deadlocks, always read the output stream first and then wait
                 // TODO: don't read in all the data at once; stream it
                 string data = git.StandardOutput.ReadToEnd();
@@ -344,7 +344,7 @@ namespace GitCredentialManager
 
             using (ChildProcess git = _git.CreateProcess(gitArgs))
             {
-                git.Start();
+                git.Start(Trace2ProcessClass.Git);
                 // To avoid deadlocks, always read the output stream first and then wait
                 // TODO: don't read in all the data at once; stream it
                 string data = git.StandardOutput.ReadToEnd();
@@ -386,7 +386,7 @@ namespace GitCredentialManager
 
             using (ChildProcess git = _git.CreateProcess(gitArgs))
             {
-                git.Start();
+                git.Start(Trace2ProcessClass.Git);
                 git.WaitForExit();
 
                 switch (git.ExitCode)
@@ -413,7 +413,7 @@ namespace GitCredentialManager
 
             using (ChildProcess git = _git.CreateProcess(gitArgs))
             {
-                git.Start();
+                git.Start(Trace2ProcessClass.Git);
                 git.WaitForExit();
 
                 switch (git.ExitCode)

--- a/src/shared/Core/Gpg.cs
+++ b/src/shared/Core/Gpg.cs
@@ -14,14 +14,16 @@ namespace GitCredentialManager
     {
         private readonly string _gpgPath;
         private readonly ISessionManager _sessionManager;
+        private readonly IProcessManager _processManager;
 
-        public Gpg(string gpgPath, ISessionManager sessionManager)
+        public Gpg(string gpgPath, ISessionManager sessionManager, IProcessManager processManager)
         {
             EnsureArgument.NotNullOrWhiteSpace(gpgPath, nameof(gpgPath));
             EnsureArgument.NotNull(sessionManager, nameof(sessionManager));
 
             _gpgPath = gpgPath;
             _sessionManager = sessionManager;
+            _processManager = processManager;
         }
 
         public string DecryptFile(string path)
@@ -37,7 +39,7 @@ namespace GitCredentialManager
 
             PrepareEnvironment(psi);
 
-            using (var gpg = Process.Start(psi))
+            using (var gpg = _processManager.CreateProcess(psi))
             {
                 if (gpg is null)
                 {
@@ -69,7 +71,7 @@ namespace GitCredentialManager
 
             PrepareEnvironment(psi);
 
-            using (var gpg = Process.Start(psi))
+            using (var gpg = _processManager.CreateProcess(psi))
             {
                 if (gpg is null)
                 {

--- a/src/shared/Core/Gpg.cs
+++ b/src/shared/Core/Gpg.cs
@@ -30,7 +30,9 @@ namespace GitCredentialManager
             {
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
-                RedirectStandardError = true, // Suppress verbose decryption messages
+                // Suppress verbose decryption messages
+                // Ok to redirect stderr for non-Git-related processes
+                RedirectStandardError = true,
             };
 
             PrepareEnvironment(psi);
@@ -62,7 +64,7 @@ namespace GitCredentialManager
                 UseShellExecute = false,
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
-                RedirectStandardError = true,
+                RedirectStandardError = true, // Ok to redirect stderr for non-git-related processes
             };
 
             PrepareEnvironment(psi);

--- a/src/shared/Core/HttpClientFactory.cs
+++ b/src/shared/Core/HttpClientFactory.cs
@@ -37,10 +37,11 @@ namespace GitCredentialManager
     {
         private readonly IFileSystem _fileSystem;
         private readonly ITrace _trace;
+        private readonly ITrace2 _trace2;
         private readonly ISettings _settings;
         private readonly IStandardStreams _streams;
 
-        public HttpClientFactory(IFileSystem fileSystem, ITrace trace, ISettings settings, IStandardStreams streams)
+        public HttpClientFactory(IFileSystem fileSystem, ITrace trace, ITrace2 trace2, ISettings settings, IStandardStreams streams)
         {
             EnsureArgument.NotNull(fileSystem, nameof(fileSystem));
             EnsureArgument.NotNull(trace, nameof(trace));
@@ -49,6 +50,7 @@ namespace GitCredentialManager
 
             _fileSystem = fileSystem;
             _trace = trace;
+            _trace2 = trace2;
             _settings = settings;
             _streams = streams;
         }
@@ -182,7 +184,7 @@ namespace GitCredentialManager
             var client = new HttpClient(handler);
 
             // Add default headers
-            client.DefaultRequestHeaders.UserAgent.ParseAdd(Constants.GetHttpUserAgent());
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(Constants.GetHttpUserAgent(_trace2));
             client.DefaultRequestHeaders.CacheControl = new CacheControlHeaderValue
             {
                 NoCache = true

--- a/src/shared/Core/ITrace2Writer.cs
+++ b/src/shared/Core/ITrace2Writer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 
 namespace GitCredentialManager;
 
@@ -7,4 +8,42 @@ public interface ITrace2Writer : IDisposable
     bool Failed { get; }
 
     void Write(Trace2Message message);
+}
+
+public class Trace2Writer : DisposableObject, ITrace2Writer
+{
+    private readonly Trace2FormatTarget _formatTarget;
+
+    public bool Failed { get; protected set; }
+
+    protected Trace2Writer(Trace2FormatTarget formatTarget)
+    {
+        _formatTarget = formatTarget;
+    }
+
+    protected string Format(Trace2Message message)
+    {
+        EnsureArgument.NotNull(message, nameof(message));
+        var sb = new StringBuilder();
+
+        switch (_formatTarget)
+        {
+            case Trace2FormatTarget.Event:
+                sb.Append(message.ToJson());
+                break;
+            case Trace2FormatTarget.Normal:
+                sb.Append(message.ToNormalString());
+                break;
+            default:
+                Console.WriteLine($"warning: unrecognized format target '{_formatTarget}', disabling TRACE2 tracing.");
+                Failed = true;
+                break;
+        }
+
+        sb.Append('\n');
+        return sb.ToString();
+    }
+
+    public virtual void Write(Trace2Message message)
+    { }
 }

--- a/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
+++ b/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
@@ -70,18 +70,6 @@ namespace GitCredentialManager.Interop.Windows
             }
         }
 
-        public override Process CreateProcess(string path, string args, bool useShellExecute, string workingDirectory)
-        {
-            // If we're asked to start a WSL executable we must launch via the wsl.exe command tool
-            if (!useShellExecute && WslUtils.IsWslPath(path))
-            {
-                string wslPath = WslUtils.ConvertToDistroPath(path, out string distro);
-                return WslUtils.CreateWslProcess(distro, $"{wslPath} {args}", workingDirectory);
-            }
-
-            return base.CreateProcess(path, args, useShellExecute, workingDirectory);
-        }
-
         #endregion
 
         protected override IReadOnlyDictionary<string, string> GetCurrentVariables()

--- a/src/shared/Core/Interop/Windows/WindowsProcessManager.cs
+++ b/src/shared/Core/Interop/Windows/WindowsProcessManager.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics;
+
+namespace GitCredentialManager.Interop.Windows;
+
+public class WindowsProcessManager : ProcessManager
+{
+    private readonly ITrace2 _trace2;
+
+    public WindowsProcessManager(ITrace2 trace2) : base(trace2)
+    {
+        _trace2 = trace2;
+    }
+
+    public override ChildProcess CreateProcess(string path, string args, bool useShellExecute, string workingDirectory)
+    {
+        // If we're asked to start a WSL executable we must launch via the wsl.exe command tool
+        if (!useShellExecute && WslUtils.IsWslPath(path))
+        {
+            string wslPath = WslUtils.ConvertToDistroPath(path, out string distro);
+            return WslUtils.CreateWslProcess(distro, $"{wslPath} {args}", _trace2, workingDirectory);
+        }
+
+        return base.CreateProcess(path, args, useShellExecute, workingDirectory);
+    }
+}

--- a/src/shared/Core/PlatformUtils.cs
+++ b/src/shared/Core/PlatformUtils.cs
@@ -338,7 +338,7 @@ namespace GitCredentialManager
 
                 using (var swvers = new ChildProcess(trace2, psi))
                 {
-                    swvers.Start();
+                    swvers.Start(Trace2ProcessClass.Other);
                     swvers.WaitForExit();
 
                     if (swvers.ExitCode == 0)
@@ -359,7 +359,7 @@ namespace GitCredentialManager
 
                 using (var uname = new ChildProcess(trace2, psi))
                 {
-                    uname.Start();
+                    uname.Start(Trace2ProcessClass.Other);
                     uname.Process.WaitForExit();
 
                     if (uname.ExitCode == 0)

--- a/src/shared/Core/PlatformUtils.cs
+++ b/src/shared/Core/PlatformUtils.cs
@@ -12,10 +12,10 @@ namespace GitCredentialManager
         /// Get information about the current platform (OS and CLR details).
         /// </summary>
         /// <returns>Platform information.</returns>
-        public static PlatformInformation GetPlatformInformation()
+        public static PlatformInformation GetPlatformInformation(ITrace2 trace2)
         {
             string osType = GetOSType();
-            string osVersion = GetOSVersion();
+            string osVersion = GetOSVersion(trace2);
             string cpuArch = GetCpuArchitecture();
             string clrVersion = GetClrVersion();
 
@@ -320,7 +320,7 @@ namespace GitCredentialManager
             return "Unknown";
         }
 
-        private static string GetOSVersion()
+        private static string GetOSVersion(ITrace2 trace2)
         {
             if (IsWindows() && RtlGetVersionEx(out RTL_OSVERSIONINFOEX osvi) == 0)
             {
@@ -336,10 +336,11 @@ namespace GitCredentialManager
                     RedirectStandardOutput = true
                 };
 
-                using (var swvers = new Process { StartInfo = psi })
+                using (var swvers = new ChildProcess(trace2, psi))
                 {
                     swvers.Start();
                     swvers.WaitForExit();
+
                     if (swvers.ExitCode == 0)
                     {
                         return swvers.StandardOutput.ReadToEnd().Trim();
@@ -356,10 +357,11 @@ namespace GitCredentialManager
                     RedirectStandardOutput = true
                 };
 
-                using (var uname = new Process { StartInfo = psi })
+                using (var uname = new ChildProcess(trace2, psi))
                 {
                     uname.Start();
-                    uname.WaitForExit();
+                    uname.Process.WaitForExit();
+
                     if (uname.ExitCode == 0)
                     {
                         return uname.StandardOutput.ReadToEnd().Trim();

--- a/src/shared/Core/ProcessManager.cs
+++ b/src/shared/Core/ProcessManager.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace GitCredentialManager;
+
+public interface IProcessManager
+{
+    /// <summary>
+    /// Create a process ready to start.
+    /// </summary>
+    /// <param name="path">Absolute file path of executable or command to start.</param>
+    /// <param name="args">Command line arguments to pass to executable.</param>
+    /// <param name="useShellExecute">
+    ///     True to resolve <paramref name="path"/> using the OS shell, false to use as an absolute file path.
+    /// </param>
+    /// <param name="workingDirectory">Working directory for the new process.</param>
+    /// <returns><see cref="Process"/> object ready to start.</returns>
+    ChildProcess CreateProcess(string path, string args, bool useShellExecute, string workingDirectory);
+
+    /// <summary>
+    /// Create a process ready to start.
+    /// </summary>
+    /// <param name="psi">Process start info.</param>
+    /// <returns><see cref="Process"/> object ready to start.</returns>
+    ChildProcess CreateProcess(ProcessStartInfo psi);
+}
+
+public class ProcessManager : IProcessManager
+{
+    private readonly ITrace2 _trace2;
+
+    public ProcessManager(ITrace2 trace2)
+    {
+        _trace2 = trace2;
+    }
+
+    public virtual ChildProcess CreateProcess(string path, string args, bool useShellExecute, string workingDirectory)
+    {
+        var psi = new ProcessStartInfo(path, args)
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = false, // Do not redirect stderr as tracing might be enabled
+            UseShellExecute = useShellExecute,
+            WorkingDirectory = workingDirectory ?? string.Empty
+        };
+
+        return CreateProcess(psi);
+    }
+
+
+    public virtual ChildProcess CreateProcess(ProcessStartInfo psi)
+    {
+        return new ChildProcess(_trace2, psi);
+    }
+}

--- a/src/shared/Core/SidManager.cs
+++ b/src/shared/Core/SidManager.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace GitCredentialManager;
+
+public class SidManager
+{
+    private const string SidEnvar = "GIT_TRACE2_PARENT_SID";
+
+    public static string Sid { get; private set; }
+
+    public static void CreateSid()
+    {
+        Sid = Environment.GetEnvironmentVariable(SidEnvar);
+
+        if (!string.IsNullOrEmpty(Sid))
+        {
+            Sid = $"{Sid}/{Guid.NewGuid():D}";
+        }
+        else
+        {
+            // We are the root process; create our own 'root' SID
+            Sid = Guid.NewGuid().ToString("D");
+        }
+
+        Environment.SetEnvironmentVariable(SidEnvar, Sid);
+    }
+}

--- a/src/shared/Core/StringExtensions.cs
+++ b/src/shared/Core/StringExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 
 namespace GitCredentialManager
 {
@@ -239,6 +240,29 @@ namespace GitCredentialManager
         public static bool Contains(this string str, string value, StringComparison comparisonType)
         {
             return str?.IndexOf(value, comparisonType) >= 0;
+        }
+
+        /// <summary>
+        /// Convert string to snake case.
+        /// </summary>
+        /// <param name="str">String to convert.</param>
+        /// <returns>Input string converted to snake case.</returns>
+        public static string ToSnakeCase(this string str)
+        {
+            int len = str.Length;
+            var sb = new StringBuilder(2*len);
+            for (int i = 0; i < len; i++)
+            {
+                if (i > 0 && char.IsUpper(str[i]) &&
+                    (char.IsLower(str[i - 1]) || i < len - 1 && char.IsLower(str[i + 1])))
+                {
+                    sb.Append('_');
+
+                }
+                sb.Append(char.ToLower(str[i]));
+            }
+
+            return sb.ToString();
         }
     }
 }

--- a/src/shared/Core/Trace2.cs
+++ b/src/shared/Core/Trace2.cs
@@ -158,7 +158,7 @@ public class Trace2 : DisposableObject, ITrace2
         {
             if (TryGetPipeName(formatTarget.Value, out string name)) // Write to named pipe/socket
             {
-                AddWriter(new Trace2CollectorWriter((
+                AddWriter(new Trace2CollectorWriter(formatTarget.Key, (
                         () => new NamedPipeClientStream(".", name,
                             PipeDirection.Out,
                             PipeOptions.Asynchronous)
@@ -167,16 +167,13 @@ public class Trace2 : DisposableObject, ITrace2
             }
             else if (formatTarget.Value.IsTruthy()) // Write to stderr
             {
-                AddWriter(new Trace2StreamWriter(error, formatTarget.Key));
+                AddWriter(new Trace2StreamWriter(formatTarget.Key, error));
             }
             else if (Path.IsPathRooted(formatTarget.Value)) // Write to file
             {
                 try
                 {
-                    Stream stream = fileSystem.OpenFileStream(formatTarget.Value, FileMode.Append,
-                        FileAccess.Write, FileShare.ReadWrite);
-                    AddWriter(new Trace2StreamWriter(new StreamWriter(stream, _utf8NoBomEncoding,
-                        4096, leaveOpen: false), formatTarget.Key));
+                    AddWriter(new Trace2FileWriter(formatTarget.Key, formatTarget.Value));
                 }
                 catch (Exception ex)
                 {

--- a/src/shared/Core/Trace2.cs
+++ b/src/shared/Core/Trace2.cs
@@ -18,11 +18,8 @@ namespace GitCredentialManager;
 /// </summary>
 public enum Trace2Event
 {
-    [EnumMember(Value = "version")]
     Version = 0,
-    [EnumMember(Value = "start")]
     Start = 1,
-    [EnumMember(Value = "exit")]
     Exit = 2
 }
 
@@ -337,7 +334,7 @@ public class VersionMessage : Trace2Message
     public override string ToJson()
     {
         return JsonConvert.SerializeObject(this,
-                new StringEnumConverter(),
+                new StringEnumConverter(typeof(SnakeCaseNamingStrategy)),
             new IsoDateTimeConverter()
             {
                 DateTimeFormat = TimeFormat
@@ -361,7 +358,7 @@ public class StartMessage : Trace2Message
     public override string ToJson()
     {
         return JsonConvert.SerializeObject(this,
-            new StringEnumConverter(),
+            new StringEnumConverter(typeof(SnakeCaseNamingStrategy)),
             new IsoDateTimeConverter()
             {
                 DateTimeFormat = TimeFormat
@@ -385,7 +382,7 @@ public class ExitMessage : Trace2Message
     public override string ToJson()
     {
         return JsonConvert.SerializeObject(this,
-            new StringEnumConverter(),
+            new StringEnumConverter(typeof(SnakeCaseNamingStrategy)),
             new IsoDateTimeConverter()
             {
                 DateTimeFormat = TimeFormat

--- a/src/shared/Core/Trace2.cs
+++ b/src/shared/Core/Trace2.cs
@@ -84,7 +84,7 @@ public class Trace2 : DisposableObject, ITrace2
         _argv = argv;
         _applicationStartTime = applicationStartTime;
 
-        _sid = SetSid();
+        _sid = SidManager.Sid;
     }
 
     public void Start(TextWriter error,
@@ -132,22 +132,6 @@ public class Trace2 : DisposableObject, ITrace2
         }
 
         base.ReleaseManagedResources();
-    }
-
-    internal string SetSid()
-    {
-        var sids = new List<string>();
-        if (_environment.Variables.TryGetValue(GitSidVariable, out string parentSid))
-        {
-            sids.Add(parentSid);
-        }
-
-        // Add GCM "child" sid
-        sids.Add(Guid.NewGuid().ToString("D"));
-        var combinedSid = string.Join("/", sids);
-
-        _environment.SetEnvironmentVariable(GitSidVariable, combinedSid);
-        return combinedSid;
     }
 
     internal bool TryGetPipeName(string eventTarget, out string name)

--- a/src/shared/Core/Trace2.cs
+++ b/src/shared/Core/Trace2.cs
@@ -35,22 +35,25 @@ public class Trace2Settings
 public interface ITrace2 : IDisposable
 {
     /// <summary>
-    /// Initialize TRACE2 tracing by setting up any configured target formats and
-    /// writing Version and Start events.
+    /// Initialize TRACE2 tracing by initializing multi-use fields and setting up any configured target formats.
     /// </summary>
-    /// <param name="error">The standard error text stream connected back to the calling process.</param>
-    /// <param name="fileSystem">File system abstraction.</param>
-    /// <param name="appPath">The path to the GCM application.</param>
+    /// <param name="startTime">Approximate time calling application began executing.</param>
+    void Initialize(DateTimeOffset startTime);
+
+    /// <summary>
+    /// Write Version and Start events.
+    /// </summary>
+    /// <param name="appPath">The path to the application.</param>
+    /// <param name="args">Args passed to the application (if applicable).</param>
     /// <param name="filePath">Path of the file this method is called from.</param>
     /// <param name="lineNumber">Line number of file this method is called from.</param>
-    void Start(TextWriter error,
-        IFileSystem fileSystem,
-        string appPath,
+    void Start(string appPath,
+        string[] args,
         [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
         [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0);
 
     /// <summary>
-    /// Shut down TRACE2 tracing by writing Exit event and disposing of writers.
+    /// Write Exit event and dispose of writers.
     /// </summary>
     /// <param name="exitCode">The exit code of the GCM application.</param>
     /// <param name="filePath">Path of the file this method is called from.</param>
@@ -62,36 +65,45 @@ public interface ITrace2 : IDisposable
 
 public class Trace2 : DisposableObject, ITrace2
 {
+    private readonly ICommandContext _commandContext;
     private readonly object _writersLock = new object();
     private readonly Encoding _utf8NoBomEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+    private readonly List<ITrace2Writer> _writers = new List<ITrace2Writer>();
 
     private const string GitSidVariable = "GIT_TRACE2_PARENT_SID";
 
-    private List<ITrace2Writer> _writers = new List<ITrace2Writer>();
-    private IEnvironment _environment;
-    private Trace2Settings _settings;
-    private string[] _argv;
     private DateTimeOffset _applicationStartTime;
+    private Trace2Settings _settings;
     private string _sid;
 
-    public Trace2(IEnvironment environment, Trace2Settings settings, string[] argv, DateTimeOffset applicationStartTime)
-    {
-        _environment = environment;
-        _settings = settings;
-        _argv = argv;
-        _applicationStartTime = applicationStartTime;
+    private bool _initialized;
 
-        _sid = SidManager.Sid;
+    public Trace2(ICommandContext commandContext)
+    {
+        _commandContext = commandContext;
     }
 
-    public void Start(TextWriter error,
-        IFileSystem fileSystem,
-        string appPath,
+    public void Initialize(DateTimeOffset startTime)
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        _applicationStartTime = startTime;
+        _settings = _commandContext.Settings.GetTrace2Settings();
+        _sid = SidManager.Sid;
+
+        InitializeWriters();
+
+        _initialized = true;
+    }
+
+    public void Start(string appPath,
+        string[] args,
         string filePath,
         int lineNumber)
     {
-        TryParseSettings(error, fileSystem);
-
         if (!AssemblyUtils.TryGetAssemblyVersion(out string version))
         {
             // A version is required for TRACE2, so if this call fails
@@ -99,13 +111,12 @@ public class Trace2 : DisposableObject, ITrace2
             version = "0.0.0";
         }
         WriteVersion(version, filePath, lineNumber);
-        WriteStart(appPath, filePath, lineNumber);
+        WriteStart(appPath, args, filePath, lineNumber);
     }
 
     public void Stop(int exitCode, string filePath, int lineNumber)
     {
         WriteExit(exitCode, filePath, lineNumber);
-        ReleaseManagedResources();
     }
 
     protected override void ReleaseManagedResources()
@@ -131,7 +142,7 @@ public class Trace2 : DisposableObject, ITrace2
         base.ReleaseManagedResources();
     }
 
-    internal bool TryGetPipeName(string eventTarget, out string name)
+    internal static bool TryGetPipeName(string eventTarget, out string name)
     {
         // Use prefixes to determine whether target is a named pipe/socket
         if (eventTarget.Contains("af_unix:", StringComparison.OrdinalIgnoreCase) ||
@@ -148,7 +159,7 @@ public class Trace2 : DisposableObject, ITrace2
         return false;
     }
 
-    private void TryParseSettings(TextWriter error, IFileSystem fileSystem)
+    private void InitializeWriters()
     {
         // Set up the correct writer for every enabled format target.
         foreach (var formatTarget in _settings.FormatTargetsAndValues)
@@ -164,7 +175,7 @@ public class Trace2 : DisposableObject, ITrace2
             }
             else if (formatTarget.Value.IsTruthy()) // Write to stderr
             {
-                AddWriter(new Trace2StreamWriter(formatTarget.Key, error));
+                AddWriter(new Trace2StreamWriter(formatTarget.Key, _commandContext.Streams.Error));
             }
             else if (Path.IsPathRooted(formatTarget.Value)) // Write to file
             {
@@ -174,7 +185,7 @@ public class Trace2 : DisposableObject, ITrace2
                 }
                 catch (Exception ex)
                 {
-                    error.WriteLine($"warning: unable to trace to file '{formatTarget.Value}': {ex.Message}");
+                    Console.Error.WriteLine($"warning: unable to trace to file '{formatTarget.Value}': {ex.Message}");
                 }
             }
         }
@@ -202,6 +213,7 @@ public class Trace2 : DisposableObject, ITrace2
 
     private void WriteStart(
         string appPath,
+        string[] args,
         string filePath,
         int lineNumber)
     {
@@ -210,7 +222,11 @@ public class Trace2 : DisposableObject, ITrace2
         {
             Path.GetFileName(appPath),
         };
-        argv.AddRange(_argv);
+
+        if (args.Length > 0)
+        {
+            argv.AddRange(args);
+        }
 
         WriteMessage(new StartMessage()
         {
@@ -257,6 +273,11 @@ public class Trace2 : DisposableObject, ITrace2
     private void WriteMessage(Trace2Message message)
     {
         ThrowIfDisposed();
+
+        if (!_initialized)
+        {
+            return;
+        }
 
         lock (_writersLock)
         {

--- a/src/shared/Core/Trace2CollectorWriter.cs
+++ b/src/shared/Core/Trace2CollectorWriter.cs
@@ -12,7 +12,7 @@ namespace GitCredentialManager
     /// Accepts string messages from multiple threads and dispatches them over a named pipe from a
     /// background thread.
     /// </summary>
-    public class Trace2CollectorWriter : DisposableObject, ITrace2Writer
+    public class Trace2CollectorWriter : Trace2Writer
     {
         private const int DefaultMaxQueueSize = 256;
 
@@ -22,10 +22,9 @@ namespace GitCredentialManager
         private Thread _writerThread;
         private NamedPipeClientStream _pipeClient;
 
-        public bool Failed { get; private set; }
-
-        public Trace2CollectorWriter(Func<NamedPipeClientStream> createPipeFunc,
-            int maxQueueSize = DefaultMaxQueueSize)
+        public Trace2CollectorWriter(Trace2FormatTarget formatTarget,
+            Func<NamedPipeClientStream> createPipeFunc,
+            int maxQueueSize = DefaultMaxQueueSize) : base(formatTarget)
         {
             EnsureArgument.NotNull(createPipeFunc, nameof(createPipeFunc));
             EnsureArgument.Positive(maxQueueSize, nameof(maxQueueSize));
@@ -36,7 +35,7 @@ namespace GitCredentialManager
             Start();
         }
 
-        public void Write(Trace2Message message)
+        public override void Write(Trace2Message message)
         {
            _queue.TryAdd(message.ToJson());
         }

--- a/src/shared/Core/Trace2FileWriter.cs
+++ b/src/shared/Core/Trace2FileWriter.cs
@@ -1,0 +1,18 @@
+using System.IO;
+
+namespace GitCredentialManager;
+
+public class Trace2FileWriter : Trace2Writer
+{
+    private readonly string _path;
+
+    public Trace2FileWriter(Trace2FormatTarget formatTarget, string path) : base(formatTarget)
+    {
+        _path = path;
+    }
+
+    public override void Write(Trace2Message message)
+    {
+        File.AppendAllText(_path, Format(message));
+    }
+}

--- a/src/shared/Core/Trace2StreamWriter.cs
+++ b/src/shared/Core/Trace2StreamWriter.cs
@@ -13,25 +13,21 @@ public enum Trace2FormatTarget
     Normal
 }
 
-public class Trace2StreamWriter : DisposableObject, ITrace2Writer
+public class Trace2StreamWriter : Trace2Writer
 {
     private readonly TextWriter _writer;
-    private readonly Trace2FormatTarget _formatTarget;
 
-    public bool Failed { get; private set; }
-
-    public Trace2StreamWriter(TextWriter writer, Trace2FormatTarget formatTarget)
+    public Trace2StreamWriter(Trace2FormatTarget formatTarget, TextWriter writer)
+        : base(formatTarget)
     {
         _writer = writer;
-        _formatTarget = formatTarget;
     }
 
-    public void Write(Trace2Message message)
+    public override void Write(Trace2Message message)
     {
         try
         {
             _writer.Write(Format(message));
-            _writer.Write('\n');
             _writer.Flush();
         }
         catch
@@ -44,22 +40,5 @@ public class Trace2StreamWriter : DisposableObject, ITrace2Writer
     {
         _writer.Dispose();
         base.ReleaseManagedResources();
-    }
-
-    private string Format(Trace2Message message)
-    {
-        EnsureArgument.NotNull(message, nameof(message));
-
-        switch (_formatTarget)
-        {
-            case Trace2FormatTarget.Event:
-                return message.ToJson();
-            case Trace2FormatTarget.Normal:
-                return message.ToNormalString();
-            default:
-                Console.WriteLine($"warning: unrecognized format target '{_formatTarget}', disabling TRACE2 tracing.");
-                Failed = true;
-                return "";
-        }
     }
 }

--- a/src/shared/Core/WslUtils.cs
+++ b/src/shared/Core/WslUtils.cs
@@ -31,9 +31,13 @@ namespace GitCredentialManager
         /// </summary>
         /// <param name="distribution">WSL distribution name.</param>
         /// <param name="command">Command to execute.</param>
+        /// <param name="trace2">The applications TRACE2 tracer.</param>
         /// <param name="workingDirectory">Optional working directory.</param>
         /// <returns><see cref="Process"/> object ready to start.</returns>
-        public static Process CreateWslProcess(string distribution, string command, string workingDirectory = null)
+        public static ChildProcess CreateWslProcess(string distribution,
+            string command,
+            ITrace2 trace2,
+            string workingDirectory = null)
         {
             var args = new StringBuilder();
             args.AppendFormat("--distribution {0} ", distribution);
@@ -50,7 +54,7 @@ namespace GitCredentialManager
                 WorkingDirectory = workingDirectory ?? string.Empty
             };
 
-            return new Process { StartInfo = psi };
+            return new ChildProcess(trace2, psi);
         }
 
         public static string ConvertToDistroPath(string path, out string distribution)

--- a/src/shared/Core/WslUtils.cs
+++ b/src/shared/Core/WslUtils.cs
@@ -45,7 +45,7 @@ namespace GitCredentialManager
             {
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
-                RedirectStandardError = true,
+                RedirectStandardError = false, // Do not redirect stderr as tracing might be enabled
                 UseShellExecute = false,
                 WorkingDirectory = workingDirectory ?? string.Empty
             };

--- a/src/shared/Git-Credential-Manager.UI.Avalonia/Controls/TesterWindow.axaml.cs
+++ b/src/shared/Git-Credential-Manager.UI.Avalonia/Controls/TesterWindow.axaml.cs
@@ -22,7 +22,6 @@ namespace GitCredentialManager.UI.Controls
 #if DEBUG
             this.AttachDevTools();
 #endif
-
             if (PlatformUtils.IsWindows())
             {
                 _environment = new WindowsEnvironment(new WindowsFileSystem());

--- a/src/shared/Git-Credential-Manager.UI.Avalonia/Program.cs
+++ b/src/shared/Git-Credential-Manager.UI.Avalonia/Program.cs
@@ -43,6 +43,9 @@ namespace GitCredentialManager.UI
         {
             string[] args = (string[]) o;
 
+            // Set the session id (sid) for the helper process, to be
+            // used when TRACE2 tracing is enabled.
+            SidManager.CreateSid();
             using (var context = new CommandContext(args))
             using (var app = new HelperApplication(context))
             {

--- a/src/shared/Git-Credential-Manager.UI.Avalonia/Program.cs
+++ b/src/shared/Git-Credential-Manager.UI.Avalonia/Program.cs
@@ -46,9 +46,15 @@ namespace GitCredentialManager.UI
             // Set the session id (sid) for the helper process, to be
             // used when TRACE2 tracing is enabled.
             SidManager.CreateSid();
-            using (var context = new CommandContext(args))
+            using (var context = new CommandContext())
             using (var app = new HelperApplication(context))
             {
+                // Initialize TRACE2 system
+                context.Trace2.Initialize(DateTimeOffset.UtcNow);
+
+                // Write the start and version events
+                context.Trace2.Start(context.ApplicationPath, args);
+
                 app.RegisterCommand(new CredentialsCommandImpl(context));
                 app.RegisterCommand(new OAuthCommandImpl(context));
                 app.RegisterCommand(new DeviceCodeCommandImpl(context));

--- a/src/shared/Git-Credential-Manager/Program.cs
+++ b/src/shared/Git-Credential-Manager/Program.cs
@@ -11,6 +11,9 @@ namespace GitCredentialManager
     {
         public static void Main(string[] args)
         {
+            // Set the session id (sid) for the GCM process, to be
+            // used when TRACE2 tracing is enabled.
+            SidManager.CreateSid();
             using (var context = new CommandContext(args))
             using (var app = new Application(context))
             {

--- a/src/shared/GitHub.UI.Avalonia/Controls/TesterWindow.axaml.cs
+++ b/src/shared/GitHub.UI.Avalonia/Controls/TesterWindow.axaml.cs
@@ -17,6 +17,7 @@ namespace GitHub.UI.Controls
     public class TesterWindow : Window
     {
         private readonly IEnvironment _environment;
+        private readonly IProcessManager _processManager;
 
         public TesterWindow()
         {
@@ -24,10 +25,13 @@ namespace GitHub.UI.Controls
 #if DEBUG
             this.AttachDevTools();
 #endif
+            ICommandContext commandContext = new CommandContext();
+            ITrace2 trace2 = new Trace2(commandContext);
 
             if (PlatformUtils.IsWindows())
             {
                 _environment = new WindowsEnvironment(new WindowsFileSystem());
+                _processManager = new WindowsProcessManager(trace2);
             }
             else
             {
@@ -42,6 +46,7 @@ namespace GitHub.UI.Controls
                 }
 
                 _environment = new PosixEnvironment(fs);
+                _processManager = new ProcessManager(trace2);
             }
         }
 
@@ -52,7 +57,7 @@ namespace GitHub.UI.Controls
 
         private void ShowCredentials(object sender, RoutedEventArgs e)
         {
-            var vm = new CredentialsViewModel(_environment)
+            var vm = new CredentialsViewModel(_environment, _processManager)
             {
                 ShowBrowserLogin = this.FindControl<CheckBox>("useBrowser").IsChecked ?? false,
                 ShowDeviceLogin = this.FindControl<CheckBox>("useDevice").IsChecked ?? false,
@@ -68,7 +73,7 @@ namespace GitHub.UI.Controls
 
         private void ShowTwoFactorCode(object sender, RoutedEventArgs e)
         {
-            var vm = new TwoFactorViewModel(_environment)
+            var vm = new TwoFactorViewModel(_environment, _processManager)
             {
                 IsSms = this.FindControl<CheckBox>("2faSms").IsChecked ?? false,
             };

--- a/src/shared/GitHub.UI.Avalonia/Program.cs
+++ b/src/shared/GitHub.UI.Avalonia/Program.cs
@@ -45,6 +45,9 @@ namespace GitHub.UI
         {
             string[] args = (string[]) o;
 
+            // Set the session id (sid) for the helper process, to be
+            // used when TRACE2 tracing is enabled.
+            SidManager.CreateSid();
             using (var context = new CommandContext(args))
             using (var app = new HelperApplication(context))
             {

--- a/src/shared/GitHub.UI.Avalonia/Program.cs
+++ b/src/shared/GitHub.UI.Avalonia/Program.cs
@@ -48,9 +48,15 @@ namespace GitHub.UI
             // Set the session id (sid) for the helper process, to be
             // used when TRACE2 tracing is enabled.
             SidManager.CreateSid();
-            using (var context = new CommandContext(args))
+            using (var context = new CommandContext())
             using (var app = new HelperApplication(context))
             {
+                // Initialize TRACE2 system
+                context.Trace2.Initialize(DateTimeOffset.UtcNow);
+
+                // Write the start and version events
+                context.Trace2.Start(context.ApplicationPath, args);
+
                 app.RegisterCommand(new CredentialsCommandImpl(context));
                 app.RegisterCommand(new TwoFactorCommandImpl(context));
                 app.RegisterCommand(new DeviceCodeCommandImpl(context));

--- a/src/shared/GitHub.UI/Commands/CredentialsCommand.cs
+++ b/src/shared/GitHub.UI/Commands/CredentialsCommand.cs
@@ -59,7 +59,7 @@ namespace GitHub.UI.Commands
 
         private async Task<int> ExecuteAsync(CommandOptions options)
         {
-            var viewModel = new CredentialsViewModel(Context.Environment)
+            var viewModel = new CredentialsViewModel(Context.Environment, Context.ProcessManager)
             {
                 ShowBrowserLogin = options.All || options.Browser,
                 ShowDeviceLogin  = options.All || options.Device,

--- a/src/shared/GitHub.UI/Commands/TwoFactorCommand.cs
+++ b/src/shared/GitHub.UI/Commands/TwoFactorCommand.cs
@@ -24,7 +24,7 @@ namespace GitHub.UI.Commands
 
         private async Task<int> ExecuteAsync(bool sms)
         {
-            var viewModel = new TwoFactorViewModel(Context.Environment)
+            var viewModel = new TwoFactorViewModel(Context.Environment, Context.ProcessManager)
             {
                 IsSms = sms
             };

--- a/src/shared/GitHub.UI/ViewModels/CredentialsViewModel.cs
+++ b/src/shared/GitHub.UI/ViewModels/CredentialsViewModel.cs
@@ -9,6 +9,7 @@ namespace GitHub.UI.ViewModels
     public class CredentialsViewModel : WindowViewModel
     {
         private readonly IEnvironment _environment;
+        private readonly IProcessManager _processManager;
 
         private string _enterpriseUrl;
         private string _token;
@@ -29,11 +30,13 @@ namespace GitHub.UI.ViewModels
             // Constructor the XAML designer
         }
 
-        public CredentialsViewModel(IEnvironment environment)
+        public CredentialsViewModel(IEnvironment environment, IProcessManager processManager)
         {
             EnsureArgument.NotNull(environment, nameof(environment));
+            EnsureArgument.NotNull(processManager, nameof(processManager));
 
             _environment = environment;
+            _processManager = processManager;
 
             Title = "Connect to GitHub";
             SignUpCommand = new RelayCommand(SignUp);

--- a/src/shared/GitHub.UI/ViewModels/TwoFactorViewModel.cs
+++ b/src/shared/GitHub.UI/ViewModels/TwoFactorViewModel.cs
@@ -9,6 +9,7 @@ namespace GitHub.UI.ViewModels
     public class TwoFactorViewModel : WindowViewModel
     {
         private readonly IEnvironment _environment;
+        private readonly IProcessManager _processManager;
 
         private string _code;
         private ICommand _learnMoreCommand;
@@ -20,11 +21,13 @@ namespace GitHub.UI.ViewModels
             // Constructor the XAML designer
         }
 
-        public TwoFactorViewModel(IEnvironment environment)
+        public TwoFactorViewModel(IEnvironment environment, IProcessManager processManager)
         {
             EnsureArgument.NotNull(environment, nameof(environment));
+            EnsureArgument.NotNull(processManager, nameof(processManager));
 
             _environment = environment;
+            _processManager = processManager;
 
             Title = "Two-factor authentication required";
             LearnMoreCommand = new RelayCommand(LearnMore);

--- a/src/shared/GitHub/Diagnostics/GitHubApiDiagnostic.cs
+++ b/src/shared/GitHub/Diagnostics/GitHubApiDiagnostic.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.CommandLine;
 using System.Text;
 using System.Threading.Tasks;
+using GitCredentialManager;
 using GitCredentialManager.Diagnostics;
 
 namespace GitHub.Diagnostics
@@ -10,8 +12,8 @@ namespace GitHub.Diagnostics
     {
         private readonly IGitHubRestApi _api;
 
-        public GitHubApiDiagnostic(IGitHubRestApi api)
-            : base("GitHub API")
+        public GitHubApiDiagnostic(IGitHubRestApi api, ICommandContext commandContext)
+            : base("GitHub API", commandContext)
         {
             _api = api;
         }

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -304,7 +304,7 @@ namespace GitHub
 
         public IEnumerable<IDiagnostic> GetDiagnostics()
         {
-            yield return new GitHubApiDiagnostic(_gitHubApi);
+            yield return new GitHubApiDiagnostic(_gitHubApi, Context);
         }
 
         #region Private Methods

--- a/src/shared/GitLab.UI.Avalonia/Controls/TesterWindow.axaml.cs
+++ b/src/shared/GitLab.UI.Avalonia/Controls/TesterWindow.axaml.cs
@@ -24,7 +24,6 @@ namespace GitLab.UI.Controls
 #if DEBUG
             this.AttachDevTools();
 #endif
-
             if (PlatformUtils.IsWindows())
             {
                 _environment = new WindowsEnvironment(new WindowsFileSystem());

--- a/src/shared/GitLab.UI.Avalonia/Program.cs
+++ b/src/shared/GitLab.UI.Avalonia/Program.cs
@@ -48,9 +48,15 @@ namespace GitLab.UI
             // Set the session id (sid) for the helper process, to be
             // used when TRACE2 tracing is enabled.
             SidManager.CreateSid();
-            using (var context = new CommandContext(args))
+            using (var context = new CommandContext())
             using (var app = new HelperApplication(context))
             {
+                // Initialize TRACE2 system
+                context.Trace2.Initialize(DateTimeOffset.UtcNow);
+
+                // Write the start and version events
+                context.Trace2.Start(context.ApplicationPath, args);
+
                 app.RegisterCommand(new CredentialsCommandImpl(context));
 
                 int exitCode = app.RunAsync(args)

--- a/src/shared/GitLab.UI.Avalonia/Program.cs
+++ b/src/shared/GitLab.UI.Avalonia/Program.cs
@@ -44,6 +44,10 @@ namespace GitLab.UI
         private static void AppMain(object o)
         {
             string[] args = (string[]) o;
+
+            // Set the session id (sid) for the helper process, to be
+            // used when TRACE2 tracing is enabled.
+            SidManager.CreateSid();
             using (var context = new CommandContext(args))
             using (var app = new HelperApplication(context))
             {

--- a/src/shared/TestInfrastructure/GitTestUtilities.cs
+++ b/src/shared/TestInfrastructure/GitTestUtilities.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using GitCredentialManager.Tests.Objects;
 using Xunit;
 
 namespace GitCredentialManager.Tests
@@ -26,7 +27,7 @@ namespace GitCredentialManager.Tests
 
             psi.RedirectStandardOutput = true;
 
-            using (var which = new Process {StartInfo = psi})
+            using (var which = new ChildProcess(new NullTrace2(), psi))
             {
                 which.Start();
                 which.WaitForExit();
@@ -79,7 +80,7 @@ namespace GitCredentialManager.Tests
 
             procInfo.Environment["GIT_DIR"] = repositoryPath;
 
-            Process proc = Process.Start(procInfo);
+            var proc = ChildProcess.Start(new NullTrace2(), procInfo);
             if (proc is null)
             {
                 throw new Exception("Failed to start Git process");

--- a/src/shared/TestInfrastructure/GitTestUtilities.cs
+++ b/src/shared/TestInfrastructure/GitTestUtilities.cs
@@ -29,7 +29,7 @@ namespace GitCredentialManager.Tests
 
             using (var which = new ChildProcess(new NullTrace2(), psi))
             {
-                which.Start();
+                which.Start(Trace2ProcessClass.None);
                 which.WaitForExit();
 
                 if (which.ExitCode != 0)
@@ -80,7 +80,7 @@ namespace GitCredentialManager.Tests
 
             procInfo.Environment["GIT_DIR"] = repositoryPath;
 
-            var proc = ChildProcess.Start(new NullTrace2(), procInfo);
+            var proc = ChildProcess.Start(new NullTrace2(), procInfo, Trace2ProcessClass.None);
             if (proc is null)
             {
                 throw new Exception("Failed to start Git process");

--- a/src/shared/TestInfrastructure/Objects/NullTrace.cs
+++ b/src/shared/TestInfrastructure/Objects/NullTrace.cs
@@ -51,15 +51,17 @@ namespace GitCredentialManager.Tests.Objects
     public class NullTrace2 : ITrace2
     {
         #region ITrace2
-        public void AddWriter(ITrace2Writer writer) { }
 
-        public void Start(TextWriter error,
-            IFileSystem fileSystem,
-            string appPath,
+        public void Initialize(DateTimeOffset startTime) { }
+
+        public void Start(string appPath,
+            string[] args,
             string filePath = "",
             int lineNumber = 0) { }
 
-        public void Stop(int exitCode, string fileName, int lineNumber) { }
+        public void Stop(int exitCode,
+            string fileName,
+            int lineNumber) { }
 
         #endregion
 

--- a/src/shared/TestInfrastructure/Objects/NullTrace.cs
+++ b/src/shared/TestInfrastructure/Objects/NullTrace.cs
@@ -63,6 +63,23 @@ namespace GitCredentialManager.Tests.Objects
             string fileName,
             int lineNumber) { }
 
+        public void WriteChildStart(DateTimeOffset startTime,
+            Trace2ProcessClass processClass,
+            bool useShell,
+            string appName,
+            string argv,
+            string filePath = "",
+            int lineNumber = 0) { }
+
+        public void WriteChildExit(
+            double elapsedTime,
+            int pid,
+            int code,
+            string filePath = "",
+            int lineNumber = 0) { }
+
+        public string SetSid() { return ""; }
+
         #endregion
 
         #region IDisposable

--- a/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
+++ b/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
@@ -17,6 +17,7 @@ namespace GitCredentialManager.Tests.Objects
             Terminal = new TestTerminal();
             SessionManager = new TestSessionManager();
             Trace = new NullTrace();
+            Trace2 = new NullTrace2();
             FileSystem = new TestFileSystem();
             CredentialStore = new TestCredentialStore();
             HttpClientFactory = new TestHttpClientFactory();
@@ -39,6 +40,8 @@ namespace GitCredentialManager.Tests.Objects
         public TestHttpClientFactory HttpClientFactory { get; set; }
         public TestGit Git { get; set; }
         public TestEnvironment Environment { get; set; }
+
+        public IProcessManager ProcessManager { get; set; }
 
         #region ICommandContext
 

--- a/src/shared/TestInfrastructure/Objects/TestEnvironment.cs
+++ b/src/shared/TestInfrastructure/Objects/TestEnvironment.cs
@@ -107,7 +107,7 @@ namespace GitCredentialManager.Tests.Objects
             {
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
-                RedirectStandardError = true,
+                RedirectStandardError = true, // Ok to redirect stderr for testing
                 UseShellExecute = useShellExecute,
                 WorkingDirectory = workingDirectory ?? string.Empty
             };
@@ -116,7 +116,7 @@ namespace GitCredentialManager.Tests.Objects
 
             return new Process { StartInfo = psi };
         }
-        
+
         public void SetEnvironmentVariable(string variable, string value,
             EnvironmentVariableTarget target = EnvironmentVariableTarget.Process)
         {

--- a/src/shared/TestInfrastructure/Objects/TestEnvironment.cs
+++ b/src/shared/TestInfrastructure/Objects/TestEnvironment.cs
@@ -32,7 +32,6 @@ namespace GitCredentialManager.Tests.Objects
 
             Variables = new Dictionary<string, string>(_envarComparer);
             Symlinks = new Dictionary<string, string>(_pathComparer);
-            CreatedProcesses = new List<ProcessStartInfo>();
         }
 
         public IDictionary<string, string> Variables { get; set; }
@@ -53,8 +52,6 @@ namespace GitCredentialManager.Tests.Objects
 
             set => Variables["PATH"] = string.Join(_envPathSeparator, value);
         }
-
-        public IList<ProcessStartInfo> CreatedProcesses { get; set; }
 
         #region IEnvironment
 
@@ -99,22 +96,6 @@ namespace GitCredentialManager.Tests.Objects
 
             path = null;
             return false;
-        }
-
-        public Process CreateProcess(string path, string args, bool useShellExecute, string workingDirectory)
-        {
-            var psi = new ProcessStartInfo(path, args)
-            {
-                RedirectStandardInput = true,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true, // Ok to redirect stderr for testing
-                UseShellExecute = useShellExecute,
-                WorkingDirectory = workingDirectory ?? string.Empty
-            };
-
-            CreatedProcesses.Add(psi);
-
-            return new Process { StartInfo = psi };
         }
 
         public void SetEnvironmentVariable(string variable, string value,

--- a/src/shared/TestInfrastructure/Objects/TestGit.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGit.cs
@@ -28,7 +28,7 @@ namespace GitCredentialManager.Tests.Objects
 
         GitVersion IGit.Version => Version;
 
-        public Process CreateProcess(string args)
+        public ChildProcess CreateProcess(string args)
         {
             throw new NotImplementedException();
         }

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/Program.cs
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/Program.cs
@@ -15,9 +15,15 @@ namespace Atlassian.Bitbucket.UI
             // Set the session id (sid) for the helper process, to be
             // used when TRACE2 tracing is enabled.
             SidManager.CreateSid();
-            using (var context = new CommandContext(args))
+            using (var context = new CommandContext())
             using (var app = new HelperApplication(context))
             {
+                // Initialize TRACE2 system
+                context.Trace2.Initialize(DateTimeOffset.UtcNow);
+
+                // Write the start and version events
+                context.Trace2.Start(context.ApplicationPath, args);
+
                 if (args.Length == 0)
                 {
                     await Gui.ShowWindow(() => new TesterWindow(), IntPtr.Zero);

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/Program.cs
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/Program.cs
@@ -12,6 +12,9 @@ namespace Atlassian.Bitbucket.UI
     {
         public static async Task Main(string[] args)
         {
+            // Set the session id (sid) for the helper process, to be
+            // used when TRACE2 tracing is enabled.
+            SidManager.CreateSid();
             using (var context = new CommandContext(args))
             using (var app = new HelperApplication(context))
             {

--- a/src/windows/Git-Credential-Manager.UI.Windows/Program.cs
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Program.cs
@@ -13,9 +13,15 @@ namespace GitCredentialManager.UI
             // Set the session id (sid) for the helper process, to be
             // used when TRACE2 tracing is enabled.
             SidManager.CreateSid();
-            using (var context = new CommandContext(args))
+            using (var context = new CommandContext())
             using (var app = new HelperApplication(context))
             {
+                // Initialize TRACE2 system
+                context.Trace2.Initialize(DateTimeOffset.UtcNow);
+
+                context.Trace2.Start(context.ApplicationPath, args);
+
+                // Write the start and version events
                 if (args.Length == 0)
                 {
                     await Gui.ShowWindow(() => new TesterWindow(), IntPtr.Zero);

--- a/src/windows/Git-Credential-Manager.UI.Windows/Program.cs
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Program.cs
@@ -10,6 +10,9 @@ namespace GitCredentialManager.UI
     {
         public static async Task Main(string[] args)
         {
+            // Set the session id (sid) for the helper process, to be
+            // used when TRACE2 tracing is enabled.
+            SidManager.CreateSid();
             using (var context = new CommandContext(args))
             using (var app = new HelperApplication(context))
             {

--- a/src/windows/GitHub.UI.Windows/Controls/TesterWindow.xaml.cs
+++ b/src/windows/GitHub.UI.Windows/Controls/TesterWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using GitCredentialManager;
 using GitHub.UI.ViewModels;
 using GitHub.UI.Views;
 using GitCredentialManager.Interop.Windows;
@@ -9,15 +10,18 @@ namespace GitHub.UI.Controls
     public partial class TesterWindow : Window
     {
         private readonly WindowsEnvironment _environment = new WindowsEnvironment(new WindowsFileSystem());
+        private readonly IProcessManager _processManager;
 
         public TesterWindow()
         {
+            ICommandContext commandContext = new CommandContext();
+            _processManager = new ProcessManager(new Trace2(commandContext));
             InitializeComponent();
         }
 
         private void ShowCredentials(object sender, RoutedEventArgs e)
         {
-            var vm = new CredentialsViewModel(_environment)
+            var vm = new CredentialsViewModel(_environment, _processManager)
             {
                 ShowBrowserLogin = useBrowser.IsChecked ?? false,
                 ShowDeviceLogin = useDevice.IsChecked ?? false,
@@ -33,7 +37,7 @@ namespace GitHub.UI.Controls
 
         private void ShowTwoFactorCode(object sender, RoutedEventArgs e)
         {
-            var vm = new TwoFactorViewModel(_environment)
+            var vm = new TwoFactorViewModel(_environment, _processManager)
             {
                 IsSms = twoFaSms.IsChecked ?? false,
             };

--- a/src/windows/GitHub.UI.Windows/Program.cs
+++ b/src/windows/GitHub.UI.Windows/Program.cs
@@ -15,9 +15,15 @@ namespace GitHub.UI
             // Set the session id (sid) for the helper process, to be
             // used when TRACE2 tracing is enabled.
             SidManager.CreateSid();
-            using (var context = new CommandContext(args))
+            using (var context = new CommandContext())
             using (var app = new HelperApplication(context))
             {
+                // Initialize TRACE2 system
+                context.Trace2.Initialize(DateTimeOffset.UtcNow);
+
+                // Write the start and version events
+                context.Trace2.Start(context.ApplicationPath, args);
+
                 if (args.Length == 0)
                 {
                     await Gui.ShowWindow(() => new TesterWindow(), IntPtr.Zero);

--- a/src/windows/GitHub.UI.Windows/Program.cs
+++ b/src/windows/GitHub.UI.Windows/Program.cs
@@ -12,6 +12,9 @@ namespace GitHub.UI
     {
         public static async Task Main(string[] args)
         {
+            // Set the session id (sid) for the helper process, to be
+            // used when TRACE2 tracing is enabled.
+            SidManager.CreateSid();
             using (var context = new CommandContext(args))
             using (var app = new HelperApplication(context))
             {

--- a/src/windows/GitLab.UI.Windows/Program.cs
+++ b/src/windows/GitLab.UI.Windows/Program.cs
@@ -12,6 +12,9 @@ namespace GitLab.UI
     {
         public static async Task Main(string[] args)
         {
+            // Set the session id (sid) for the helper process, to be
+            // used when TRACE2 tracing is enabled.
+            SidManager.CreateSid();
             using (var context = new CommandContext(args))
             using (var app = new HelperApplication(context))
             {

--- a/src/windows/GitLab.UI.Windows/Program.cs
+++ b/src/windows/GitLab.UI.Windows/Program.cs
@@ -15,9 +15,15 @@ namespace GitLab.UI
             // Set the session id (sid) for the helper process, to be
             // used when TRACE2 tracing is enabled.
             SidManager.CreateSid();
-            using (var context = new CommandContext(args))
+            using (var context = new CommandContext())
             using (var app = new HelperApplication(context))
             {
+                // Initialize TRACE2 system
+                context.Trace2.Initialize(DateTimeOffset.UtcNow);
+
+                // Write the start and version events
+                context.Trace2.Start(context.ApplicationPath, args);
+
                 if (args.Length == 0)
                 {
                     await Gui.ShowWindow(() => new TesterWindow(), IntPtr.Zero);


### PR DESCRIPTION
This change adds the `child_start` and `child_exit` events to GCM's `TRACE2` tracing system.

The first two patches are small bug fixes. The first fix ensures all events are written in snake case. Up until this point, we've only written single word events, but the `TRACE2` convention for multi-word events is to write in snake case, so for simplicity we update all events to use this convention. The second fix ensures we do _not_ redirect standard error for Git-related processes, as this causes deadlocks with `TRACE2` tracing enabled. 

The third patch contains a refactor of the `Trace2` class necessary to support `child_start` and `child_exit`. 
The main change is addition of an `Initialize()` method to `Trace2.cs` to detect whether `TRACE2` tracing is enabled and to set long-lived variables. This also sets a new `_initialized` property that allows us to determine whether `TRACE2` tracing has been initialized. GCM `TRACE2` tracing is disabled until `_initialized` is set to true by the `Initialize()` method (although it is worth noting that Git's `TRACE2` tracing is not disabled and will be reflected in logs).

The third patch pulls Sid-related logic into a separate `SidManager` class to  improve separation of concerns and make Sid logic less error-prone/easier to reason about.

The fourth patch adds a `ChildProcess` class that wraps `Process` and gives us the required control to write process-related `TRACE2` events. It also decouples process-related logic from environment logic to maintain a functional, non-circular order of dependencies with the new wrapper. All `Process` invocations have been updated to use `ChildProcess`.

The fifth patch adds the appropriate `Trace2` methods to write `child_start` and `child_exit` events.