### PR TITLE
http: add support for client certificates

### DIFF
--- a/src/shared/Core/Constants.cs
+++ b/src/shared/Core/Constants.cs
@@ -158,6 +158,7 @@ namespace GitCredentialManager
                 public const string SslBackend = "sslBackend";
                 public const string SslVerify = "sslVerify";
                 public const string SslCaInfo = "sslCAInfo";
+                public const string SslAutoClientCert = "sslAutoClientCert";
             }
 
             public static class Remote

--- a/src/shared/Core/HttpClientFactory.cs
+++ b/src/shared/Core/HttpClientFactory.cs
@@ -76,6 +76,20 @@ namespace GitCredentialManager
                 handler = new HttpClientHandler();
             }
 
+            // Trace Git's chosen SSL/TLS backend
+            _trace.WriteLine($"Git's SSL/TLS backend is: {_settings.TlsBackend}");
+
+            // Mirror Git for Windows and only send client TLS certificates automatically if we're using
+            // the schannel backend _and_ the user has opted in to sending them.
+            if (_settings.TlsBackend == TlsBackend.Schannel &&
+                _settings.AutomaticallyUseClientCertificates)
+            {
+                _trace.WriteLine("Configured to automatically send TLS client certificates.");
+                handler.ClientCertificateOptions = ClientCertificateOption.Automatic;
+            }
+
+            // Configure server certificate verification and warn if we're bypassing validation
+
             // IsCertificateVerificationEnabled takes precedence over custom TLS cert verification
             if (!_settings.IsCertificateVerificationEnabled)
             {

--- a/src/shared/Core/Settings.cs
+++ b/src/shared/Core/Settings.cs
@@ -120,6 +120,11 @@ namespace GitCredentialManager
         bool IsCertificateVerificationEnabled { get; }
 
         /// <summary>
+        /// Automatically send client TLS certificates.
+        /// </summary>
+        bool AutomaticallyUseClientCertificates { get; }
+
+        /// <summary>
         /// Get the proxy setting if configured, or null otherwise.
         /// </summary>
         /// <returns>Proxy setting, or null if not configured.</returns>
@@ -562,6 +567,9 @@ namespace GitCredentialManager
                 return true;
             }
         }
+
+        public bool AutomaticallyUseClientCertificates =>
+            TryGetSetting(null, KnownGitCfg.Credential.SectionName, KnownGitCfg.Http.SslAutoClientCert, out string value) && value.ToBooleanyOrDefault(false);
 
         public string CustomCertificateBundlePath =>
             TryGetPathSetting(KnownEnvars.GitSslCaInfo, KnownGitCfg.Http.SectionName, KnownGitCfg.Http.SslCaInfo, out string value) ? value : null;

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -31,6 +31,8 @@ namespace GitCredentialManager.Tests.Objects
 
         public bool IsCertificateVerificationEnabled { get; set; } = true;
 
+        public bool AutomaticallyUseClientCertificates { get; set; }
+
         public ProxyConfiguration ProxyConfiguration { get; set; }
 
         public string ParentWindowId { get; set; }


### PR DESCRIPTION
Add support for automatically sending client TLS certificates using the Git configuration setting 'http.sslAutoClientCert'.

This setting is currently only [present in Git for Windows](https://github.com/git-for-windows/git/blob/c8edb521bdabec14b07e9142e48cab77a40ba339/http.c#L906-L910), and there is only respected when the SSL backend is "schannel".

Fixes #369