### PR TITLE
Assume GitHub Enterprise instances with a null version number support OAuth

### DIFF
--- a/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
+++ b/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
@@ -117,12 +117,14 @@ namespace GitHub.Tests
             Assert.Equal(expectedModes, actualModes);
         }
 
-
         [Theory]
         [InlineData("https://example.com", null, "0.1", false, AuthenticationModes.Pat)]
         [InlineData("https://example.com", null, "0.1", true, AuthenticationModes.Basic | AuthenticationModes.Pat)]
         [InlineData("https://example.com", null, "100.0", false, AuthenticationModes.OAuth | AuthenticationModes.Pat)]
         [InlineData("https://example.com", null, "100.0", true, AuthenticationModes.All)]
+        [InlineData("https://example.com", null, null, false, AuthenticationModes.OAuth | AuthenticationModes.Pat)]
+        [InlineData("https://example.com", null, "", false, AuthenticationModes.OAuth | AuthenticationModes.Pat)]
+        [InlineData("https://example.com", null, " ", false, AuthenticationModes.OAuth | AuthenticationModes.Pat)]
         public async Task GitHubHostProvider_GetSupportedAuthenticationModes_WithMetadata(string uriString, string gitHubAuthModes,
             string installedVersion, bool verifiablePasswordAuthentication, AuthenticationModes expectedModes)
         {
@@ -148,8 +150,6 @@ namespace GitHub.Tests
 
             Assert.Equal(expectedModes, actualModes);
         }
-
-
 
         [Fact]
         public async Task GitHubHostProvider_GenerateCredentialAsync_UnencryptedHttp_ThrowsException()

--- a/src/shared/GitHub/GitHubConstants.cs
+++ b/src/shared/GitHub/GitHubConstants.cs
@@ -31,11 +31,6 @@ namespace GitHub
         public static readonly Version MinimumOnPremOAuthVersion = new Version("3.2");
 
         /// <summary>
-        /// The version string returned from the meta API endpoint for GitHub AE instances.
-        /// </summary>
-        public const string GitHubAeVersionString = "GitHub AE";
-
-        /// <summary>
         /// Supported authentication modes for GitHub.com.
         /// </summary>
         /// <remarks>

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -263,20 +263,20 @@ namespace GitHub
             {
                 GitHubMetaInfo metaInfo = await _gitHubApi.GetMetaInfoAsync(targetUri);
 
+                // All Enterprise/AE instances support PATs
                 var modes = AuthenticationModes.Pat;
+
+                // If the server says it supports basic auth, we can use that too!
                 if (metaInfo.VerifiablePasswordAuthentication)
                 {
                     modes |= AuthenticationModes.Basic;
                 }
 
-                if (StringComparer.OrdinalIgnoreCase.Equals(metaInfo.InstalledVersion, GitHubConstants.GitHubAeVersionString))
+                // If the version is unknown, we *assume* it supports OAuth.
+                // If the server version at least the minimum required, we *know* we can use OAuth.
+                if (!Version.TryParse(metaInfo.InstalledVersion, out var version) ||
+                    version >= GitHubConstants.MinimumOnPremOAuthVersion)
                 {
-                    // Assume all GHAE instances have the GCM OAuth application deployed
-                    modes |= AuthenticationModes.OAuth;
-                }
-                else if (Version.TryParse(metaInfo.InstalledVersion, out var version) && version >= GitHubConstants.MinimumOnPremOAuthVersion)
-                {
-                    // Only GHES versions beyond the minimum version have the GCM OAuth application deployed
                     modes |= AuthenticationModes.OAuth;
                 }
 


### PR DESCRIPTION
Enterprise instances that return a null version are considered to support OAuth. Only disable OAuth as an option if we can verify we are talking to an old Enterprise Server.

This is a less fragile option as we never block the user from using an auth method they could use, and don't need to special case GHAE.