### PR TITLE
Better browser/interactive session detection inside of WSL

### DIFF
--- a/src/shared/Core.Tests/IniFileTests.cs
+++ b/src/shared/Core.Tests/IniFileTests.cs
@@ -1,0 +1,135 @@
+using System.Collections.Generic;
+using System.Text;
+using GitCredentialManager.Tests.Objects;
+using Xunit;
+
+namespace GitCredentialManager.Tests
+{
+    public class IniFileTests
+    {
+        [Fact]
+        public void IniSectionName_Equality()
+        {
+            var a1 = new IniSectionName("foo");
+            var b1 = new IniSectionName("foo");
+            Assert.Equal(a1,b1);
+            Assert.Equal(a1.GetHashCode(),b1.GetHashCode());
+
+            var a2 = new IniSectionName("foo");
+            var b2 = new IniSectionName("FOO");
+            Assert.Equal(a2,b2);
+            Assert.Equal(a2.GetHashCode(),b2.GetHashCode());
+
+            var a3 = new IniSectionName("foo", "bar");
+            var b3 = new IniSectionName("foo", "BAR");
+            Assert.NotEqual(a3,b3);
+            Assert.NotEqual(a3.GetHashCode(),b3.GetHashCode());
+
+            var a4 = new IniSectionName("foo", "bar");
+            var b4 = new IniSectionName("FOO", "bar");
+            Assert.Equal(a4,b4);
+            Assert.Equal(a4.GetHashCode(),b4.GetHashCode());
+        }
+
+        [Fact]
+        public void IniSerializer_Deserialize()
+        {
+            const string path = "/tmp/test.ini";
+            string iniText = @"
+[one]
+    foo = 123
+  [two]
+    foo   =   abc
+# comment
+[two ""subsection name""] # comment [section]
+    foo = this is different # comment prop = val
+
+#[notasection]
+
+    [
+[bad #section]
+recovery tests]
+[]
+    ]
+
+    [three]
+    bar = a
+    bar = b
+    # comment
+    bar = c
+    empty =
+[TWO]
+    foo = hello
+    widget = ""Hello, World!""
+[four]
+[five]
+    prop1 = ""this hash # is inside quotes""
+    prop2 = ""this hash # is inside quotes"" # this line has two hashes
+    prop3 = ""   this dquoted string has three spaces around   ""
+    #prop4 = this property has been commented-out
+";
+
+            var fs = new TestFileSystem
+            {
+                Files = { [path] = Encoding.UTF8.GetBytes(iniText) }
+            };
+
+            IniFile ini = IniSerializer.Deserialize(fs, path);
+
+            Assert.Equal(6, ini.Sections.Count);
+
+            AssertSection(ini, "one", out IniSection one);
+            Assert.Equal(1, one.Properties.Count);
+            AssertProperty(one, "foo", "123");
+
+            AssertSection(ini, "two", out IniSection twoA);
+            Assert.Equal(3, twoA.Properties.Count);
+            AssertProperty(twoA, "foo", "hello");
+            AssertProperty(twoA, "widget", "Hello, World!");
+
+            AssertSection(ini, "two", "subsection name", out IniSection twoB);
+            Assert.Equal(1, twoB.Properties.Count);
+            AssertProperty(twoB, "foo", "this is different");
+
+            AssertSection(ini, "three", out IniSection three);
+            Assert.Equal(4, three.Properties.Count);
+            AssertMultiProperty(three, "bar", "a", "b", "c");
+            AssertProperty(three, "empty", "");
+
+            AssertSection(ini, "four", out IniSection four);
+            Assert.Equal(0, four.Properties.Count);
+
+            AssertSection(ini, "five", out IniSection five);
+            Assert.Equal(3, five.Properties.Count);
+            AssertProperty(five, "prop1", "this hash # is inside quotes");
+            AssertProperty(five, "prop2", "this hash # is inside quotes");
+            AssertProperty(five, "prop3", "   this dquoted string has three spaces around   ");
+        }
+
+        private static void AssertSection(IniFile file, string name, out IniSection section)
+        {
+            Assert.True(file.TryGetSection(name, out section));
+            Assert.Equal(name, section.Name.Name);
+            Assert.Null(section.Name.SubName);
+        }
+
+        private static void AssertSection(IniFile file, string name, string subName, out IniSection section)
+        {
+            Assert.True(file.TryGetSection(name, subName, out section));
+            Assert.Equal(name, section.Name.Name);
+            Assert.Equal(subName, section.Name.SubName);
+        }
+
+        private static void AssertProperty(IniSection section, string name, string value)
+        {
+            Assert.True(section.TryGetProperty(name, out var actualValue));
+            Assert.Equal(value, actualValue);
+        }
+
+        private static void AssertMultiProperty(IniSection section, string name, params string[] values)
+        {
+            Assert.True(section.TryGetMultiProperty(name, out IEnumerable<string> actualValues));
+            Assert.Equal(values, actualValues);
+        }
+    }
+}

--- a/src/shared/Core/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Core/Authentication/MicrosoftAuthentication.cs
@@ -508,14 +508,14 @@ namespace GitCredentialManager.Authentication
         private bool CanUseSystemWebView(IPublicClientApplication app, Uri redirectUri)
         {
             // MSAL requires the application redirect URI is a loopback address to use the System WebView
-            return Context.SessionManager.IsDesktopSession && app.IsSystemWebViewAvailable && redirectUri.IsLoopback;
+            return Context.SessionManager.IsWebBrowserAvailable && app.IsSystemWebViewAvailable && redirectUri.IsLoopback;
         }
 
         private void EnsureCanUseSystemWebView(IPublicClientApplication app, Uri redirectUri)
         {
-            if (!Context.SessionManager.IsDesktopSession)
+            if (!Context.SessionManager.IsWebBrowserAvailable)
             {
-                throw new InvalidOperationException("System web view is not available without a desktop session.");
+                throw new InvalidOperationException("System web view is not available without a way to start a browser.");
             }
 
             if (!app.IsSystemWebViewAvailable)

--- a/src/shared/Core/BrowserUtils.cs
+++ b/src/shared/Core/BrowserUtils.cs
@@ -25,7 +25,7 @@ namespace GitCredentialManager
 
             string url = uri.ToString();
 
-            ProcessStartInfo psi = null;
+            ProcessStartInfo psi;
             if (PlatformUtils.IsLinux())
             {
                 //
@@ -41,29 +41,17 @@ namespace GitCredentialManager
                 // We try and use the same 'shell execute' utilities as the Framework does,
                 // searching for them in the same order until we find one.
                 //
-                // One additional 'shell execute' utility we also attempt to use is `wslview`
-                // that is commonly found on WSL (Windows Subsystem for Linux) distributions that
-                // opens the browser on the Windows host.
-                foreach (string shellExec in new[] {"xdg-open", "gnome-open", "kfmclient", "wslview"})
-                {
-                    if (environment.TryLocateExecutable(shellExec, out string shellExecPath))
-                    {
-                        psi = new ProcessStartInfo(shellExecPath, url)
-                        {
-                            RedirectStandardOutput = true,
-                            // Ok to redirect stderr for non-git-related processes
-                            RedirectStandardError = true
-                        };
-
-                        // We found a way to open the URI; stop searching!
-                        break;
-                    }
-                }
-
-                if (psi is null)
+                if (!TryGetLinuxShellExecuteHandler(environment, out string shellExecPath))
                 {
                     throw new Exception("Failed to locate a utility to launch the default web browser.");
                 }
+
+                psi = new ProcessStartInfo(shellExecPath, url)
+                {
+                    RedirectStandardOutput = true,
+                    // Ok to redirect stderr for non-git-related processes
+                    RedirectStandardError = true
+                };
             }
             else
             {
@@ -77,6 +65,24 @@ namespace GitCredentialManager
             // Since we will not be collecting TRACE2 data from the browser, there
             // is no need to add the extra overhead associated with ChildProcess here.
             Process.Start(psi);
+        }
+
+        public static bool TryGetLinuxShellExecuteHandler(IEnvironment env, out string shellExecPath)
+        {
+            // One additional 'shell execute' utility we also attempt to use over the Framework
+            // is `wslview` that is commonly found on WSL (Windows Subsystem for Linux) distributions
+            // that opens the browser on the Windows host.
+            string[] shellHandlers = { "xdg-open", "gnome-open", "kfmclient", WslUtils.WslViewShellHandlerName };
+            foreach (string shellExec in shellHandlers)
+            {
+                if (env.TryLocateExecutable(shellExec, out shellExecPath))
+                {
+                    return true;
+                }
+            }
+
+            shellExecPath = null;
+            return false;
         }
     }
 }

--- a/src/shared/Core/BrowserUtils.cs
+++ b/src/shared/Core/BrowserUtils.cs
@@ -28,6 +28,7 @@ namespace GitCredentialManager
             ProcessStartInfo psi = null;
             if (PlatformUtils.IsLinux())
             {
+                //
                 // On Linux, 'shell execute' utilities like xdg-open launch a process without
                 // detaching from the standard in/out descriptors. Some applications (like
                 // Chromium) write messages to stdout, which is currently hooked up and being

--- a/src/shared/Core/CommandContext.cs
+++ b/src/shared/Core/CommandContext.cs
@@ -102,8 +102,8 @@ namespace GitCredentialManager
             if (PlatformUtils.IsWindows())
             {
                 FileSystem        = new WindowsFileSystem();
-                SessionManager    = new WindowsSessionManager();
                 Environment       = new WindowsEnvironment(FileSystem);
+                SessionManager    = new WindowsSessionManager(Environment, FileSystem);
                 ProcessManager    = new WindowsProcessManager(Trace2);
                 Terminal          = new WindowsTerminal(Trace);
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
@@ -118,7 +118,7 @@ namespace GitCredentialManager
             else if (PlatformUtils.IsMacOS())
             {
                 FileSystem        = new MacOSFileSystem();
-                SessionManager    = new MacOSSessionManager();
+                SessionManager    = new MacOSSessionManager(Environment, FileSystem);
                 Environment       = new MacOSEnvironment(FileSystem);
                 ProcessManager    = new ProcessManager(Trace2);
                 Terminal          = new MacOSTerminal(Trace);
@@ -134,7 +134,7 @@ namespace GitCredentialManager
             else if (PlatformUtils.IsLinux())
             {
                 FileSystem        = new LinuxFileSystem();
-                SessionManager    = new PosixSessionManager();
+                SessionManager    = new LinuxSessionManager(Environment, FileSystem);
                 Environment       = new PosixEnvironment(FileSystem);
                 ProcessManager    = new ProcessManager(Trace2);
                 Terminal          = new LinuxTerminal(Trace);

--- a/src/shared/Core/CommandContext.cs
+++ b/src/shared/Core/CommandContext.cs
@@ -134,7 +134,6 @@ namespace GitCredentialManager
             else if (PlatformUtils.IsLinux())
             {
                 FileSystem        = new LinuxFileSystem();
-                // TODO: support more than just 'Posix' or X11
                 SessionManager    = new PosixSessionManager();
                 Environment       = new PosixEnvironment(FileSystem);
                 ProcessManager    = new ProcessManager(Trace2);

--- a/src/shared/Core/EnvironmentBase.cs
+++ b/src/shared/Core/EnvironmentBase.cs
@@ -191,5 +191,18 @@ namespace GitCredentialManager
 
             throw new Exception($"Failed to locate '{program}' executable on the path.");
         }
+
+        /// <summary>
+        /// Retrieves the value of an environment variable from the current process.
+        /// </summary>
+        /// <param name="environment">The <see cref="IEnvironment"/>.</param>
+        /// <param name="variable">The name of the environment variable.</param>
+        /// <returns>
+        /// The value of the environment variable specified by variable, or null if the environment variable is not found.
+        /// </returns>
+        public static string GetEnvironmentVariable(this IEnvironment environment, string variable)
+        {
+            return environment.Variables.TryGetValue(variable, out string value) ? value : null;
+        }
     }
 }

--- a/src/shared/Core/EnvironmentBase.cs
+++ b/src/shared/Core/EnvironmentBase.cs
@@ -53,18 +53,45 @@ namespace GitCredentialManager
         /// <param name="target">Target level of environment variable to set (Machine, Process, or User).</param>
         void SetEnvironmentVariable(string variable, string value,
             EnvironmentVariableTarget target = EnvironmentVariableTarget.Process);
+
+        /// <summary>
+        /// Refresh the current process environment variables. See <see cref="Variables"/>.
+        /// </summary>
+        /// <remarks>This is automatically called after <see cref="SetEnvironmentVariable"/>.</remarks>
+        void Refresh();
     }
 
     public abstract class EnvironmentBase : IEnvironment
     {
+        private IReadOnlyDictionary<string, string> _variables;
+
         protected EnvironmentBase(IFileSystem fileSystem)
         {
             EnsureArgument.NotNull(fileSystem, nameof(fileSystem));
-
             FileSystem = fileSystem;
         }
 
-        public IReadOnlyDictionary<string, string> Variables { get; protected set; }
+        internal EnvironmentBase(IFileSystem fileSystem, IReadOnlyDictionary<string, string> variables)
+            : this(fileSystem)
+        {
+            EnsureArgument.NotNull(variables, nameof(variables));
+            _variables = variables;
+        }
+
+        public IReadOnlyDictionary<string, string> Variables
+        {
+            get
+            {
+                // Variables are lazily loaded
+                if (_variables is null)
+                {
+                    Refresh();
+                }
+
+                Debug.Assert(_variables != null);
+                return _variables;
+            }
+        }
 
         protected IFileSystem FileSystem { get; }
 
@@ -126,9 +153,22 @@ namespace GitCredentialManager
         public void SetEnvironmentVariable(string variable, string value,
             EnvironmentVariableTarget target = EnvironmentVariableTarget.Process)
         {
-            if (Variables.Keys.Contains(variable)) return;
+            // Don't bother setting the variable if it already has the same value
+            if (Variables.TryGetValue(variable, out var currentValue) &&
+                StringComparer.Ordinal.Equals(currentValue, value))
+            {
+                return;
+            }
+
             Environment.SetEnvironmentVariable(variable, value, target);
-            Variables = GetCurrentVariables();
+
+            // Immediately refresh the variables so that the new value is available to callers using IEnvironment
+            Refresh();
+        }
+
+        public void Refresh()
+        {
+            _variables = GetCurrentVariables();
         }
 
         protected abstract IReadOnlyDictionary<string, string> GetCurrentVariables();

--- a/src/shared/Core/FileSystem.cs
+++ b/src/shared/Core/FileSystem.cs
@@ -84,6 +84,29 @@ namespace GitCredentialManager
         /// </returns>
         IEnumerable<string> EnumerateFiles(string path, string searchPattern);
 
+        /// <summary>
+        /// Returns an enumerable collection of directory full names in a specified path.
+        /// </summary>
+        /// <param name="path">The relative or absolute path to the directory to search. This string is not case-sensitive.</param>
+        /// <returns>
+        /// An enumerable collection of the full names (including paths) for the directories
+        /// in the directory specified by path.
+        /// </returns>
+        IEnumerable<string> EnumerateDirectories(string path);
+
+        /// <summary>
+        /// Opens a text file, reads all the text in the file, and then closes the file
+        /// </summary>
+        /// <param name="path">The file to open for reading.</param>
+        /// <returns>A string containing all the text in the file.</returns>
+        string ReadAllText(string path);
+
+        /// <summary>
+        /// Opens a text file, reads all lines of the file, and then closes the file.
+        /// </summary>
+        /// <param name="path">The file to open for reading.</param>
+        /// <returns>A string array containing all lines of the file.</returns>
+        string[] ReadAllLines(string path);
     }
 
     /// <summary>
@@ -111,5 +134,11 @@ namespace GitCredentialManager
         public void DeleteFile(string path) => File.Delete(path);
 
         public IEnumerable<string> EnumerateFiles(string path, string searchPattern) => Directory.EnumerateFiles(path, searchPattern);
+
+        public IEnumerable<string> EnumerateDirectories(string path) => Directory.EnumerateDirectories(path);
+
+        public string ReadAllText(string path) => File.ReadAllText(path);
+
+        public string[] ReadAllLines(string path) => File.ReadAllLines(path);
     }
 }

--- a/src/shared/Core/ISessionManager.cs
+++ b/src/shared/Core/ISessionManager.cs
@@ -17,6 +17,15 @@ namespace GitCredentialManager
     
     public abstract class SessionManager : ISessionManager
     {
+        protected IEnvironment Environment { get; }
+        protected IFileSystem FileSystem { get; }
+
+        protected SessionManager(IEnvironment env, IFileSystem fs)
+        {
+            Environment = env;
+            FileSystem = fs;
+        }
+        
         public abstract bool IsDesktopSession { get; }
 
         public virtual bool IsWebBrowserAvailable => IsDesktopSession;

--- a/src/shared/Core/ISessionManager.cs
+++ b/src/shared/Core/ISessionManager.cs
@@ -7,5 +7,18 @@ namespace GitCredentialManager
         /// </summary>
         /// <returns>True if the session can display UI, false otherwise.</returns>
         bool IsDesktopSession { get; }
+
+        /// <summary>
+        /// Determine if the current session has access to a web browser.
+        /// </summary>
+        /// <returns>True if the session can display a web browser, false otherwise.</returns>
+        bool IsWebBrowserAvailable { get; }
+    }
+    
+    public abstract class SessionManager : ISessionManager
+    {
+        public abstract bool IsDesktopSession { get; }
+
+        public virtual bool IsWebBrowserAvailable => IsDesktopSession;
     }
 }

--- a/src/shared/Core/IniFile.cs
+++ b/src/shared/Core/IniFile.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace GitCredentialManager
+{
+    public class IniFile
+    {
+        public IniFile()
+        {
+            Sections = new Dictionary<IniSectionName, IniSection>();
+        }
+
+        public IDictionary<IniSectionName, IniSection> Sections { get; }
+
+        public bool TryGetSection(string name, string subName, out IniSection section)
+        {
+            return Sections.TryGetValue(new IniSectionName(name, subName), out section);
+        }
+
+        public bool TryGetSection(string name, out IniSection section)
+        {
+            return Sections.TryGetValue(new IniSectionName(name), out section);
+        }
+    }
+
+    [DebuggerDisplay("{DebuggerDisplay}")]
+    public readonly struct IniSectionName : IEquatable<IniSectionName>
+    {
+        public IniSectionName(string name, string subName = null)
+        {
+            Name = name;
+            SubName = string.IsNullOrEmpty(subName) ? null : subName;
+        }
+
+        public string Name { get; }
+
+        public string SubName { get; }
+
+        public bool Equals(IniSectionName other)
+        {
+            // Main section name is case-insensitive, but subsection name IS case-sensitive!
+            return StringComparer.OrdinalIgnoreCase.Equals(Name, other.Name) &&
+                   StringComparer.Ordinal.Equals(SubName, other.SubName);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is IniSectionName other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((Name != null ? Name.ToLowerInvariant().GetHashCode() : 0) * 397) ^
+                       (SubName != null ? SubName.GetHashCode() : 0);
+            }
+        }
+
+        private string DebuggerDisplay => SubName is null ? Name : $"{Name} \"{SubName}\"";
+    }
+
+    [DebuggerDisplay("{DebuggerDisplay}")]
+    public class IniSection
+    {
+        public IniSection(IniSectionName name)
+        {
+            Name = name;
+            Properties = new List<IniProperty>();
+        }
+
+        public IniSectionName Name { get; }
+
+        public IList<IniProperty> Properties { get; }
+
+        public bool TryGetProperty(string name, out string value)
+        {
+            if (TryGetMultiProperty(name, out IEnumerable<string> values))
+            {
+                value = values.Last();
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        public bool TryGetMultiProperty(string name, out IEnumerable<string> values)
+        {
+            IniProperty[] props = Properties
+                .Where(x => StringComparer.OrdinalIgnoreCase.Equals(x.Name, name))
+                .ToArray();
+
+            if (props.Length == 0)
+            {
+                values = Array.Empty<string>();
+                return false;
+            }
+
+            values = props.Select(x => x.Value);
+            return true;
+        }
+
+        private string DebuggerDisplay => Name.SubName is null
+            ? $"{Name.Name} [Properties: {Properties.Count}]"
+            : $"{Name.Name} \"{Name.SubName}\" [Properties: {Properties.Count}]";
+    }
+
+    [DebuggerDisplay("{DebuggerDisplay}")]
+    public class IniProperty
+    {
+        public IniProperty(string name, string value)
+        {
+            Name = name;
+            Value = value;
+        }
+
+        public string Name { get; }
+        public string Value { get; }
+
+        private string DebuggerDisplay => $"{Name}={Value}";
+    }
+
+    public static class IniSerializer
+    {
+        private static readonly Regex SectionRegex =
+            new Regex(@"^\[[^\S#]*(?'name'[^\s#\]]*?)(?:\s+""(?'sub'.+)"")?\s*\]", RegexOptions.Compiled);
+
+        private static readonly Regex PropertyRegex =
+            new Regex(@"^[^\S#]*?(?'name'[^\s#]+)\s*=(?'value'.*)?$", RegexOptions.Compiled);
+
+        public static IniFile Deserialize(IFileSystem fs, string path)
+        {
+            IEnumerable<string> lines = fs.ReadAllLines(path).Select(x => x.Trim());
+
+            var iniFile = new IniFile();
+            IniSection section = null;
+
+            foreach (string line in lines)
+            {
+                Match match = SectionRegex.Match(line);
+                if (match.Success)
+                {
+                    string mainName = match.Groups["name"].Value;
+                    string subName = match.Groups["sub"].Value;
+
+                    // Skip empty-named sections
+                    if (string.IsNullOrWhiteSpace(mainName))
+                    {
+                        continue;
+                    }
+
+                    if (!iniFile.TryGetSection(mainName, subName, out section))
+                    {
+                        var sectionName = new IniSectionName(mainName, subName);
+                        section = new IniSection(sectionName);
+                        iniFile.Sections[sectionName] = section;
+                    }
+
+                    continue;
+                }
+
+                match = PropertyRegex.Match(line);
+                if (match.Success)
+                {
+                    if (section is null)
+                    {
+                        throw new Exception("Missing section header");
+                    }
+
+                    string propName = match.Groups["name"].Value;
+                    string propValue = match.Groups["value"].Value.Trim();
+
+                    // Trim trailing comments
+                    int firstDQuote = propValue.IndexOf('"');
+                    int lastDQuote = propValue.LastIndexOf('"');
+                    int commentIdx = propValue.LastIndexOf('#');
+                    if (commentIdx > -1)
+                    {
+                        bool insideDQuotes = firstDQuote > -1 && lastDQuote > -1 &&
+                                             (firstDQuote < commentIdx && commentIdx < lastDQuote);
+
+                        if (!insideDQuotes)
+                        {
+                            propValue = propValue.Substring(0, commentIdx).Trim();
+                        }
+                    }
+
+                    // Trim book-ending double quotes: "foo" => foo
+                    if (propValue.Length > 1 && propValue[0] == '"' &&
+                        propValue[propValue.Length - 1] == '"')
+                    {
+                        propValue = propValue.Substring(1, propValue.Length - 2);
+                    }
+
+                    var property = new IniProperty(propName, propValue);
+                    section.Properties.Add(property);
+                }
+            }
+
+            return iniFile;
+        }
+    }
+}

--- a/src/shared/Core/Interop/Linux/LinuxSessionManager.cs
+++ b/src/shared/Core/Interop/Linux/LinuxSessionManager.cs
@@ -1,0 +1,64 @@
+using GitCredentialManager.Interop.Posix;
+
+namespace GitCredentialManager.Interop.Linux;
+
+public class LinuxSessionManager : PosixSessionManager
+{
+    private bool? _isWebBrowserAvailable;
+
+    public LinuxSessionManager(IEnvironment env, IFileSystem fs) : base(env, fs)
+    {
+        PlatformUtils.EnsureLinux();
+    }
+    
+    public override bool IsWebBrowserAvailable
+    {
+        get
+        {
+            return _isWebBrowserAvailable ??= GetWebBrowserAvailable();
+        }
+    }
+    
+    private bool GetWebBrowserAvailable()
+    {
+        // If this is a Windows Subsystem for Linux distribution we may
+        // be able to launch the web browser of the host Windows OS.
+        if (WslUtils.IsWslDistribution(Environment, FileSystem, out _))
+        {
+            // We need a shell execute handler to be able to launch to browser
+            if (!BrowserUtils.TryGetLinuxShellExecuteHandler(Environment, out _))
+            {
+                return false;
+            }
+
+            //
+            // If we are in Windows logon session 0 then the user can never interact,
+            // even in the WinSta0 window station. This is typical when SSH-ing into a
+            // Windows 10+ machine using the default OpenSSH Server configuration,
+            // which runs in the 'services' session 0.
+            //
+            // If we're in any other session, and in the WinSta0 window station then
+            // the user can possibly interact. However, since it's hard to determine
+            // the window station from PowerShell cmdlets (we'd need to write P/Invoke
+            // code and that's just messy and too many levels of indirection quite
+            // frankly!) we just assume any non session 0 is interactive.
+            //
+            // This assumption doesn't hold true if the user has changed the user that
+            // the OpenSSH Server service runs as (not a built-in NT service) *AND*
+            // they've SSH-ed into the Windows host (and then started a WSL shell).
+            // This feels like a very small subset of users...
+            //
+            if (WslUtils.GetWindowsSessionId(FileSystem) == 0)
+            {
+                return false;
+            }
+
+            // If we are not in session 0, or we cannot get the Windows session ID,
+            // assume that we *CAN* launch the browser so that users are never blocked.
+            return true;
+        }
+
+        // We require an interactive desktop session to be able to launch a browser
+        return IsDesktopSession;
+    }
+}

--- a/src/shared/Core/Interop/MacOS/MacOSEnvironment.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSEnvironment.cs
@@ -15,11 +15,7 @@ namespace GitCredentialManager.Interop.MacOS
             : base(fileSystem) { }
 
         internal MacOSEnvironment(IFileSystem fileSystem, IReadOnlyDictionary<string, string> variables)
-            : base(fileSystem)
-        {
-            EnsureArgument.NotNull(variables, nameof(variables));
-            Variables = variables;
-        }
+            : base(fileSystem, variables) { }
 
         public override bool TryLocateExecutable(string program, out string path)
         {

--- a/src/shared/Core/Interop/MacOS/MacOSSessionManager.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSSessionManager.cs
@@ -5,7 +5,7 @@ namespace GitCredentialManager.Interop.MacOS
 {
     public class MacOSSessionManager : PosixSessionManager
     {
-        public MacOSSessionManager()
+        public MacOSSessionManager(IEnvironment env, IFileSystem fs) : base(env, fs)
         {
             PlatformUtils.EnsureMacOS();
         }

--- a/src/shared/Core/Interop/Posix/PosixEnvironment.cs
+++ b/src/shared/Core/Interop/Posix/PosixEnvironment.cs
@@ -7,13 +7,10 @@ namespace GitCredentialManager.Interop.Posix
     public class PosixEnvironment : EnvironmentBase
     {
         public PosixEnvironment(IFileSystem fileSystem)
-            : this(fileSystem, null) { }
+            : base(fileSystem) { }
 
         internal PosixEnvironment(IFileSystem fileSystem, IReadOnlyDictionary<string, string> variables)
-            : base(fileSystem)
-        {
-            Variables = variables ?? GetCurrentVariables();
-        }
+            : base(fileSystem, variables) { }
 
         #region EnvironmentBase
 

--- a/src/shared/Core/Interop/Posix/PosixSessionManager.cs
+++ b/src/shared/Core/Interop/Posix/PosixSessionManager.cs
@@ -9,7 +9,9 @@ namespace GitCredentialManager.Interop.Posix
             PlatformUtils.EnsurePosix();
         }
 
-        // Check if we have an X11 environment available
-        public virtual bool IsDesktopSession => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DISPLAY"));
+        // Check if we have an X11 or Wayland display environment available
+        public virtual bool IsDesktopSession =>
+            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DISPLAY")) ||
+            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("WAYLAND_DISPLAY"));
     }
 }

--- a/src/shared/Core/Interop/Posix/PosixSessionManager.cs
+++ b/src/shared/Core/Interop/Posix/PosixSessionManager.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace GitCredentialManager.Interop.Posix
 {
-    public class PosixSessionManager : ISessionManager
+    public class PosixSessionManager : SessionManager
     {
         public PosixSessionManager()
         {
@@ -10,7 +10,7 @@ namespace GitCredentialManager.Interop.Posix
         }
 
         // Check if we have an X11 or Wayland display environment available
-        public virtual bool IsDesktopSession =>
+        public override bool IsDesktopSession =>
             !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DISPLAY")) ||
             !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("WAYLAND_DISPLAY"));
     }

--- a/src/shared/Core/Interop/Posix/PosixSessionManager.cs
+++ b/src/shared/Core/Interop/Posix/PosixSessionManager.cs
@@ -1,17 +1,15 @@
-using System;
-
 namespace GitCredentialManager.Interop.Posix
 {
-    public class PosixSessionManager : SessionManager
+    public abstract class PosixSessionManager : SessionManager
     {
-        public PosixSessionManager()
+        protected PosixSessionManager(IEnvironment env, IFileSystem fs) : base(env, fs)
         {
             PlatformUtils.EnsurePosix();
         }
 
         // Check if we have an X11 or Wayland display environment available
         public override bool IsDesktopSession =>
-            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DISPLAY")) ||
-            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("WAYLAND_DISPLAY"));
+            !string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("DISPLAY")) ||
+            !string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("WAYLAND_DISPLAY"));
     }
 }

--- a/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
+++ b/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
@@ -10,13 +10,10 @@ namespace GitCredentialManager.Interop.Windows
     public class WindowsEnvironment : EnvironmentBase
     {
         public WindowsEnvironment(IFileSystem fileSystem)
-            : this(fileSystem, null) { }
+            : base(fileSystem) { }
 
         internal WindowsEnvironment(IFileSystem fileSystem, IReadOnlyDictionary<string, string> variables)
-            : base(fileSystem)
-        {
-            Variables = variables ?? GetCurrentVariables();
-        }
+            : base(fileSystem, variables) { }
 
         #region EnvironmentBase
 
@@ -48,7 +45,7 @@ namespace GitCredentialManager.Interop.Windows
             Environment.SetEnvironmentVariable("PATH", newValue, target);
 
             // Update the cached PATH variable to the latest value (as well as all other variables)
-            Variables = GetCurrentVariables();
+            Refresh();
         }
 
         public override void RemoveDirectoryFromPath(string directoryPath, EnvironmentVariableTarget target)
@@ -66,7 +63,7 @@ namespace GitCredentialManager.Interop.Windows
                 Environment.SetEnvironmentVariable("PATH", newValue, target);
 
                 // Update the cached PATH variable to the latest value (as well as all other variables)
-                Variables = GetCurrentVariables();
+                Refresh();
             }
         }
 

--- a/src/shared/Core/Interop/Windows/WindowsSessionManager.cs
+++ b/src/shared/Core/Interop/Windows/WindowsSessionManager.cs
@@ -5,7 +5,7 @@ namespace GitCredentialManager.Interop.Windows
 {
     public class WindowsSessionManager : SessionManager
     {
-        public WindowsSessionManager()
+        public WindowsSessionManager(IEnvironment env, IFileSystem fs) : base(env, fs)
         {
             PlatformUtils.EnsureWindows();
         }

--- a/src/shared/Core/Interop/Windows/WindowsSessionManager.cs
+++ b/src/shared/Core/Interop/Windows/WindowsSessionManager.cs
@@ -3,14 +3,14 @@ using GitCredentialManager.Interop.Windows.Native;
 
 namespace GitCredentialManager.Interop.Windows
 {
-    public class WindowsSessionManager : ISessionManager
+    public class WindowsSessionManager : SessionManager
     {
         public WindowsSessionManager()
         {
             PlatformUtils.EnsureWindows();
         }
 
-        public unsafe bool IsDesktopSession
+        public override unsafe bool IsDesktopSession
         {
             get
             {

--- a/src/shared/Core/ProcessManager.cs
+++ b/src/shared/Core/ProcessManager.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Threading.Tasks;
 
 namespace GitCredentialManager;
 

--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -64,8 +64,8 @@ namespace GitHub
 
         public async Task<AuthenticationPromptResult> GetAuthenticationAsync(Uri targetUri, string userName, AuthenticationModes modes)
         {
-            // If we don't have a desktop session/GUI then we cannot offer browser
-            if (!Context.SessionManager.IsDesktopSession)
+            // If we cannot start a browser then don't offer the option
+            if (!Context.SessionManager.IsWebBrowserAvailable)
             {
                 modes = modes & ~AuthenticationModes.Browser;
             }
@@ -257,8 +257,8 @@ namespace GitHub
 
             var oauthClient = new GitHubOAuth2Client(HttpClient, Context.Settings, targetUri);
 
-            // We require a desktop session to launch the user's default web browser
-            if (!Context.SessionManager.IsDesktopSession)
+            // Can we launch the user's default web browser?
+            if (!Context.SessionManager.IsWebBrowserAvailable)
             {
                 throw new InvalidOperationException("Browser authentication requires a desktop session");
             }

--- a/src/shared/GitLab/GitLabAuthentication.cs
+++ b/src/shared/GitLab/GitLabAuthentication.cs
@@ -55,8 +55,8 @@ namespace GitLab
 
         public async Task<AuthenticationPromptResult> GetAuthenticationAsync(Uri targetUri, string userName, AuthenticationModes modes)
         {
-            // If we don't have a desktop session/GUI then we cannot offer browser
-            if (!Context.SessionManager.IsDesktopSession)
+            // If we cannot start a browser then don't offer the option
+            if (!Context.SessionManager.IsWebBrowserAvailable)
             {
                 modes = modes & ~AuthenticationModes.Browser;
             }

--- a/src/shared/TestInfrastructure/Objects/TestEnvironment.cs
+++ b/src/shared/TestInfrastructure/Objects/TestEnvironment.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 
 namespace GitCredentialManager.Tests.Objects
@@ -104,6 +103,11 @@ namespace GitCredentialManager.Tests.Objects
             if (Variables.Keys.Contains(variable)) return;
             Environment.SetEnvironmentVariable(variable, value, target);
             Variables.Add(variable, value);
+        }
+
+        public void Refresh()
+        {
+            // Nothing to do!
         }
 
         #endregion

--- a/src/shared/TestInfrastructure/Objects/TestFileSystem.cs
+++ b/src/shared/TestInfrastructure/Objects/TestFileSystem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace GitCredentialManager.Tests.Objects
@@ -90,6 +91,41 @@ namespace GitCredentialManager.Tests.Objects
                     yield return filePath;
                 }
             }
+        }
+
+        IEnumerable<string> IFileSystem.EnumerateDirectories(string path)
+        {
+            StringComparison comparer = IsCaseSensitive
+                ? StringComparison.Ordinal
+                : StringComparison.OrdinalIgnoreCase;
+
+            foreach (var dirPath in Directories)
+            {
+                if (dirPath.StartsWith(path, comparer))
+                {
+                    yield return dirPath;
+                }
+            }
+        }
+
+        string IFileSystem.ReadAllText(string path)
+        {
+            if (Files.TryGetValue(path, out byte[] data))
+            {
+                return Encoding.UTF8.GetString(data);
+            }
+
+            throw new IOException("File not found");
+        }
+
+        string[] IFileSystem.ReadAllLines(string path)
+        {
+            if (Files.TryGetValue(path, out byte[] data))
+            {
+                return Encoding.UTF8.GetString(data).Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+            }
+
+            throw new IOException("File not found");
         }
 
         #endregion

--- a/src/shared/TestInfrastructure/Objects/TestSessionManager.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSessionManager.cs
@@ -3,6 +3,10 @@ namespace GitCredentialManager.Tests.Objects
 {
     public class TestSessionManager : ISessionManager
     {
+        public bool? IsWebBrowserAvailableOverride { get; set; }
+
         public bool IsDesktopSession { get; set; }
+
+        bool ISessionManager.IsWebBrowserAvailable => IsWebBrowserAvailableOverride ?? IsDesktopSession;
     }
 }


### PR DESCRIPTION
Today we're gating browser-based authentication mechanisms behind a GUI-possible session, which isn't 100% correct. When inside of a WSL session, without WSLg enabled, it is still possible to launch a web browser in the hosting Windows session.

Split the determination between "GUI session" and "browser possible", and add the special case for WSL inside an interactive Windows session.

Things are complicated here because it is possible to SSH in to the WSL instance from outside of the Windows host, meaning the Windows session also doesn't have UI. This case we still need to prevent browser-based options.

In order to detect these cases we need to 'punch out' to the Windows host and run a script/cmdlet to determine the session type.

Fixes #878