### PR TITLE
Ensure we create a `WindowsProcessManager` on Windows

### DIFF
--- a/src/shared/Core/CommandContext.cs
+++ b/src/shared/Core/CommandContext.cs
@@ -104,7 +104,7 @@ namespace GitCredentialManager
                 FileSystem        = new WindowsFileSystem();
                 SessionManager    = new WindowsSessionManager();
                 Environment       = new WindowsEnvironment(FileSystem);
-                ProcessManager    = new ProcessManager(Trace2);
+                ProcessManager    = new WindowsProcessManager(Trace2);
                 Terminal          = new WindowsTerminal(Trace);
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(
@@ -120,7 +120,7 @@ namespace GitCredentialManager
                 FileSystem        = new MacOSFileSystem();
                 SessionManager    = new MacOSSessionManager();
                 Environment       = new MacOSEnvironment(FileSystem);
-                ProcessManager    = new WindowsProcessManager(Trace2);
+                ProcessManager    = new ProcessManager(Trace2);
                 Terminal          = new MacOSTerminal(Trace);
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(

--- a/src/shared/Core/Interop/Windows/WindowsProcessManager.cs
+++ b/src/shared/Core/Interop/Windows/WindowsProcessManager.cs
@@ -1,14 +1,10 @@
-using System.Diagnostics;
-
 namespace GitCredentialManager.Interop.Windows;
 
 public class WindowsProcessManager : ProcessManager
 {
-    private readonly ITrace2 _trace2;
-
     public WindowsProcessManager(ITrace2 trace2) : base(trace2)
     {
-        _trace2 = trace2;
+        PlatformUtils.EnsureWindows();
     }
 
     public override ChildProcess CreateProcess(string path, string args, bool useShellExecute, string workingDirectory)
@@ -17,7 +13,7 @@ public class WindowsProcessManager : ProcessManager
         if (!useShellExecute && WslUtils.IsWslPath(path))
         {
             string wslPath = WslUtils.ConvertToDistroPath(path, out string distro);
-            return WslUtils.CreateWslProcess(distro, $"{wslPath} {args}", _trace2, workingDirectory);
+            return WslUtils.CreateWslProcess(distro, $"{wslPath} {args}", Trace2, workingDirectory);
         }
 
         return base.CreateProcess(path, args, useShellExecute, workingDirectory);

--- a/src/shared/Core/ProcessManager.cs
+++ b/src/shared/Core/ProcessManager.cs
@@ -27,11 +27,13 @@ public interface IProcessManager
 
 public class ProcessManager : IProcessManager
 {
-    private readonly ITrace2 _trace2;
+    protected readonly ITrace2 Trace2;
 
     public ProcessManager(ITrace2 trace2)
     {
-        _trace2 = trace2;
+        EnsureArgument.NotNull(trace2, nameof(trace2));
+
+        Trace2 = trace2;
     }
 
     public virtual ChildProcess CreateProcess(string path, string args, bool useShellExecute, string workingDirectory)
@@ -51,6 +53,6 @@ public class ProcessManager : IProcessManager
 
     public virtual ChildProcess CreateProcess(ProcessStartInfo psi)
     {
-        return new ChildProcess(_trace2, psi);
+        return new ChildProcess(Trace2, psi);
     }
 }


### PR DESCRIPTION
We are creating a `WindowsProcessManager` implementation on macOS and a non-Windows/WSL aware, plain `ProcessManager` on Windows - this is the reverse of what we should do. Fix this.