### PR TITLE
settings: support scoped enterprise settings

### DIFF
--- a/src/shared/Core.Tests/SettingsTests.cs
+++ b/src/shared/Core.Tests/SettingsTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using GitCredentialManager.Tests.Objects;

--- a/src/shared/Core/Interop/Windows/WindowsSettings.cs
+++ b/src/shared/Core/Interop/Windows/WindowsSettings.cs
@@ -17,7 +17,7 @@ namespace GitCredentialManager.Interop.Windows
             PlatformUtils.EnsureWindows();
         }
 
-        protected override bool TryGetExternalDefault(string section, string property, out string value)
+        protected override bool TryGetExternalDefault(string section, string scope, string property, out string value)
         {
             value = null;
 
@@ -32,7 +32,10 @@ namespace GitCredentialManager.Interop.Windows
                     return false;
                 }
 
-                string name = $"{section}.{property}";
+                string name = string.IsNullOrWhiteSpace(scope)
+                    ? $"{section}.{property}"
+                    : $"{section}.{scope}.{property}";
+
                 object registryValue = configKey.GetValue(name);
                 if (registryValue is null)
                 {
@@ -46,7 +49,7 @@ namespace GitCredentialManager.Interop.Windows
                 return true;
             }
 #else
-            return base.TryGetExternalDefault(section, property, out value);
+            return base.TryGetExternalDefault(section, scope, property, out value);
 #endif
         }
     }

--- a/src/shared/Core/Settings.cs
+++ b/src/shared/Core/Settings.cs
@@ -408,6 +408,12 @@ namespace GitCredentialManager
                         {
                             yield return value;
                         }
+
+                        // Check for an externally specified default value
+                        if (TryGetExternalDefault(section, scope, property, out value))
+                        {
+                            yield return value;
+                        }
                     }
                 }
 
@@ -423,10 +429,10 @@ namespace GitCredentialManager
                     yield return value;
                 }
 
-                // Check for an externally specified default value
-                if (TryGetExternalDefault(section, property, out string defaultValue))
+                // Check for an externally specified default value without a scope
+                if (TryGetExternalDefault(section, null, property, out value))
                 {
-                    yield return defaultValue;
+                    yield return value;
                 }
             }
         }
@@ -436,10 +442,11 @@ namespace GitCredentialManager
         /// This may come from external policies or the Operating System.
         /// </summary>
         /// <param name="section">Configuration section name.</param>
+        /// <param name="scope">Optional configuration scope.</param>
         /// <param name="property">Configuration property name.</param>
         /// <param name="value">Value of the configuration setting, or null.</param>
         /// <returns>True if a default setting has been set, false otherwise.</returns>
-        protected virtual bool TryGetExternalDefault(string section, string property, out string value)
+        protected virtual bool TryGetExternalDefault(string section, string scope, string property, out string value)
         {
             value = null;
             return false;


### PR DESCRIPTION
Add support for remote URL-scoped enterprise default settings.

Fixes #983