### PR TITLE
fix about   OAuth2Exception

### DIFF
--- a/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
+++ b/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
@@ -266,7 +266,6 @@ namespace GitCredentialManager.Authentication.OAuth
                 {
                     return result;
                 }
-
                 throw CreateExceptionFromResponse(json);
             }
         }

--- a/src/shared/Core/Core.csproj
+++ b/src/shared/Core/Core.csproj
@@ -1,26 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net6.0;net472</TargetFrameworks>
-    <AssemblyName>gcmcore</AssemblyName>
-    <RootNamespace>GitCredentialManager</RootNamespace>
-    <IsTestProject>false</IsTestProject>
-    <LangVersion>latest</LangVersion>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net6.0</TargetFrameworks>
+		<TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net6.0;net472</TargetFrameworks>
+		<AssemblyName>gcmcore</AssemblyName>
+		<RootNamespace>GitCredentialManager</RootNamespace>
+		<IsTestProject>false</IsTestProject>
+		<LangVersion>latest</LangVersion>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+	</PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Web" />
-    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.37.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.37.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.19.2" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+		<Reference Include="System.Net.Http" />
+		<Reference Include="System.Web" />
+		<PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.37.0" />
+	</ItemGroup>
+	
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.37.0" />
+		<PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.19.2" />
+		<PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Issue [#1444](https://github.com/git-ecosystem/git-credential-manager/issues/1144)   to solve  

1. When OAuth2Exception appears, delete the refresh_token.host
2. Add a text encoding package to avoid garbled characters.