### PR TITLE
trace2: add error event

### DIFF
--- a/src/shared/Atlassian.Bitbucket.Tests/Cloud/BitbucketOAuth2ClientTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/Cloud/BitbucketOAuth2ClientTest.cs
@@ -70,7 +70,7 @@ namespace Atlassian.Bitbucket.Tests.Cloud
         {
             var trace2 = new NullTrace2();
             var client = new Bitbucket.Cloud.BitbucketOAuth2Client(httpClient.Object, settings.Object, trace2);
-            await Assert.ThrowsAsync<InvalidOperationException>(async () => await client.GetDeviceCodeAsync(scopes, ct));
+            await Assert.ThrowsAsync<Trace2InvalidOperationException>(async () => await client.GetDeviceCodeAsync(scopes, ct));
         }
 
         [Theory]

--- a/src/shared/Atlassian.Bitbucket.Tests/Cloud/BitbucketOAuth2ClientTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/Cloud/BitbucketOAuth2ClientTest.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Atlassian.Bitbucket.Cloud;
 using GitCredentialManager;
 using GitCredentialManager.Authentication.OAuth;
+using GitCredentialManager.Tests.Objects;
 using Moq;
 using Xunit;
 
@@ -16,7 +17,6 @@ namespace Atlassian.Bitbucket.Tests.Cloud
     {
         private Mock<HttpClient> httpClient = new Mock<HttpClient>(MockBehavior.Strict);
         private Mock<ISettings> settings = new Mock<ISettings>(MockBehavior.Loose);
-        private Mock<Trace> trace = new Mock<Trace>(MockBehavior.Loose);
         private Mock<IOAuth2WebBrowser> browser = new Mock<IOAuth2WebBrowser>(MockBehavior.Strict);
         private Mock<IOAuth2CodeGenerator> codeGenerator = new Mock<IOAuth2CodeGenerator>(MockBehavior.Strict);
         private IEnumerable<string> scopes = new List<string>();
@@ -55,7 +55,7 @@ namespace Atlassian.Bitbucket.Tests.Cloud
             Uri finalCallbackUri = MockFinalCallbackUri();
 
             Bitbucket.Cloud.BitbucketOAuth2Client client = GetBitbucketOAuth2Client();
-            
+
             MockGetAuthenticationCodeAsync(finalCallbackUri, clientId, client.Scopes);
 
             MockCodeGenerator();
@@ -68,7 +68,8 @@ namespace Atlassian.Bitbucket.Tests.Cloud
         [Fact]
         public async Task BitbucketOAuth2Client_GetDeviceCodeAsync()
         {
-            var client = new Bitbucket.Cloud.BitbucketOAuth2Client(httpClient.Object, settings.Object, trace.Object);
+            var trace2 = new NullTrace2();
+            var client = new Bitbucket.Cloud.BitbucketOAuth2Client(httpClient.Object, settings.Object, trace2);
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await client.GetDeviceCodeAsync(scopes, ct));
         }
 
@@ -79,7 +80,8 @@ namespace Atlassian.Bitbucket.Tests.Cloud
         [InlineData("https", "example.com/", "john", "https://example.com/refresh_token")]
         public void BitbucketOAuth2Client_GetRefreshTokenServiceName(string protocol, string host, string username, string expectedResult)
         {
-            var client = new Bitbucket.Cloud.BitbucketOAuth2Client(httpClient.Object, settings.Object, trace.Object);
+            var trace2 = new NullTrace2();
+            var client = new Bitbucket.Cloud.BitbucketOAuth2Client(httpClient.Object, settings.Object, trace2);
             var input = new InputArguments(new Dictionary<string, string>
             {
                 ["protocol"] = protocol,
@@ -100,7 +102,8 @@ namespace Atlassian.Bitbucket.Tests.Cloud
 
         private Bitbucket.Cloud.BitbucketOAuth2Client GetBitbucketOAuth2Client()
         {
-            var client = new Bitbucket.Cloud.BitbucketOAuth2Client(httpClient.Object, settings.Object, trace.Object);
+            var trace2 = new NullTrace2();
+            var client = new Bitbucket.Cloud.BitbucketOAuth2Client(httpClient.Object, settings.Object, trace2);
             client.CodeGenerator = codeGenerator.Object;
             return client;
         }

--- a/src/shared/Atlassian.Bitbucket.Tests/DataCenter/BitbucketOAuth2ClientTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/DataCenter/BitbucketOAuth2ClientTest.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Atlassian.Bitbucket.DataCenter;
 using GitCredentialManager;
 using GitCredentialManager.Authentication.OAuth;
+using GitCredentialManager.Tests.Objects;
 using Moq;
 using Xunit;
 
@@ -16,7 +17,6 @@ namespace Atlassian.Bitbucket.Tests.DataCenter
     {
         private Mock<HttpClient> httpClient = new Mock<HttpClient>(MockBehavior.Strict);
         private Mock<ISettings> settings = new Mock<ISettings>(MockBehavior.Loose);
-        private Mock<Trace> trace = new Mock<Trace>(MockBehavior.Loose);
         private Mock<IOAuth2WebBrowser> browser = new Mock<IOAuth2WebBrowser>(MockBehavior.Strict);
         private Mock<IOAuth2CodeGenerator> codeGenerator = new Mock<IOAuth2CodeGenerator>(MockBehavior.Strict);
         private CancellationToken ct = new CancellationToken();
@@ -77,7 +77,8 @@ namespace Atlassian.Bitbucket.Tests.DataCenter
 
         private Bitbucket.DataCenter.BitbucketOAuth2Client GetBitbucketOAuth2Client()
         {
-            var client = new Bitbucket.DataCenter.BitbucketOAuth2Client(httpClient.Object, settings.Object, trace.Object);
+            var trace2 = new NullTrace2();
+            var client = new Bitbucket.DataCenter.BitbucketOAuth2Client(httpClient.Object, settings.Object, trace2);
             client.CodeGenerator = codeGenerator.Object;
             return client;
         }

--- a/src/shared/Atlassian.Bitbucket.UI/Commands/CredentialsCommand.cs
+++ b/src/shared/Atlassian.Bitbucket.UI/Commands/CredentialsCommand.cs
@@ -48,7 +48,7 @@ namespace Atlassian.Bitbucket.UI.Commands
 
             if (!viewModel.WindowResult || viewModel.SelectedMode == AuthenticationModes.None)
             {
-                throw new Exception("User cancelled dialog.");
+                throw new Trace2Exception(Context.Trace2, "User cancelled dialog.");
             }
 
             switch (viewModel.SelectedMode)

--- a/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Atlassian.Bitbucket.Cloud;
 using GitCredentialManager;
 using GitCredentialManager.Authentication;
 using GitCredentialManager.Authentication.OAuth;
@@ -128,12 +127,12 @@ namespace Atlassian.Bitbucket
                 {
                     if (!output.TryGetValue("username", out userName))
                     {
-                        throw new Exception("Missing username in response");
+                        throw new Trace2Exception(Context.Trace2, "Missing username in response");
                     }
 
                     if (!output.TryGetValue("password", out password))
                     {
-                        throw new Exception("Missing password in response");
+                        throw new Trace2Exception(Context.Trace2, "Missing password in response");
                     }
 
                     return new CredentialsPromptResult(

--- a/src/shared/Atlassian.Bitbucket/BitbucketOAuth2Client.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketOAuth2Client.cs
@@ -10,7 +10,12 @@ namespace Atlassian.Bitbucket
 {
     public abstract class BitbucketOAuth2Client : OAuth2Client
     {
-        public BitbucketOAuth2Client(HttpClient httpClient, OAuth2ServerEndpoints endpoints, string clientId, Uri redirectUri, string clientSecret, ITrace trace) : base(httpClient, endpoints, clientId, redirectUri, clientSecret, false)
+        public BitbucketOAuth2Client(HttpClient httpClient,
+            OAuth2ServerEndpoints endpoints,
+            string clientId,
+            Uri redirectUri,
+            string clientSecret,
+            ITrace2 trace2) : base(httpClient, endpoints, clientId, trace2, redirectUri, clientSecret, false)
         {
         }
 

--- a/src/shared/Atlassian.Bitbucket/Cloud/BitbucketOAuth2Client.cs
+++ b/src/shared/Atlassian.Bitbucket/Cloud/BitbucketOAuth2Client.cs
@@ -10,9 +10,9 @@ namespace Atlassian.Bitbucket.Cloud
 {
     public class BitbucketOAuth2Client : Bitbucket.BitbucketOAuth2Client
     {
-        public BitbucketOAuth2Client(HttpClient httpClient, ISettings settings, ITrace trace)
+        public BitbucketOAuth2Client(HttpClient httpClient, ISettings settings, ITrace2 trace2)
             : base(httpClient, GetEndpoints(),
-                GetClientId(settings), GetRedirectUri(settings), GetClientSecret(settings), trace)
+                GetClientId(settings), GetRedirectUri(settings), GetClientSecret(settings), trace2)
         {
         }
 
@@ -62,7 +62,7 @@ namespace Atlassian.Bitbucket.Cloud
 
             return CloudConstants.OAuth2ClientSecret;
         }
-        
+
         private static OAuth2ServerEndpoints GetEndpoints()
         {
             return new OAuth2ServerEndpoints(

--- a/src/shared/Atlassian.Bitbucket/DataCenter/BitbucketOAuth2Client.cs
+++ b/src/shared/Atlassian.Bitbucket/DataCenter/BitbucketOAuth2Client.cs
@@ -12,9 +12,9 @@ namespace Atlassian.Bitbucket.DataCenter
 {
     public class BitbucketOAuth2Client : Bitbucket.BitbucketOAuth2Client
     {
-        public BitbucketOAuth2Client(HttpClient httpClient, ISettings settings, ITrace trace)
+        public BitbucketOAuth2Client(HttpClient httpClient, ISettings settings, ITrace2 trace2)
             : base(httpClient, GetEndpoints(settings),
-                GetClientId(settings), GetRedirectUri(settings), GetClientSecret(settings), trace)
+                GetClientId(settings), GetRedirectUri(settings), GetClientSecret(settings), trace2)
         {
         }
 

--- a/src/shared/Atlassian.Bitbucket/DataCenter/BitbucketRestApi.cs
+++ b/src/shared/Atlassian.Bitbucket/DataCenter/BitbucketRestApi.cs
@@ -20,7 +20,7 @@ namespace Atlassian.Bitbucket.DataCenter
             EnsureArgument.NotNull(context, nameof(context));
 
             _context = context;
-        
+
         }
 
         public async Task<RestApiResult<IUserInfo>> GetUserInformationAsync(string userName, string password, bool isBearerToken)
@@ -35,7 +35,7 @@ namespace Atlassian.Bitbucket.DataCenter
             }
 
             // Bitbucket Server/DC doesn't actually provide a REST API we can use to trade an access_token for the owning username,
-            // therefore this is always going to return a placeholder username, however this call does provide a way to validate the 
+            // therefore this is always going to return a placeholder username, however this call does provide a way to validate the
             // credentials we do have
             var requestUri = new Uri(ApiUri, "api/1.0/users");
             using (HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri))
@@ -131,9 +131,9 @@ namespace Atlassian.Bitbucket.DataCenter
 
         private HttpClient HttpClient => _httpClient ??= _context.HttpClientFactory.CreateClient();
 
-        private Uri ApiUri 
+        private Uri ApiUri
         {
-            get 
+            get
             {
                 var remoteUri = _context.Settings?.RemoteUri;
                 if (remoteUri == null)

--- a/src/shared/Atlassian.Bitbucket/OAuth2ClientRegistry.cs
+++ b/src/shared/Atlassian.Bitbucket/OAuth2ClientRegistry.cs
@@ -8,6 +8,7 @@ namespace Atlassian.Bitbucket
         private readonly HttpClient http;
         private ISettings settings;
         private readonly ITrace trace;
+        private readonly ITrace2 trace2;
         private Cloud.BitbucketOAuth2Client cloudClient;
         private DataCenter.BitbucketOAuth2Client dataCenterClient;
 
@@ -16,6 +17,7 @@ namespace Atlassian.Bitbucket
             this.http = context.HttpClientFactory.CreateClient();
             this.settings = context.Settings;
             this.trace = context.Trace;
+            this.trace2 = context.Trace2;
         }
 
         public BitbucketOAuth2Client Get(InputArguments input)
@@ -36,7 +38,7 @@ namespace Atlassian.Bitbucket
             dataCenterClient = null;
         }
 
-        private Cloud.BitbucketOAuth2Client CloudClient => cloudClient ??= new Cloud.BitbucketOAuth2Client(http, settings, trace);
-        private DataCenter.BitbucketOAuth2Client DataCenterClient => dataCenterClient ??= new DataCenter.BitbucketOAuth2Client(http, settings, trace);
+        private Cloud.BitbucketOAuth2Client CloudClient => cloudClient ??= new Cloud.BitbucketOAuth2Client(http, settings, trace2);
+        private DataCenter.BitbucketOAuth2Client DataCenterClient => dataCenterClient ??= new DataCenter.BitbucketOAuth2Client(http, settings, trace2);
     }
 }

--- a/src/shared/Core.Tests/Authentication/MicrosoftAuthenticationTests.cs
+++ b/src/shared/Core.Tests/Authentication/MicrosoftAuthenticationTests.cs
@@ -23,7 +23,7 @@ namespace GitCredentialManager.Tests.Authentication
 
             var msAuth = new MicrosoftAuthentication(context);
 
-            await Assert.ThrowsAsync<InvalidOperationException>(
+            await Assert.ThrowsAsync<Trace2InvalidOperationException>(
                 () => msAuth.GetTokenAsync(authority, clientId, redirectUri, scopes, userName));
         }
     }

--- a/src/shared/Core.Tests/Authentication/OAuth2ClientTests.cs
+++ b/src/shared/Core.Tests/Authentication/OAuth2ClientTests.cs
@@ -36,7 +36,8 @@ namespace GitCredentialManager.Tests.Authentication
 
             IOAuth2WebBrowser browser = new TestOAuth2WebBrowser(httpHandler);
 
-            OAuth2Client client = CreateClient(httpHandler, endpoints);
+            var trace2 = new NullTrace2();
+            OAuth2Client client = CreateClient(httpHandler, endpoints, trace2);
 
             OAuth2AuthorizationCodeResult result = await client.GetAuthorizationCodeAsync(expectedScopes, browser, null, CancellationToken.None);
 
@@ -81,7 +82,8 @@ namespace GitCredentialManager.Tests.Authentication
 
             IOAuth2WebBrowser browser = new TestOAuth2WebBrowser(httpHandler);
 
-            OAuth2Client client = CreateClient(httpHandler, endpoints);
+            var trace2 = new NullTrace2();
+            OAuth2Client client = CreateClient(httpHandler, endpoints, trace2);
 
             OAuth2AuthorizationCodeResult result = await client.GetAuthorizationCodeAsync(expectedScopes, browser, extraParams, CancellationToken.None);
 
@@ -116,7 +118,8 @@ namespace GitCredentialManager.Tests.Authentication
 
             IOAuth2WebBrowser browser = new TestOAuth2WebBrowser(httpHandler);
 
-            OAuth2Client client = CreateClient(httpHandler, endpoints);
+            var trace2 = new NullTrace2();
+            OAuth2Client client = CreateClient(httpHandler, endpoints, trace2);
 
             await Assert.ThrowsAsync<ArgumentException>(() =>
                 client.GetAuthorizationCodeAsync(expectedScopes, browser, extraParams, CancellationToken.None));
@@ -143,7 +146,8 @@ namespace GitCredentialManager.Tests.Authentication
             server.TokenGenerator.UserCodes.Add(expectedUserCode);
             server.TokenGenerator.DeviceCodes.Add(expectedDeviceCode);
 
-            OAuth2Client client = CreateClient(httpHandler, endpoints);
+            var trace2 = new NullTrace2();
+            OAuth2Client client = CreateClient(httpHandler, endpoints, trace2);
 
             OAuth2DeviceCodeResult result = await client.GetDeviceCodeAsync(expectedScopes, CancellationToken.None);
 
@@ -174,7 +178,8 @@ namespace GitCredentialManager.Tests.Authentication
             server.TokenGenerator.AccessTokens.Add(expectedAccessToken);
             server.TokenGenerator.RefreshTokens.Add(expectedRefreshToken);
 
-            OAuth2Client client = CreateClient(httpHandler, endpoints);
+            var trace2 = new NullTrace2();
+            OAuth2Client client = CreateClient(httpHandler, endpoints, trace2);
 
             var authCodeResult = new OAuth2AuthorizationCodeResult(authCode, TestRedirectUri);
             OAuth2TokenResult result = await client.GetTokenByAuthorizationCodeAsync(authCodeResult, CancellationToken.None);
@@ -211,7 +216,8 @@ namespace GitCredentialManager.Tests.Authentication
             server.TokenGenerator.AccessTokens.Add(expectedAccessToken);
             server.TokenGenerator.RefreshTokens.Add(expectedRefreshToken);
 
-            OAuth2Client client = CreateClient(httpHandler, endpoints);
+            var trace2 = new NullTrace2();
+            OAuth2Client client = CreateClient(httpHandler, endpoints, trace2);
 
             OAuth2TokenResult result = await client.GetTokenByRefreshTokenAsync(oldRefreshToken, CancellationToken.None);
 
@@ -249,7 +255,8 @@ namespace GitCredentialManager.Tests.Authentication
             server.TokenGenerator.AccessTokens.Add(expectedAccessToken);
             server.TokenGenerator.RefreshTokens.Add(expectedRefreshToken);
 
-            OAuth2Client client = CreateClient(httpHandler, endpoints);
+            var trace2 = new NullTrace2();
+            OAuth2Client client = CreateClient(httpHandler, endpoints, trace2);
 
             var deviceCodeResult = new OAuth2DeviceCodeResult(expectedDeviceCode, expectedUserCode, null, null);
 
@@ -294,7 +301,8 @@ namespace GitCredentialManager.Tests.Authentication
 
             IOAuth2WebBrowser browser = new TestOAuth2WebBrowser(httpHandler);
 
-            OAuth2Client client = CreateClient(httpHandler, endpoints);
+            var trace2 = new NullTrace2();
+            OAuth2Client client = CreateClient(httpHandler, endpoints, trace2);
 
             OAuth2AuthorizationCodeResult authCodeResult = await client.GetAuthorizationCodeAsync(
                 expectedScopes, browser, null, CancellationToken.None);
@@ -343,7 +351,8 @@ namespace GitCredentialManager.Tests.Authentication
             server.TokenGenerator.AccessTokens.Add(expectedAccessToken1);
             server.TokenGenerator.RefreshTokens.Add(expectedRefreshToken1);
 
-            OAuth2Client client = CreateClient(httpHandler, endpoints);
+            var trace2 = new NullTrace2();
+            OAuth2Client client = CreateClient(httpHandler, endpoints, trace2);
 
             OAuth2DeviceCodeResult deviceResult = await client.GetDeviceCodeAsync(expectedScopes, CancellationToken.None);
 
@@ -376,9 +385,9 @@ namespace GitCredentialManager.Tests.Authentication
             RedirectUris = new[] {TestRedirectUri}
         };
 
-        private static OAuth2Client CreateClient(HttpMessageHandler httpHandler, OAuth2ServerEndpoints endpoints, IOAuth2CodeGenerator generator = null)
+        private static OAuth2Client CreateClient(HttpMessageHandler httpHandler, OAuth2ServerEndpoints endpoints, ITrace2 trace2, IOAuth2CodeGenerator generator = null)
         {
-            return new OAuth2Client(new HttpClient(httpHandler), endpoints, TestClientId, TestRedirectUri, TestClientSecret)
+            return new OAuth2Client(new HttpClient(httpHandler), endpoints, TestClientId, trace2, TestRedirectUri, TestClientSecret)
             {
                 CodeGenerator = generator
             };

--- a/src/shared/Core.Tests/GitConfigurationTests.cs
+++ b/src/shared/Core.Tests/GitConfigurationTests.cs
@@ -47,9 +47,9 @@ namespace GitCredentialManager.Tests
         {
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath);
             var config = git.GetConfiguration();
             Assert.NotNull(config);
         }
@@ -71,9 +71,9 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, repoPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             var actualVisitedEntries = new List<(string name, string value)>();
@@ -110,9 +110,9 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, repoPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             var actualVisitedEntries = new List<(string name, string value)>();
@@ -138,13 +138,12 @@ namespace GitCredentialManager.Tests
         {
             string repoPath = CreateRepository(out string workDirPath);
             ExecGit(repoPath, workDirPath, "config --local user.name john.doe").AssertSuccess();
-
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
 
-            var git = new GitProcess(trace, processManager, gitPath, repoPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             bool result = config.TryGet("user.name", false, out string value);
@@ -160,9 +159,10 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, repoPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             string randomName = $"{Guid.NewGuid():N}.{Guid.NewGuid():N}";
@@ -180,9 +180,9 @@ namespace GitCredentialManager.Tests
             string homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, repoPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             bool result = config.TryGet("example.path", true, out string value);
@@ -199,9 +199,9 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, repoPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             bool result = config.TryGet("example.path", false, out string value);
@@ -218,9 +218,9 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, repoPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             bool result = config.TryGet(GitConfigurationLevel.Local, GitConfigurationType.Bool,
@@ -238,9 +238,9 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, repoPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             bool result = config.TryGet(GitConfigurationLevel.Local, GitConfigurationType.Raw,
@@ -258,9 +258,10 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, repoPath);
+
+            var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             string value = config.Get("user.name");
@@ -275,9 +276,9 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, repoPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             string randomName = $"{Guid.NewGuid():N}.{Guid.NewGuid():N}";
@@ -291,16 +292,16 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, repoPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);;
             IGitConfiguration config = git.GetConfiguration();
 
             config.Set(GitConfigurationLevel.Local, "core.foobar", "foo123");
 
             GitResult localResult = ExecGit(repoPath, workDirPath, "config --local core.foobar");
 
-            Assert.Equal("foo123",     localResult.StandardOutput.Trim());
+            Assert.Equal("foo123", localResult.StandardOutput.Trim());
         }
 
         [Fact]
@@ -310,12 +311,13 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, repoPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
-            Assert.Throws<InvalidOperationException>(() => config.Set(GitConfigurationLevel.All, "core.foobar", "test123"));
+            Assert.Throws<InvalidOperationException>(() =>
+                config.Set(GitConfigurationLevel.All, "core.foobar", "test123"));
         }
 
         [Fact]
@@ -324,15 +326,14 @@ namespace GitCredentialManager.Tests
             string repoPath = CreateRepository(out string workDirPath);
             try
             {
-
                 ExecGit(repoPath, workDirPath, "config --global core.foobar alice").AssertSuccess();
                 ExecGit(repoPath, workDirPath, "config --local core.foobar bob").AssertSuccess();
 
                 string gitPath = GetGitPath();
                 var trace = new NullTrace();
-                var env = new TestEnvironment();
+                var trace2 = new NullTrace2();
                 var processManager = new TestProcessManager();
-                var git = new GitProcess(trace, processManager, gitPath, repoPath);
+                var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
                 IGitConfiguration config = git.GetConfiguration();
 
                 config.Unset(GitConfigurationLevel.Global, "core.foobar");
@@ -362,9 +363,9 @@ namespace GitCredentialManager.Tests
 
                 string gitPath = GetGitPath();
                 var trace = new NullTrace();
-                var env = new TestEnvironment();
+                var trace2 = new NullTrace2();
                 var processManager = new TestProcessManager();
-                var git = new GitProcess(trace, processManager, gitPath, repoPath);
+                var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
                 IGitConfiguration config = git.GetConfiguration();
 
                 config.Unset(GitConfigurationLevel.Local, "core.foobar");
@@ -389,9 +390,9 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, repoPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             Assert.Throws<InvalidOperationException>(() => config.Unset(GitConfigurationLevel.All, "core.foobar"));
@@ -407,9 +408,9 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, repoPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
             config.UnsetAll(GitConfigurationLevel.Local, "core.foobar", "foo*");
@@ -426,12 +427,14 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, repoPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
             IGitConfiguration config = git.GetConfiguration();
 
-            Assert.Throws<InvalidOperationException>(() => config.UnsetAll(GitConfigurationLevel.All, "core.foobar", Constants.RegexPatterns.Any));
+            Assert.Throws<InvalidOperationException>(() =>
+                config.UnsetAll(GitConfigurationLevel.All, "core.foobar", Constants.RegexPatterns.Any));
         }
     }
 }

--- a/src/shared/Core.Tests/GitTests.cs
+++ b/src/shared/Core.Tests/GitTests.cs
@@ -13,9 +13,9 @@ namespace GitCredentialManager.Tests
         {
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, Path.GetTempPath());
+            var git = new GitProcess(trace, trace2, processManager, gitPath, Path.GetTempPath());
 
             string actual = git.GetCurrentRepository();
 
@@ -29,9 +29,9 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, workDirPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, workDirPath);
 
             string actual = git.GetCurrentRepository();
 
@@ -43,9 +43,9 @@ namespace GitCredentialManager.Tests
         {
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, Path.GetTempPath());
+            var git = new GitProcess(trace, trace2, processManager, gitPath, Path.GetTempPath());
 
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
@@ -59,9 +59,9 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
-            var git = new GitProcess(trace, processManager, gitPath, workDirPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, workDirPath);
 
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
@@ -78,10 +78,10 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
 
-            var git = new GitProcess(trace, processManager, gitPath, workDirPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, workDirPath);
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
             Assert.Single(remotes);
@@ -100,10 +100,10 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
 
-            var git = new GitProcess(trace, processManager, gitPath, workDirPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, workDirPath);
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
             Assert.Single(remotes);
@@ -124,10 +124,10 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
 
-            var git = new GitProcess(trace, processManager, gitPath, workDirPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, workDirPath);
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
             Assert.Single(remotes);
@@ -150,10 +150,10 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
 
-            var git = new GitProcess(trace, processManager, gitPath, workDirPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, workDirPath);
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
             Assert.Equal(3, remotes.Length);
@@ -175,10 +175,10 @@ namespace GitCredentialManager.Tests
 
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
 
-            var git = new GitProcess(trace, processManager, gitPath, workDirPath);
+            var git = new GitProcess(trace, trace2, processManager, gitPath, workDirPath);
             GitRemote[] remotes = git.GetRemotes().ToArray();
 
             Assert.Single(remotes);
@@ -191,13 +191,14 @@ namespace GitCredentialManager.Tests
         {
             string gitPath = GetGitPath();
             var trace = new NullTrace();
-            var env = new TestEnvironment();
+            var trace2 = new NullTrace2();
             var processManager = new TestProcessManager();
 
-            var git = new GitProcess(trace, processManager, gitPath, Path.GetTempPath());
+            var git = new GitProcess(trace, trace2, processManager, gitPath, Path.GetTempPath());
             GitVersion version = git.Version;
 
             Assert.NotEqual(new GitVersion(), version);
+
         }
 
         #region Test Helpers

--- a/src/shared/Core.UI/Commands/CredentialsCommand.cs
+++ b/src/shared/Core.UI/Commands/CredentialsCommand.cs
@@ -63,7 +63,7 @@ namespace GitCredentialManager.UI.Commands
 
             if (!viewModel.WindowResult)
             {
-                throw new Exception("User cancelled dialog.");
+                throw new Trace2Exception(Context.Trace2, "User cancelled dialog.");
             }
 
             WriteResult(

--- a/src/shared/Core.UI/Commands/DeviceCodeCommand.cs
+++ b/src/shared/Core.UI/Commands/DeviceCodeCommand.cs
@@ -41,7 +41,7 @@ namespace GitCredentialManager.UI.Commands
 
             if (!viewModel.WindowResult)
             {
-                throw new Exception("User cancelled dialog.");
+                throw new Trace2Exception(Context.Trace2, "User cancelled dialog.");
             }
 
             return 0;

--- a/src/shared/Core.UI/Commands/OAuthCommand.cs
+++ b/src/shared/Core.UI/Commands/OAuthCommand.cs
@@ -66,7 +66,7 @@ namespace GitCredentialManager.UI.Commands
 
             if (!viewModel.WindowResult)
             {
-                throw new Exception("User cancelled dialog.");
+                throw new Trace2Exception(Context.Trace2, "User cancelled dialog.");
             }
 
             var result = new Dictionary<string, string>();

--- a/src/shared/Core/Authentication/AuthenticationBase.cs
+++ b/src/shared/Core/Authentication/AuthenticationBase.cs
@@ -46,7 +46,10 @@ namespace GitCredentialManager.Authentication
             var process = ChildProcess.Start(Context.Trace2, procStartInfo, Trace2ProcessClass.UIHelper);
             if (process is null)
             {
-                throw new Exception($"Failed to start helper process: {path} {args}");
+                var format = "Failed to start helper process: {0} {1}";
+                var message = string.Format(format, path, args);
+
+                throw new Trace2Exception(Context.Trace2, message, format);
             }
 
             // Kill the process upon a cancellation request
@@ -69,7 +72,7 @@ namespace GitCredentialManager.Authentication
                     errorMessage = "Unknown";
                 }
 
-                throw new Exception($"helper error ({exitCode}): {errorMessage}");
+                throw new Trace2Exception(Context.Trace2, $"helper error ({exitCode}): {errorMessage}");
             }
 
             return resultDict;
@@ -85,8 +88,7 @@ namespace GitCredentialManager.Authentication
                     Constants.GitConfiguration.Credential.Interactive);
 
                 Context.Trace.WriteLine($"{envName} / {cfgName} is false/never; user interactivity has been disabled.");
-
-                throw new InvalidOperationException("Cannot prompt because user interactivity has been disabled.");
+                throw new Trace2InvalidOperationException(Context.Trace2, "Cannot prompt because user interactivity has been disabled.");
             }
         }
 
@@ -95,8 +97,7 @@ namespace GitCredentialManager.Authentication
             if (!Context.Settings.IsGuiPromptsEnabled)
             {
                 Context.Trace.WriteLine($"{Constants.EnvironmentVariables.GitTerminalPrompts} is 0; GUI prompts have been disabled.");
-
-                throw new InvalidOperationException("Cannot show prompt because GUI prompts have been disabled.");
+                throw new Trace2InvalidOperationException(Context.Trace2, "Cannot show prompt because GUI prompts have been disabled.");
             }
         }
 
@@ -105,8 +106,7 @@ namespace GitCredentialManager.Authentication
             if (!Context.Settings.IsTerminalPromptsEnabled)
             {
                 Context.Trace.WriteLine($"{Constants.EnvironmentVariables.GitTerminalPrompts} is 0; terminal prompts have been disabled.");
-
-                throw new InvalidOperationException("Cannot prompt because terminal prompts have been disabled.");
+                throw new Trace2InvalidOperationException(Context.Trace2, "Cannot prompt because terminal prompts have been disabled.");
             }
         }
 

--- a/src/shared/Core/Authentication/BasicAuthentication.cs
+++ b/src/shared/Core/Authentication/BasicAuthentication.cs
@@ -85,12 +85,12 @@ namespace GitCredentialManager.Authentication
 
             if (!resultDict.TryGetValue("username", out userName))
             {
-                throw new Exception("Missing 'username' in response");
+                throw new Trace2Exception(Context.Trace2, "Missing 'username' in response");
             }
 
             if (!resultDict.TryGetValue("password", out string password))
             {
-                throw new Exception("Missing 'password' in response");
+                throw new Trace2Exception(Context.Trace2, "Missing 'password' in response");
             }
 
             return new GitCredential(userName, password);

--- a/src/shared/Core/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Core/Authentication/MicrosoftAuthentication.cs
@@ -333,9 +333,11 @@ namespace GitCredentialManager.Authentication
             }
             catch (MsalCachePersistenceException ex)
             {
+                var message = "Cannot persist Microsoft Authentication data securely!";
                 Context.Streams.Error.WriteLine("warning: cannot persist Microsoft authentication token cache securely!");
-                Context.Trace.WriteLine("Cannot persist Microsoft Authentication data securely!");
+                Context.Trace.WriteLine(message);
                 Context.Trace.WriteException(ex);
+                Context.Trace2.WriteError(message);
 
                 if (PlatformUtils.IsMacOS())
                 {
@@ -498,10 +500,12 @@ namespace GitCredentialManager.Authentication
 #if NETFRAMEWORK
             if (!Context.SessionManager.IsDesktopSession)
             {
-                throw new InvalidOperationException("Embedded web view is not available without a desktop session.");
+                throw new Trace2InvalidOperationException(Context.Trace2,
+                    "Embedded web view is not available without a desktop session.");
             }
 #else
-            throw new InvalidOperationException("Embedded web view is not available on .NET Core.");
+            throw new Trace2InvalidOperationException(Context.Trace2,
+                "Embedded web view is not available on .NET Core.");
 #endif
         }
 
@@ -515,17 +519,20 @@ namespace GitCredentialManager.Authentication
         {
             if (!Context.SessionManager.IsWebBrowserAvailable)
             {
-                throw new InvalidOperationException("System web view is not available without a way to start a browser.");
+                throw new Trace2InvalidOperationException(Context.Trace2,
+                    "System web view is not available without a way to start a browser.");
             }
 
             if (!app.IsSystemWebViewAvailable)
             {
-                throw new InvalidOperationException("System web view is not available on this platform.");
+                throw new Trace2InvalidOperationException(Context.Trace2,
+                    "System web view is not available on this platform.");
             }
 
             if (!redirectUri.IsLoopback)
             {
-                throw new InvalidOperationException("System web view is not available for this service configuration.");
+                throw new Trace2InvalidOperationException(Context.Trace2,
+                    "System web view is not available for this service configuration.");
             }
         }
 

--- a/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
+++ b/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
@@ -70,16 +70,24 @@ namespace GitCredentialManager.Authentication.OAuth
         private readonly OAuth2ServerEndpoints _endpoints;
         private readonly Uri _redirectUri;
         private readonly string _clientId;
+        private readonly ITrace2 _trace2;
         private readonly string _clientSecret;
         private readonly bool _addAuthHeader;
 
         private IOAuth2CodeGenerator _codeGenerator;
 
-        public OAuth2Client(HttpClient httpClient, OAuth2ServerEndpoints endpoints, string clientId, Uri redirectUri = null, string clientSecret = null, bool addAuthHeader = true)
+        public OAuth2Client(HttpClient httpClient,
+            OAuth2ServerEndpoints endpoints,
+            string clientId,
+            ITrace2 trace2,
+            Uri redirectUri = null,
+            string clientSecret = null,
+            bool addAuthHeader = true)
         {
             _httpClient = httpClient;
             _endpoints = endpoints;
             _clientId = clientId;
+            _trace2 = trace2;
             _redirectUri = redirectUri;
             _clientSecret = clientSecret;
             _addAuthHeader = addAuthHeader;

--- a/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
+++ b/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
@@ -163,17 +163,19 @@ namespace GitCredentialManager.Authentication.OAuth
             IDictionary<string, string> redirectQueryParams = finalUri.GetQueryParameters();
             if (!redirectQueryParams.TryGetValue(OAuth2Constants.AuthorizationGrantResponse.StateParameter, out string replyState))
             {
-                throw new OAuth2Exception($"Missing '{OAuth2Constants.AuthorizationGrantResponse.StateParameter}' in response.");
+                throw new Trace2OAuth2Exception(_trace2, $"Missing '{OAuth2Constants.AuthorizationGrantResponse.StateParameter}' in response.");
             }
             if (!StringComparer.Ordinal.Equals(state, replyState))
             {
-                throw new OAuth2Exception($"Invalid '{OAuth2Constants.AuthorizationGrantResponse.StateParameter}' in response. Does not match initial request.");
+                throw new Trace2OAuth2Exception(_trace2,
+                    $"Missing '{OAuth2Constants.AuthorizationGrantResponse.StateParameter}' in response.");
             }
 
             // We expect to have the auth code in the response otherwise terminate the flow (we failed authentication for some reason)
             if (!redirectQueryParams.TryGetValue(OAuth2Constants.AuthorizationGrantResponse.AuthorizationCodeParameter, out string authCode))
             {
-                throw new OAuth2Exception($"Missing '{OAuth2Constants.AuthorizationGrantResponse.AuthorizationCodeParameter}' in response.");
+                throw new Trace2OAuth2Exception(_trace2,
+                    $"Missing '{OAuth2Constants.AuthorizationGrantResponse.AuthorizationCodeParameter}' in response.");
             }
 
             return new OAuth2AuthorizationCodeResult(authCode, redirectUri, codeVerifier);
@@ -183,7 +185,8 @@ namespace GitCredentialManager.Authentication.OAuth
         {
             if (_endpoints.DeviceAuthorizationEndpoint is null)
             {
-                throw new InvalidOperationException("No device authorization endpoint has been configured for this client.");
+                throw new Trace2InvalidOperationException(_trace2,
+                    "No device authorization endpoint has been configured for this client.");
             }
 
             string scopesStr = string.Join(" ", scopes);
@@ -383,10 +386,13 @@ namespace GitCredentialManager.Authentication.OAuth
         {
             if (TryCreateExceptionFromResponse(json, out OAuth2Exception exception))
             {
+                _trace2.WriteError(exception.Message);
                 return exception;
             }
 
-            return new OAuth2Exception($"Unknown OAuth error: {json}");
+            var format = "Unknown OAuth error: {0}";
+            var message = string.Format(format, json);
+            return new Trace2OAuth2Exception(_trace2, message, format);
         }
 
         protected static bool TryDeserializeJson<T>(string json, out T obj)

--- a/src/shared/Core/Authentication/OAuthAuthentication.cs
+++ b/src/shared/Core/Authentication/OAuthAuthentication.cs
@@ -82,7 +82,7 @@ namespace GitCredentialManager.Authentication
 
                 if (!resultDict.TryGetValue("mode", out string responseMode))
                 {
-                    throw new Exception("Missing 'mode' in response");
+                    throw new Trace2Exception(Context.Trace2, "Missing 'mode' in response");
                 }
 
                 switch (responseMode.ToLowerInvariant())
@@ -94,7 +94,8 @@ namespace GitCredentialManager.Authentication
                         return OAuthAuthenticationModes.DeviceCode;
 
                     default:
-                        throw new Exception($"Unknown mode value in response '{responseMode}'");
+                        throw new Trace2Exception(Context.Trace2,
+                            $"Unknown mode value in response '{responseMode}'");
                 }
             }
             else
@@ -137,7 +138,8 @@ namespace GitCredentialManager.Authentication
             // We require a desktop session to launch the user's default web browser
             if (!Context.SessionManager.IsDesktopSession)
             {
-                throw new InvalidOperationException("Browser authentication requires a desktop session");
+                throw new Trace2InvalidOperationException(Context.Trace2,
+                    "Browser authentication requires a desktop session");
             }
 
             var browserOptions = new OAuth2WebBrowserOptions();
@@ -185,7 +187,7 @@ namespace GitCredentialManager.Authentication
                 }
                 catch (OperationCanceledException)
                 {
-                    throw new Exception("User canceled device code authentication");
+                    throw new Trace2Exception(Context.Trace2, "User canceled device code authentication");
                 }
 
                 // Close the dialog

--- a/src/shared/Core/CommandContext.cs
+++ b/src/shared/Core/CommandContext.cs
@@ -105,7 +105,7 @@ namespace GitCredentialManager
                 Environment       = new WindowsEnvironment(FileSystem);
                 SessionManager    = new WindowsSessionManager(Environment, FileSystem);
                 ProcessManager    = new WindowsProcessManager(Trace2);
-                Terminal          = new WindowsTerminal(Trace);
+                Terminal          = new WindowsTerminal(Trace, Trace2);
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(
                                             Trace,
@@ -122,7 +122,7 @@ namespace GitCredentialManager
                 SessionManager    = new MacOSSessionManager(Environment, FileSystem);
                 Environment       = new MacOSEnvironment(FileSystem);
                 ProcessManager    = new ProcessManager(Trace2);
-                Terminal          = new MacOSTerminal(Trace);
+                Terminal          = new MacOSTerminal(Trace, Trace2);
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(
                                             Trace,
@@ -139,7 +139,7 @@ namespace GitCredentialManager
                 SessionManager    = new LinuxSessionManager(Environment, FileSystem);
                 Environment       = new PosixEnvironment(FileSystem);
                 ProcessManager    = new ProcessManager(Trace2);
-                Terminal          = new LinuxTerminal(Trace);
+                Terminal          = new LinuxTerminal(Trace, Trace2);
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(
                                             Trace,

--- a/src/shared/Core/CommandContext.cs
+++ b/src/shared/Core/CommandContext.cs
@@ -109,6 +109,7 @@ namespace GitCredentialManager
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(
                                             Trace,
+                                            Trace2,
                                             ProcessManager,
                                             gitPath,
                                             FileSystem.GetCurrentDirectory()
@@ -125,6 +126,7 @@ namespace GitCredentialManager
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(
                                             Trace,
+                                            Trace2,
                                             ProcessManager,
                                             gitPath,
                                             FileSystem.GetCurrentDirectory()
@@ -141,6 +143,7 @@ namespace GitCredentialManager
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(
                                             Trace,
+                                            Trace2,
                                             ProcessManager,
                                             gitPath,
                                             FileSystem.GetCurrentDirectory()

--- a/src/shared/Core/Commands/GitCommandBase.cs
+++ b/src/shared/Core/Commands/GitCommandBase.cs
@@ -58,22 +58,24 @@ namespace GitCredentialManager.Commands
         {
             if (input.Protocol is null)
             {
-                throw new InvalidOperationException("Missing 'protocol' input argument");
+                throw new Trace2InvalidOperationException(Context.Trace2, "Missing 'protocol' input argument");
             }
 
             if (string.IsNullOrWhiteSpace(input.Protocol))
             {
-                throw new InvalidOperationException("Invalid 'protocol' input argument (cannot be empty)");
+                throw new Trace2InvalidOperationException(Context.Trace2,
+                    "Invalid 'protocol' input argument (cannot be empty)");
             }
 
             if (input.Host is null)
             {
-                throw new InvalidOperationException("Missing 'host' input argument");
+                throw new Trace2InvalidOperationException(Context.Trace2, "Missing 'host' input argument");
             }
 
             if (string.IsNullOrWhiteSpace(input.Host))
             {
-                throw new InvalidOperationException("Invalid 'host' input argument (cannot be empty)");
+                throw new Trace2InvalidOperationException(Context.Trace2,
+                    "Invalid 'host' input argument (cannot be empty)");
             }
         }
 

--- a/src/shared/Core/Commands/StoreCommand.cs
+++ b/src/shared/Core/Commands/StoreCommand.cs
@@ -23,12 +23,12 @@ namespace GitCredentialManager.Commands
             // An empty string username/password are valid inputs, so only check for `null` (not provided)
             if (input.UserName is null)
             {
-                throw new InvalidOperationException("Missing 'username' input argument");
+                throw new Trace2InvalidOperationException(Context.Trace2, "Missing 'username' input argument");
             }
 
             if (input.Password is null)
             {
-                throw new InvalidOperationException("Missing 'password' input argument");
+                throw new Trace2InvalidOperationException(Context.Trace2, "Missing 'password' input argument");
             }
         }
     }

--- a/src/shared/Core/CredentialStore.cs
+++ b/src/shared/Core/CredentialStore.cs
@@ -98,6 +98,7 @@ namespace GitCredentialManager
                     sb.AppendLine(string.IsNullOrWhiteSpace(credStoreName)
                         ? "No credential store has been selected."
                         : $"Unknown credential store '{credStoreName}'.");
+                    _context.Trace2.WriteError(sb.ToString());
                     sb.AppendFormat(
                         "{3}Set the {0} environment variable or the {1}.{2} Git configuration setting to one of the following options:{3}{3}",
                         Constants.EnvironmentVariables.GcmCredentialStore,
@@ -166,18 +167,18 @@ namespace GitCredentialManager
         {
             if (!PlatformUtils.IsWindows())
             {
-                throw new Exception(
-                    $"Can only use the '{StoreNames.WindowsCredentialManager}' credential store on Windows." +
-                    Environment.NewLine +
-                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                var message = $"Can only use the '{StoreNames.WindowsCredentialManager}' credential store on Windows.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message + Environment.NewLine +
+                            $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
                 );
             }
 
             if (!WindowsCredentialManager.CanPersist())
             {
-                throw new Exception(
-                    $"Unable to persist credentials with the '{StoreNames.WindowsCredentialManager}' credential store." +
-                    Environment.NewLine +
+                var message = $"Unable to persist credentials with the '{StoreNames.WindowsCredentialManager}' credential store.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message + Environment.NewLine +
                     $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
                 );
             }
@@ -187,9 +188,9 @@ namespace GitCredentialManager
         {
             if (!PlatformUtils.IsWindows())
             {
-                throw new Exception(
-                    $"Can only use the '{StoreNames.Dpapi}' credential store on Windows." +
-                    Environment.NewLine +
+                var message = $"Can only use the '{StoreNames.Dpapi}' credential store on Windows.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message  + Environment.NewLine +
                     $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
                 );
             }
@@ -210,10 +211,10 @@ namespace GitCredentialManager
         {
             if (!PlatformUtils.IsMacOS())
             {
-                throw new Exception(
-                    $"Can only use the '{StoreNames.MacOSKeychain}' credential store on macOS." +
-                    Environment.NewLine +
-                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                var message = $"Can only use the '{StoreNames.MacOSKeychain}' credential store on macOS.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message  + Environment.NewLine +
+                                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
                 );
             }
         }
@@ -222,19 +223,19 @@ namespace GitCredentialManager
         {
             if (!PlatformUtils.IsLinux())
             {
-                throw new Exception(
-                    $"Can only use the '{StoreNames.SecretService}' credential store on Linux." +
-                    Environment.NewLine +
-                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                var message = $"Can only use the '{StoreNames.SecretService}' credential store on Linux.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message + Environment.NewLine +
+                                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
                 );
             }
 
             if (!_context.SessionManager.IsDesktopSession)
             {
-                throw new Exception(
-                    $"Cannot use the '{StoreNames.SecretService}' credential backing store without a graphical interface present." +
-                    Environment.NewLine +
-                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                var message = $"Cannot use the '{StoreNames.SecretService}' credential backing store without a graphical interface present.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message + Environment.NewLine +
+                                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
                 );
             }
         }
@@ -243,10 +244,10 @@ namespace GitCredentialManager
         {
             if (!PlatformUtils.IsPosix())
             {
-                throw new Exception(
-                    $"Can only use the '{StoreNames.Gpg}' credential store on POSIX systems." +
-                    Environment.NewLine +
-                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                var message = $"Can only use the '{StoreNames.Gpg}' credential store on POSIX systems.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message + Environment.NewLine +
+                                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
                 );
             }
 
@@ -258,10 +259,10 @@ namespace GitCredentialManager
                 !_context.Environment.Variables.ContainsKey("GPG_TTY") &&
                 !_context.Environment.Variables.ContainsKey("SSH_TTY"))
             {
-                throw new Exception(
-                    "GPG_TTY is not set; add `export GPG_TTY=$(tty)` to your profile." +
-                    Environment.NewLine +
-                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                var message = "GPG_TTY is not set; add `export GPG_TTY=$(tty)` to your profile.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message + Environment.NewLine +
+                                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
                 );
             }
 
@@ -279,10 +280,12 @@ namespace GitCredentialManager
             string gpgIdFile = Path.Combine(storeRoot, ".gpg-id");
             if (!_context.FileSystem.FileExists(gpgIdFile))
             {
-                throw new Exception(
-                    $"Password store has not been initialized at '{storeRoot}'; run `pass init <gpg-id>` to initialize the store." +
-                    Environment.NewLine +
-                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                var format =
+                    "Password store has not been initialized at '{0}'; run `pass init <gpg-id>` to initialize the store.";
+                var message = string.Format(format, storeRoot);
+                _context.Trace2.WriteError(message);
+                throw new Exception(message + Environment.NewLine +
+                                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
                 );
             }
         }
@@ -291,10 +294,10 @@ namespace GitCredentialManager
         {
             if (PlatformUtils.IsWindows())
             {
-                throw new Exception(
-                    $"Can not use the '{StoreNames.Cache}' credential store on Windows due to lack of UNIX socket support in Git for Windows." +
-                    Environment.NewLine +
-                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                var message = $"Can not use the '{StoreNames.Cache}' credential store on Windows due to lack of UNIX socket support in Git for Windows.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message + Environment.NewLine +
+                                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
                 );
             }
 
@@ -337,7 +340,9 @@ namespace GitCredentialManager
                     return gpgPath;
                 }
 
-                throw new Exception($"GPG executable does not exist with path '{gpgPath}'");
+                var format = "GPG executable does not exist with path '{0}'";
+                var message = string.Format(format, gpgPath);
+                throw new Trace2Exception(_context.Trace2, message, format);
             }
 
             // If no explicit GPG path is specified, mimic the way `pass`

--- a/src/shared/Core/CredentialStore.cs
+++ b/src/shared/Core/CredentialStore.cs
@@ -79,7 +79,7 @@ namespace GitCredentialManager
 
                 case StoreNames.Gpg:
                     ValidateGpgPass(out string gpgStoreRoot, out string gpgExec);
-                    IGpg gpg = new Gpg(gpgExec, _context.SessionManager, _context.ProcessManager);
+                    IGpg gpg = new Gpg(gpgExec, _context.SessionManager, _context.ProcessManager, _context.Trace2);
                     _backingStore = new GpgPassCredentialStore(_context.FileSystem, gpg, gpgStoreRoot, ns);
                     break;
 

--- a/src/shared/Core/GenericHostProvider.cs
+++ b/src/shared/Core/GenericHostProvider.cs
@@ -194,7 +194,7 @@ namespace GitCredentialManager
                     break;
 
                 default:
-                    throw new Exception("No authentication mode selected!");
+                    throw new Trace2Exception(Context.Trace2, "No authentication mode selected!");
             }
 
             // Store the refresh token if we have one

--- a/src/shared/Core/GenericHostProvider.cs
+++ b/src/shared/Core/GenericHostProvider.cs
@@ -76,7 +76,7 @@ namespace GitCredentialManager
                 Context.Trace.WriteLine($"\tUseAuthHeader   = {oauthConfig.UseAuthHeader}");
                 Context.Trace.WriteLine($"\tDefaultUserName = {oauthConfig.DefaultUserName}");
 
-                return await GetOAuthAccessToken(uri, input.UserName, oauthConfig);
+                return await GetOAuthAccessToken(uri, input.UserName, oauthConfig, Context.Trace2);
             }
             // Try detecting WIA for this remote, if permitted
             else if (IsWindowsAuthAllowed)
@@ -114,7 +114,7 @@ namespace GitCredentialManager
             return await _basicAuth.GetCredentialsAsync(uri.AbsoluteUri, input.UserName);
         }
 
-        private async Task<ICredential> GetOAuthAccessToken(Uri remoteUri, string userName, GenericOAuthConfig config)
+        private async Task<ICredential> GetOAuthAccessToken(Uri remoteUri, string userName, GenericOAuthConfig config, ITrace2 trace2)
         {
             // TODO: Determined user info from a webcall? ID token? Need OIDC support
             string oauthUser = userName ?? config.DefaultUserName;
@@ -123,6 +123,7 @@ namespace GitCredentialManager
                 HttpClient,
                 config.Endpoints,
                 config.ClientId,
+                trace2,
                 config.RedirectUri,
                 config.ClientSecret,
                 config.UseAuthHeader);

--- a/src/shared/Core/Git.cs
+++ b/src/shared/Core/Git.cs
@@ -65,17 +65,20 @@ namespace GitCredentialManager
     public class GitProcess : IGit
     {
         private readonly ITrace _trace;
+        private readonly ITrace2 _trace2;
         private readonly IProcessManager _processManager;
         private readonly string _gitPath;
         private readonly string _workingDirectory;
 
-        public GitProcess(ITrace trace, IProcessManager processManager, string gitPath, string workingDirectory = null)
+        public GitProcess(ITrace trace, ITrace2 trace2, IProcessManager processManager, string gitPath, string workingDirectory = null)
         {
             EnsureArgument.NotNull(trace, nameof(trace));
+            EnsureArgument.NotNull(trace2, nameof(trace2));
             EnsureArgument.NotNull(processManager, nameof(processManager));
             EnsureArgument.NotNullOrWhiteSpace(gitPath, nameof(gitPath));
 
             _trace = trace;
+            _trace2 = trace2;
             _processManager = processManager;
             _gitPath = gitPath;
             _workingDirectory = workingDirectory;

--- a/src/shared/Core/Gpg.cs
+++ b/src/shared/Core/Gpg.cs
@@ -15,15 +15,18 @@ namespace GitCredentialManager
         private readonly string _gpgPath;
         private readonly ISessionManager _sessionManager;
         private readonly IProcessManager _processManager;
+        private readonly ITrace2 _trace2;
 
-        public Gpg(string gpgPath, ISessionManager sessionManager, IProcessManager processManager)
+        public Gpg(string gpgPath, ISessionManager sessionManager, IProcessManager processManager, ITrace2 trace2)
         {
             EnsureArgument.NotNullOrWhiteSpace(gpgPath, nameof(gpgPath));
             EnsureArgument.NotNull(sessionManager, nameof(sessionManager));
+            EnsureArgument.NotNull(trace2, nameof(trace2));
 
             _gpgPath = gpgPath;
             _sessionManager = sessionManager;
             _processManager = processManager;
+            _trace2 = trace2;
         }
 
         public string DecryptFile(string path)

--- a/src/shared/Core/Gpg.cs
+++ b/src/shared/Core/Gpg.cs
@@ -46,7 +46,7 @@ namespace GitCredentialManager
             {
                 if (gpg is null)
                 {
-                    throw new Exception("Failed to start gpg.");
+                    throw new Trace2Exception(_trace2, "Failed to start gpg.");
                 }
 
                 gpg.WaitForExit();
@@ -55,7 +55,9 @@ namespace GitCredentialManager
                 {
                     string stdout = gpg.StandardOutput.ReadToEnd();
                     string stderr = gpg.StandardError.ReadToEnd();
-                    throw new Exception($"Failed to decrypt file '{path}' with gpg. exit={gpg.ExitCode}, out={stdout}, err={stderr}");
+                    var format = "Failed to decrypt file '{0}' with gpg. exit={1}, out={2}, err={3}";
+                    var message = string.Format(format, path, gpg.ExitCode, stdout, stderr);
+                    throw new Trace2Exception(_trace2, message, format);
                 }
 
                 return gpg.StandardOutput.ReadToEnd();
@@ -78,7 +80,7 @@ namespace GitCredentialManager
             {
                 if (gpg is null)
                 {
-                    throw new Exception("Failed to start gpg.");
+                    throw new Trace2Exception(_trace2, "Failed to start gpg.");
                 }
 
                 gpg.StandardInput.Write(contents);
@@ -90,7 +92,9 @@ namespace GitCredentialManager
                 {
                     string stdout = gpg.StandardOutput.ReadToEnd();
                     string stderr = gpg.StandardError.ReadToEnd();
-                    throw new Exception($"Failed to encrypt file '{path}' with gpg. exit={gpg.ExitCode}, out={stdout}, err={stderr}");
+                    var format = "Failed to encrypt file '{0}' with gpg. exit={1}, out={2}, err={3}";
+                    var message = string.Format(format, path, gpg.ExitCode, stdout, stderr);
+                    throw new Trace2Exception(_trace2, message, format);
                 }
             }
         }

--- a/src/shared/Core/HostProviderRegistry.cs
+++ b/src/shared/Core/HostProviderRegistry.cs
@@ -151,7 +151,7 @@ namespace GitCredentialManager
             var uri = input.GetRemoteUri();
             if (uri is null)
             {
-                throw new Exception("Unable to detect host provider without a remote URL");
+                throw new Trace2Exception(_context.Trace2, "Unable to detect host provider without a remote URL");
             }
 
             // We can only probe HTTP(S) URLs - for SMTP, IMAP, etc we cannot do network probing
@@ -240,8 +240,10 @@ namespace GitCredentialManager
                 }
                 catch (Exception ex)
                 {
-                    _context.Trace.WriteLine("Failed to set host provider!");
+                    var message = "Failed to set host provider!";
+                    _context.Trace.WriteLine(message);
                     _context.Trace.WriteException(ex);
+                    _context.Trace2.WriteError(message);
 
                     _context.Streams.Error.WriteLine("warning: failed to remember result of host provider detection!");
                     _context.Streams.Error.WriteLine($"warning: try setting this manually: `git config --global {keyName} {match.Id}`");

--- a/src/shared/Core/HttpClientFactory.cs
+++ b/src/shared/Core/HttpClientFactory.cs
@@ -115,7 +115,9 @@ namespace GitCredentialManager
                 // Throw exception if cert bundle file not found
                 if (!_fileSystem.FileExists(certBundlePath))
                 {
-                    throw new FileNotFoundException($"Custom certificate bundle not found at path: {certBundlePath}", certBundlePath);
+                    var format = "Custom certificate bundle not found at path: {0}";
+                    var message = string.Format(format, certBundlePath);
+                    throw new Trace2FileNotFoundException(_trace2, message, format, certBundlePath);
                 }
 
                 Func<X509Certificate2, X509Chain, SslPolicyErrors, bool> validationCallback = (cert, chain, errors) =>
@@ -280,8 +282,11 @@ namespace GitCredentialManager
                     }
                     catch (Exception ex)
                     {
-                        _trace.WriteLine("Failed to convert proxy bypass hosts to regular expressions; ignoring bypass list");
+                        var message =
+                            "Failed to convert proxy bypass hosts to regular expressions; ignoring bypass list";
+                        _trace.WriteLine(message);
                         _trace.WriteException(ex);
+                        _trace2.WriteError(message);
                         dict["bypass"] = "<< failed to convert >>";
                     }
                 }

--- a/src/shared/Core/Interop/Linux/LinuxTerminal.cs
+++ b/src/shared/Core/Interop/Linux/LinuxTerminal.cs
@@ -36,7 +36,7 @@ namespace GitCredentialManager.Interop.Linux
                 // Capture current terminal settings so we can restore them later
                 if ((error = Termios_Linux.tcgetattr(_fd, out termios_Linux t)) != 0)
                 {
-                    throw new InteropException("Failed to get initial terminal settings", error);
+                    throw new Trace2InteropException(trace2, "Failed to get initial terminal settings", error);
                 }
 
                 _originalTerm = t;
@@ -50,7 +50,7 @@ namespace GitCredentialManager.Interop.Linux
 
                 if ((error = Termios_Linux.tcsetattr(_fd, SetActionFlags.TCSAFLUSH, ref t)) != 0)
                 {
-                    throw new InteropException("Failed to set terminal settings", error);
+                    throw new Trace2InteropException(trace2, "Failed to set terminal settings", error);
                 }
             }
 

--- a/src/shared/Core/Interop/Linux/LinuxTerminal.cs
+++ b/src/shared/Core/Interop/Linux/LinuxTerminal.cs
@@ -7,12 +7,12 @@ namespace GitCredentialManager.Interop.Linux
 {
     public class LinuxTerminal : PosixTerminal
     {
-        public LinuxTerminal(ITrace trace)
-            : base(trace) { }
+        public LinuxTerminal(ITrace trace, ITrace2 trace2)
+            : base(trace, trace2) { }
 
         protected override IDisposable CreateTtyContext(int fd, bool echo)
         {
-            return new TtyContext(Trace, fd, echo);
+            return new TtyContext(Trace, Trace2, fd, echo);
         }
 
         private class TtyContext : IDisposable
@@ -23,7 +23,7 @@ namespace GitCredentialManager.Interop.Linux
             private termios_Linux _originalTerm;
             private bool _isDisposed;
 
-            public TtyContext(ITrace trace, int fd, bool echo)
+            public TtyContext(ITrace trace, ITrace2 trace2, int fd, bool echo)
             {
                 EnsureArgument.NotNull(trace, nameof(trace));
                 EnsureArgument.PositiveOrZero(fd, nameof(fd));

--- a/src/shared/Core/Interop/MacOS/MacOSTerminal.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSTerminal.cs
@@ -7,12 +7,12 @@ namespace GitCredentialManager.Interop.MacOS
 {
     public class MacOSTerminal : PosixTerminal
     {
-        public MacOSTerminal(ITrace trace)
-            : base(trace) { }
+        public MacOSTerminal(ITrace trace, ITrace2 trace2)
+            : base(trace, trace2) { }
 
         protected override IDisposable CreateTtyContext(int fd, bool echo)
         {
-            return new TtyContext(Trace, fd, echo);
+            return new TtyContext(Trace, Trace2, fd, echo);
         }
 
         private class TtyContext : IDisposable
@@ -23,7 +23,7 @@ namespace GitCredentialManager.Interop.MacOS
             private termios_MacOS _originalTerm;
             private bool _isDisposed;
 
-            public TtyContext(ITrace trace, int fd, bool echo)
+            public TtyContext(ITrace trace, ITrace2 trace2, int fd, bool echo)
             {
                 EnsureArgument.NotNull(trace, nameof(trace));
                 EnsureArgument.PositiveOrZero(fd, nameof(fd));

--- a/src/shared/Core/Interop/MacOS/MacOSTerminal.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSTerminal.cs
@@ -36,7 +36,7 @@ namespace GitCredentialManager.Interop.MacOS
                 // Capture current terminal settings so we can restore them later
                 if ((error = Termios_MacOS.tcgetattr(_fd, out termios_MacOS t)) != 0)
                 {
-                    throw new InteropException("Failed to get initial terminal settings", error);
+                    throw new Trace2InteropException(trace2, "Failed to get initial terminal settings", error);
                 }
 
                 _originalTerm = t;
@@ -50,7 +50,7 @@ namespace GitCredentialManager.Interop.MacOS
 
                 if ((error = Termios_MacOS.tcsetattr(_fd, SetActionFlags.TCSAFLUSH, ref t)) != 0)
                 {
-                    throw new InteropException("Failed to set terminal settings", error);
+                    throw new Trace2InteropException(trace2, "Failed to set terminal settings", error);
                 }
             }
 

--- a/src/shared/Core/Interop/Posix/PosixTerminal.cs
+++ b/src/shared/Core/Interop/Posix/PosixTerminal.cs
@@ -13,8 +13,9 @@ namespace GitCredentialManager.Interop.Posix
         private const byte DeleteChar = 127;
 
         protected readonly ITrace Trace;
+        protected readonly ITrace2 Trace2;
 
-        public PosixTerminal(ITrace trace)
+        public PosixTerminal(ITrace trace, ITrace2 trace2)
         {
             PlatformUtils.EnsurePosix();
             EnsureArgument.NotNull(trace, nameof(trace));

--- a/src/shared/Core/Interop/Windows/Native/Win32Error.cs
+++ b/src/shared/Core/Interop/Windows/Native/Win32Error.cs
@@ -100,6 +100,18 @@ namespace GitCredentialManager.Interop.Windows.Native
         /// <summary>
         /// Throw an <see cref="InteropException"/> if <paramref name="succeeded"/> is not true.
         /// </summary>
+        /// <param name="trace2">The application's TRACE2 tracer.</param>
+        /// <param name="succeeded">Windows API return code.</param>
+        /// <param name="defaultErrorMessage">Default error message.</param>
+        /// <exception cref="InteropException">Throw if <paramref name="succeeded"/> is not true.</exception>
+        public static void ThrowIfError(ITrace2 trace2, bool succeeded, string defaultErrorMessage = "Unknown error.")
+        {
+            ThrowIfError(GetLastError(succeeded), defaultErrorMessage, trace2);
+        }
+
+        /// <summary>
+        /// Throw an <see cref="InteropException"/> if <paramref name="succeeded"/> is not true.
+        /// </summary>
         /// <param name="succeeded">Windows API return code.</param>
         /// <param name="defaultErrorMessage">Default error message.</param>
         /// <exception cref="InteropException">Throw if <paramref name="succeeded"/> is not true.</exception>
@@ -113,8 +125,9 @@ namespace GitCredentialManager.Interop.Windows.Native
         /// </summary>
         /// <param name="error">Windows API error code.</param>
         /// <param name="defaultErrorMessage">Default error message.</param>
+        /// <param name="trace2">The application's TRACE2 tracer.</param>
         /// <exception cref="InteropException">Throw if <paramref name="error"/> is not <see cref="Success"/>.</exception>
-        public static void ThrowIfError(int error, string defaultErrorMessage = "Unknown error.")
+        public static void ThrowIfError(int error, string defaultErrorMessage = "Unknown error.", ITrace2 trace2 = null)
         {
             switch (error)
             {
@@ -123,6 +136,8 @@ namespace GitCredentialManager.Interop.Windows.Native
                 default:
                     // The Win32Exception constructor will automatically get the human-readable
                     // message for the error code.
+                    if (trace2 != null)
+                        throw new Trace2InteropException(trace2, defaultErrorMessage, new Win32Exception(error));
                     throw new InteropException(defaultErrorMessage, new Win32Exception(error));
             }
         }

--- a/src/shared/Core/Interop/Windows/WindowsTerminal.cs
+++ b/src/shared/Core/Interop/Windows/WindowsTerminal.cs
@@ -60,7 +60,7 @@ namespace GitCredentialManager.Interop.Windows
                              numberOfCharsWritten: out uint written,
                                          reserved: IntPtr.Zero))
                 {
-                    Win32Error.ThrowIfError(Marshal.GetLastWin32Error());
+                    Win32Error.ThrowIfError(Marshal.GetLastWin32Error(), trace2: _trace2);
                 }
             }
         }
@@ -118,13 +118,13 @@ namespace GitCredentialManager.Interop.Windows
                              numberOfCharsWritten: out written,
                                          reserved: IntPtr.Zero))
                 {
-                    Win32Error.ThrowIfError(Marshal.GetLastWin32Error(), "Failed to write prompt text");
+                    Win32Error.ThrowIfError(Marshal.GetLastWin32Error(), "Failed to write prompt text", _trace2);
                 }
 
                 sb.Clear();
 
                 // Read input from the user
-                using (new TtyContext(_trace, stdin, echo))
+                using (new TtyContext(_trace, _trace2, stdin, echo))
                 {
                     if (!Kernel32.ReadConsole(buffer: sb,
                                   consoleInputHandle: stdin,
@@ -132,7 +132,8 @@ namespace GitCredentialManager.Interop.Windows
                                    numberOfCharsRead: out read,
                                             reserved: IntPtr.Zero))
                     {
-                        Win32Error.ThrowIfError(Marshal.GetLastWin32Error(), "Unable to read prompt input from standard input");
+                        Win32Error.ThrowIfError(Marshal.GetLastWin32Error(),
+                            "Unable to read prompt input from standard input", _trace2);
                     }
 
                     // Record input from the user into local storage, stripping any EOL chars
@@ -152,7 +153,8 @@ namespace GitCredentialManager.Interop.Windows
                                  numberOfCharsWritten: out written,
                                              reserved: IntPtr.Zero))
                     {
-                        Win32Error.ThrowIfError(Marshal.GetLastWin32Error(), "Failed to write final newline in secret prompting");
+                        Win32Error.ThrowIfError(Marshal.GetLastWin32Error(),
+                            "Failed to write final newline in secret prompting", _trace2);
                     }
                 }
 
@@ -163,23 +165,25 @@ namespace GitCredentialManager.Interop.Windows
         private class TtyContext : IDisposable
         {
             private readonly ITrace _trace;
+            private readonly ITrace2 _trace2;
             private readonly SafeFileHandle _stream;
 
             private ConsoleMode _originalMode;
             private bool _isDisposed;
 
-            public TtyContext(ITrace trace, SafeFileHandle stream, bool echo)
+            public TtyContext(ITrace trace, ITrace2 trace2, SafeFileHandle stream, bool echo)
             {
                 EnsureArgument.NotNull(stream, nameof(stream));
 
                 _trace = trace;
+                _trace2 = trace2;
                 _stream = stream;
 
                 // Capture current console mode so we can restore it later
                 ConsoleMode consoleMode;
                 if (!Kernel32.GetConsoleMode(consoleMode: out consoleMode, consoleHandle: stream))
                 {
-                    Win32Error.ThrowIfError(Marshal.GetLastWin32Error(), "Failed to get initial console mode");
+                    Win32Error.ThrowIfError(Marshal.GetLastWin32Error(), "Failed to get initial console mode", trace2);
                 }
 
                 _originalMode = consoleMode;
@@ -191,7 +195,8 @@ namespace GitCredentialManager.Interop.Windows
                     ConsoleMode newConsoleMode = consoleMode ^ ConsoleMode.EchoInput;
                     if (!Kernel32.SetConsoleMode(consoleMode: newConsoleMode, consoleHandle: _stream))
                     {
-                        Win32Error.ThrowIfError(Marshal.GetLastWin32Error(), "Failed to set console mode");
+                        Win32Error.ThrowIfError(
+                            Marshal.GetLastWin32Error(), "Failed to set console mode", trace2);
                     }
                 }
             }

--- a/src/shared/Core/Interop/Windows/WindowsTerminal.cs
+++ b/src/shared/Core/Interop/Windows/WindowsTerminal.cs
@@ -17,12 +17,14 @@ namespace GitCredentialManager.Interop.Windows
         private const string ConsoleOutName = "CONOUT$";
 
         private readonly ITrace _trace;
+        private readonly ITrace2 _trace2;
 
-        public WindowsTerminal(ITrace trace)
+        public WindowsTerminal(ITrace trace, ITrace2 trace2)
         {
             PlatformUtils.EnsureWindows();
 
             _trace = trace;
+            _trace2 = trace2;
         }
 
         public void WriteLine(string format, params object[] args)

--- a/src/shared/Core/Trace2.cs
+++ b/src/shared/Core/Trace2.cs
@@ -214,7 +214,7 @@ public class Trace2 : DisposableObject, ITrace2
             Event = Trace2Event.ChildStart,
             Sid = _sid,
             Time = startTime,
-            File = Path.GetFileName(filePath).ToLower(),
+            File = Path.GetFileName(filePath),
             Line = lineNumber,
             Id = ++_childProcCounter,
             Classification = processClass,
@@ -245,7 +245,7 @@ public class Trace2 : DisposableObject, ITrace2
             Event = Trace2Event.ChildExit,
             Sid = _sid,
             Time = DateTimeOffset.UtcNow,
-            File = Path.GetFileName(filePath).ToLower(),
+            File = Path.GetFileName(filePath),
             Line = lineNumber,
             Id = _childProcCounter,
             Pid = pid,
@@ -340,7 +340,7 @@ public class Trace2 : DisposableObject, ITrace2
             Event = Trace2Event.Version,
             Sid = _sid,
             Time = DateTimeOffset.UtcNow,
-            File = Path.GetFileName(filePath).ToLower(),
+            File = Path.GetFileName(filePath),
             Line = lineNumber,
             Evt = eventFormatVersion,
             Exe = gcmVersion
@@ -369,7 +369,7 @@ public class Trace2 : DisposableObject, ITrace2
             Event = Trace2Event.Start,
             Sid = _sid,
             Time = DateTimeOffset.UtcNow,
-            File = Path.GetFileName(filePath).ToLower(),
+            File = Path.GetFileName(filePath),
             Line = lineNumber,
             Argv = argv,
             ElapsedTime = (DateTimeOffset.UtcNow - _applicationStartTime).TotalSeconds
@@ -385,7 +385,7 @@ public class Trace2 : DisposableObject, ITrace2
             Event = Trace2Event.Exit,
             Sid = _sid,
             Time = DateTimeOffset.Now,
-            File = Path.GetFileName(filePath).ToLower(),
+            File = Path.GetFileName(filePath),
             Line = lineNumber,
             Code = code,
             ElapsedTime = (DateTimeOffset.UtcNow - _applicationStartTime).TotalSeconds
@@ -539,7 +539,7 @@ public abstract class Trace2Message
     private string GetSource()
     {
         // Source column format is file:line
-        string source = $"{File.ToLower()}:{Line}";
+        string source = $"{File}:{Line}";
         if (source.Length > SourceColumnMaxWidth)
         {
             return TraceUtils.FormatSource(source, SourceColumnMaxWidth);

--- a/src/shared/Core/Trace2.cs
+++ b/src/shared/Core/Trace2.cs
@@ -441,27 +441,27 @@ public abstract class Trace2Message
     protected const string EmptyPerformanceSpan =  "|     |           |           |             ";
     protected const string TimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'ffffff'Z'";
 
-    [JsonProperty("event", Order = 1)]
+    [JsonProperty("event")]
     public Trace2Event Event { get; set; }
 
-    [JsonProperty("sid", Order = 2)]
+    [JsonProperty("sid")]
     public string Sid { get; set; }
 
     // TODO: Remove this default value when TRACE2 regions are introduced.
-    [JsonProperty("thread", Order = 3)]
+    [JsonProperty("thread")]
     public string Thread { get; set; } = "main";
 
-    [JsonProperty("time", Order = 4)]
+    [JsonProperty("time")]
     public DateTimeOffset Time { get; set; }
 
-    [JsonProperty("file", Order = 5)]
+    [JsonProperty("file")]
 
     public string File { get; set; }
 
-    [JsonProperty("line", Order = 6)]
+    [JsonProperty("line")]
     public int Line { get; set; }
 
-    [JsonProperty("depth", Order = 7)]
+    [JsonProperty("depth")]
     public int Depth { get; set; }
 
     public abstract string ToJson();
@@ -573,10 +573,10 @@ public abstract class Trace2Message
 
 public class VersionMessage : Trace2Message
 {
-    [JsonProperty("evt", Order = 8)]
+    [JsonProperty("evt")]
     public string Evt { get; set; }
 
-    [JsonProperty("exe", Order = 9)]
+    [JsonProperty("exe")]
     public string Exe { get; set; }
 
     public override string ToJson()
@@ -612,10 +612,10 @@ public class VersionMessage : Trace2Message
 
 public class StartMessage : Trace2Message
 {
-    [JsonProperty("t_abs", Order = 8)]
+    [JsonProperty("t_abs")]
     public double ElapsedTime { get; set; }
 
-    [JsonProperty("argv", Order = 9)]
+    [JsonProperty("argv")]
     public List<string> Argv { get; set; }
 
     public override string ToJson()
@@ -651,10 +651,10 @@ public class StartMessage : Trace2Message
 
 public class ExitMessage : Trace2Message
 {
-    [JsonProperty("t_abs", Order = 8)]
+    [JsonProperty("t_abs")]
     public double ElapsedTime { get; set; }
 
-    [JsonProperty("code", Order = 9)]
+    [JsonProperty("code")]
     public int Code { get; set; }
 
     public override string ToJson()
@@ -690,16 +690,16 @@ public class ExitMessage : Trace2Message
 
 public class ChildStartMessage : Trace2Message
 {
-    [JsonProperty("child_id", Order = 7)]
+    [JsonProperty("child_id")]
     public long Id { get; set; }
 
-    [JsonProperty("child_class", Order = 8)]
+    [JsonProperty("child_class")]
     public Trace2ProcessClass Classification { get; set; }
 
-    [JsonProperty("use_shell", Order = 9)]
+    [JsonProperty("use_shell")]
     public bool UseShell { get; set; }
 
-    [JsonProperty("argv", Order = 10)]
+    [JsonProperty("argv")]
     public IList<string> Argv { get; set; }
 
     public override string ToJson()
@@ -745,16 +745,16 @@ public class ChildStartMessage : Trace2Message
 
 public class ChildExitMessage : Trace2Message
 {
-    [JsonProperty("child_id", Order = 7)]
+    [JsonProperty("child_id")]
     public long Id { get; set; }
 
-    [JsonProperty("pid", Order = 8)]
+    [JsonProperty("pid")]
     public int Pid { get; set; }
 
-    [JsonProperty("code", Order = 9)]
+    [JsonProperty("code")]
     public int Code { get; set; }
 
-    [JsonProperty("t_rel", Order = 10)]
+    [JsonProperty("t_rel")]
     public double ElapsedTime { get; set; }
 
     public override string ToJson()

--- a/src/shared/Core/Trace2Exception.cs
+++ b/src/shared/Core/Trace2Exception.cs
@@ -1,0 +1,75 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using GitCredentialManager.Authentication.OAuth;
+using GitCredentialManager.Interop;
+
+namespace GitCredentialManager;
+
+public class Trace2Exception : Exception
+{
+    public Trace2Exception(ITrace2 trace2, string message) : base(message)
+    {
+        trace2.WriteError(message);
+    }
+
+    public Trace2Exception(ITrace2 trace2, string message, string messageFormat) : base(message)
+    {
+        trace2.WriteError(message, messageFormat);
+    }
+}
+
+public class Trace2InvalidOperationException : InvalidOperationException
+{
+    public Trace2InvalidOperationException(ITrace2 trace2, string message) : base(message)
+    {
+        trace2.WriteError(message);
+    }
+}
+
+public class Trace2OAuth2Exception : OAuth2Exception
+{
+    public Trace2OAuth2Exception(ITrace2 trace2, string message) : base(message)
+    {
+        trace2.WriteError(message);
+    }
+
+    public Trace2OAuth2Exception(ITrace2 trace2, string message, string messageFormat) : base(message)
+    {
+        trace2.WriteError(message, messageFormat);
+    }
+}
+
+public class Trace2InteropException : InteropException
+{
+    public Trace2InteropException(ITrace2 trace2, string message, int errorCode) : base(message, errorCode)
+    {
+        trace2.WriteError($"message: {message} error code: {errorCode}");
+    }
+
+    public Trace2InteropException(ITrace2 trace2, string message, Win32Exception ex) : base(message, ex)
+    {
+        trace2.WriteError(message);
+    }
+}
+
+public class Trace2GitException : GitException
+{
+    public Trace2GitException(ITrace2 trace2, string message, int errorCode, string gitMessage) :
+        base(message, gitMessage, errorCode)
+    {
+        var format = $"message: '{message}' error code: '{errorCode}' git message: '{{0}}'";
+        var traceMessage = string.Format(format, gitMessage);
+
+        trace2.WriteError(traceMessage, format);
+    }
+}
+
+public class Trace2FileNotFoundException : FileNotFoundException
+{
+    public Trace2FileNotFoundException(ITrace2 trace2, string message, string messageFormat, string fileName) :
+        base(message, fileName)
+    {
+        trace2.WriteError(message, messageFormat);
+    }
+}

--- a/src/shared/GitHub.Tests/GitHubAuthenticationTests.cs
+++ b/src/shared/GitHub.Tests/GitHubAuthenticationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using GitCredentialManager;
 using GitCredentialManager.Tests.Objects;
 using Moq;
 using Moq.Protected;
@@ -43,7 +44,7 @@ namespace GitHub.Tests
             var context = new TestCommandContext();
             context.Settings.IsTerminalPromptsEnabled = false;
             var auth = new GitHubAuthentication(context);
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            var exception = await Assert.ThrowsAsync<Trace2InvalidOperationException>(
                 () => auth.GetAuthenticationAsync(null, null, AuthenticationModes.All)
             );
             Assert.Equal("Cannot prompt because terminal prompts have been disabled.", exception.Message);
@@ -68,7 +69,7 @@ namespace GitHub.Tests
             var context = new TestCommandContext();
             context.Settings.IsInteractionAllowed = false;
             var auth = new GitHubAuthentication(context);
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            var exception = await Assert.ThrowsAsync<Trace2InvalidOperationException>(
                 () => auth.GetAuthenticationAsync(new Uri("https://github.com"), null, AuthenticationModes.All)
             );
             Assert.Equal("Cannot prompt because user interactivity has been disabled.", exception.Message);

--- a/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
+++ b/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
@@ -166,7 +166,7 @@ namespace GitHub.Tests
 
             var provider = new GitHubHostProvider(context, ghApi, ghAuth);
 
-            await Assert.ThrowsAsync<Exception>(() => provider.GenerateCredentialAsync(input));
+            await Assert.ThrowsAsync<Trace2Exception>(() => provider.GenerateCredentialAsync(input));
         }
 
         [Fact]

--- a/src/shared/GitHub.UI/Commands/CredentialsCommand.cs
+++ b/src/shared/GitHub.UI/Commands/CredentialsCommand.cs
@@ -81,7 +81,7 @@ namespace GitHub.UI.Commands
 
             if (!viewModel.WindowResult)
             {
-                throw new Exception("User cancelled dialog.");
+                throw new Trace2Exception(Context.Trace2, "User cancelled dialog.");
             }
 
             var result = new Dictionary<string, string>();

--- a/src/shared/GitHub.UI/Commands/DeviceCommand.cs
+++ b/src/shared/GitHub.UI/Commands/DeviceCommand.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Threading;
@@ -38,7 +37,7 @@ namespace GitHub.UI.Commands
 
             if (!viewModel.WindowResult)
             {
-                throw new Exception("User cancelled dialog.");
+                throw new Trace2Exception(Context.Trace2, "User cancelled dialog.");
             }
 
             return 0;

--- a/src/shared/GitHub.UI/Commands/TwoFactorCommand.cs
+++ b/src/shared/GitHub.UI/Commands/TwoFactorCommand.cs
@@ -33,7 +33,7 @@ namespace GitHub.UI.Commands
 
             if (!viewModel.WindowResult)
             {
-                throw new Exception("User cancelled dialog.");
+                throw new Trace2Exception(Context.Trace2, "User cancelled dialog.");
             }
 
             WriteResult(new Dictionary<string, string>

--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -255,7 +255,7 @@ namespace GitHub
         {
             ThrowIfUserInteractionDisabled();
 
-            var oauthClient = new GitHubOAuth2Client(HttpClient, Context.Settings, targetUri);
+            var oauthClient = new GitHubOAuth2Client(HttpClient, Context.Settings, targetUri, Context.Trace2);
 
             // Can we launch the user's default web browser?
             if (!Context.SessionManager.IsWebBrowserAvailable)
@@ -293,7 +293,7 @@ namespace GitHub
         {
             ThrowIfUserInteractionDisabled();
 
-            var oauthClient = new GitHubOAuth2Client(HttpClient, Context.Settings, targetUri);
+            var oauthClient = new GitHubOAuth2Client(HttpClient, Context.Settings, targetUri, Context.Trace2);
             OAuth2DeviceCodeResult dcr = await oauthClient.GetDeviceCodeAsync(scopes, CancellationToken.None);
 
             // If we have a desktop session show the device code in a dialog

--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -109,7 +109,7 @@ namespace GitHub
 
                 if (!resultDict.TryGetValue("mode", out string responseMode))
                 {
-                    throw new Exception("Missing 'mode' in response");
+                    throw new Trace2Exception(Context.Trace2, "Missing 'mode' in response");
                 }
 
                 switch (responseMode.ToLowerInvariant())
@@ -117,7 +117,7 @@ namespace GitHub
                     case "pat":
                         if (!resultDict.TryGetValue("pat", out string pat))
                         {
-                            throw new Exception("Missing 'pat' in response");
+                            throw new Trace2Exception(Context.Trace2, "Missing 'pat' in response");
                         }
 
                         return new AuthenticationPromptResult(
@@ -132,19 +132,20 @@ namespace GitHub
                     case "basic":
                         if (!resultDict.TryGetValue("username", out userName))
                         {
-                            throw new Exception("Missing 'username' in response");
+                            throw new Trace2Exception(Context.Trace2, "Missing 'username' in response");
                         }
 
                         if (!resultDict.TryGetValue("password", out string password))
                         {
-                            throw new Exception("Missing 'password' in response");
+                            throw new Trace2Exception(Context.Trace2, "Missing 'password' in response");
                         }
 
                         return new AuthenticationPromptResult(
                             AuthenticationModes.Basic, new GitCredential(userName, password));
 
                     default:
-                        throw new Exception($"Unknown mode value in response '{responseMode}'");
+                        throw new Trace2Exception(Context.Trace2,
+                            $"Unknown mode value in response '{responseMode}'");
                 }
             }
             else
@@ -227,7 +228,7 @@ namespace GitHub
 
                 if (!resultDict.TryGetValue("code", out string authCode))
                 {
-                    throw new Exception("Missing 'code' in response");
+                    throw new Trace2Exception(Context.Trace2, "Missing 'code' in response");
                 }
 
                 return authCode;
@@ -260,7 +261,8 @@ namespace GitHub
             // Can we launch the user's default web browser?
             if (!Context.SessionManager.IsWebBrowserAvailable)
             {
-                throw new InvalidOperationException("Browser authentication requires a desktop session");
+                throw new Trace2InvalidOperationException(Context.Trace2,
+                    "Browser authentication requires a desktop session");
             }
 
             var browserOptions = new OAuth2WebBrowserOptions
@@ -329,7 +331,8 @@ namespace GitHub
                 }
                 catch (OperationCanceledException)
                 {
-                    throw new Exception("User canceled device code authentication");
+                    throw new Trace2InvalidOperationException(Context.Trace2,
+                        "User canceled device code authentication");
                 }
 
                 // Close the dialog

--- a/src/shared/GitHub/GitHubOAuth2Client.cs
+++ b/src/shared/GitHub/GitHubOAuth2Client.cs
@@ -7,9 +7,9 @@ namespace GitHub
 {
     public class GitHubOAuth2Client : OAuth2Client
     {
-        public GitHubOAuth2Client(HttpClient httpClient, ISettings settings, Uri baseUri)
+        public GitHubOAuth2Client(HttpClient httpClient, ISettings settings, Uri baseUri, ITrace2 trace2)
             : base(httpClient, CreateEndpoints(baseUri),
-                GetClientId(settings), GetRedirectUri(settings), GetClientSecret(settings)) { }
+                GetClientId(settings), trace2, GetRedirectUri(settings), GetClientSecret(settings)) { }
 
         private static OAuth2ServerEndpoints CreateEndpoints(Uri baseUri)
         {

--- a/src/shared/GitLab.Tests/GitLabAuthenticationTests.cs
+++ b/src/shared/GitLab.Tests/GitLabAuthenticationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using GitCredentialManager;
 using GitCredentialManager.Tests.Objects;
 using Xunit;
 
@@ -36,7 +37,7 @@ namespace GitLab.Tests
             var context = new TestCommandContext();
             context.Settings.IsTerminalPromptsEnabled = false;
             var auth = new GitLabAuthentication(context);
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            var exception = await Assert.ThrowsAsync<Trace2InvalidOperationException>(
                 () => auth.GetAuthenticationAsync(null, null, AuthenticationModes.All)
             );
             Assert.Equal("Cannot prompt because terminal prompts have been disabled.", exception.Message);
@@ -87,7 +88,7 @@ namespace GitLab.Tests
             var context = new TestCommandContext();
             context.Settings.IsInteractionAllowed = false;
             var auth = new GitLabAuthentication(context);
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            var exception = await Assert.ThrowsAsync<Trace2InvalidOperationException>(
                 () => auth.GetAuthenticationAsync(new Uri("https://GitLab.com"), null, AuthenticationModes.All)
             );
             Assert.Equal("Cannot prompt because user interactivity has been disabled.", exception.Message);

--- a/src/shared/GitLab.UI/Commands/CredentialsCommand.cs
+++ b/src/shared/GitLab.UI/Commands/CredentialsCommand.cs
@@ -76,7 +76,7 @@ namespace GitLab.UI.Commands
 
             if (!viewModel.WindowResult)
             {
-                throw new Exception("User cancelled dialog.");
+                throw new Trace2Exception(Context.Trace2, "User cancelled dialog.");
             }
 
             var result = new Dictionary<string, string>();

--- a/src/shared/GitLab/GitLabAuthentication.cs
+++ b/src/shared/GitLab/GitLabAuthentication.cs
@@ -87,7 +87,7 @@ namespace GitLab
 
                 if (!resultDict.TryGetValue("mode", out string responseMode))
                 {
-                    throw new Exception("Missing 'mode' in response");
+                    throw new Trace2Exception(Context.Trace2, "Missing 'mode' in response");
                 }
 
                 switch (responseMode.ToLowerInvariant())
@@ -95,7 +95,7 @@ namespace GitLab
                     case "pat":
                         if (!resultDict.TryGetValue("pat", out string pat))
                         {
-                            throw new Exception("Missing 'pat' in response");
+                            throw new Trace2Exception(Context.Trace2, "Missing 'pat' in response");
                         }
 
                         if (!resultDict.TryGetValue("username", out string patUserName))
@@ -112,19 +112,20 @@ namespace GitLab
                     case "basic":
                         if (!resultDict.TryGetValue("username", out userName))
                         {
-                            throw new Exception("Missing 'username' in response");
+                            throw new Trace2Exception(Context.Trace2, "Missing 'username' in response");
                         }
 
                         if (!resultDict.TryGetValue("password", out string password))
                         {
-                            throw new Exception("Missing 'password' in response");
+                            throw new Trace2Exception(Context.Trace2, "Missing 'password' in response");
                         }
 
                         return new AuthenticationPromptResult(
                             AuthenticationModes.Basic, new GitCredential(userName, password));
 
                     default:
-                        throw new Exception($"Unknown mode value in response '{responseMode}'");
+                        throw new Trace2Exception(Context.Trace2,
+                            $"Unknown mode value in response '{responseMode}'");
                 }
             }
             else
@@ -206,7 +207,8 @@ namespace GitLab
             // We require a desktop session to launch the user's default web browser
             if (!Context.SessionManager.IsDesktopSession)
             {
-                throw new InvalidOperationException("Browser authentication requires a desktop session");
+                throw new Trace2InvalidOperationException(Context.Trace2,
+                    "Browser authentication requires a desktop session");
             }
 
             var browserOptions = new OAuth2WebBrowserOptions { };

--- a/src/shared/GitLab/GitLabAuthentication.cs
+++ b/src/shared/GitLab/GitLabAuthentication.cs
@@ -201,7 +201,7 @@ namespace GitLab
         {
             ThrowIfUserInteractionDisabled();
 
-            var oauthClient = new GitLabOAuth2Client(HttpClient, Context.Settings, targetUri);
+            var oauthClient = new GitLabOAuth2Client(HttpClient, Context.Settings, targetUri, Context.Trace2);
 
             // We require a desktop session to launch the user's default web browser
             if (!Context.SessionManager.IsDesktopSession)
@@ -223,7 +223,7 @@ namespace GitLab
 
         public async Task<OAuth2TokenResult> GetOAuthTokenViaRefresh(Uri targetUri, string refreshToken)
         {
-            var oauthClient = new GitLabOAuth2Client(HttpClient, Context.Settings, targetUri);
+            var oauthClient = new GitLabOAuth2Client(HttpClient, Context.Settings, targetUri, Context.Trace2);
             return await oauthClient.GetTokenByRefreshTokenAsync(refreshToken, CancellationToken.None);
         }
 

--- a/src/shared/GitLab/GitLabHostProvider.cs
+++ b/src/shared/GitLab/GitLabHostProvider.cs
@@ -91,7 +91,8 @@ namespace GitLab
             // We should not allow unencrypted communication and should inform the user
             if (StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "http"))
             {
-                throw new Exception("Unencrypted HTTP is not supported for GitLab. Ensure the repository remote URL is using HTTPS.");
+                throw new Trace2Exception(Context.Trace2,
+                    "Unencrypted HTTP is not supported for GitHub. Ensure the repository remote URL is using HTTPS.");
             }
 
             Uri remoteUri = input.GetRemoteUri();

--- a/src/shared/GitLab/GitLabOAuth2Client.cs
+++ b/src/shared/GitLab/GitLabOAuth2Client.cs
@@ -7,9 +7,9 @@ namespace GitLab
 {
     public class GitLabOAuth2Client : OAuth2Client
     {
-        public GitLabOAuth2Client(HttpClient httpClient, ISettings settings, Uri baseUri)
+        public GitLabOAuth2Client(HttpClient httpClient, ISettings settings, Uri baseUri, ITrace2 trace2)
             : base(httpClient, CreateEndpoints(baseUri),
-                GetClientId(settings), GetRedirectUri(settings), GetClientSecret(settings))
+                GetClientId(settings), trace2, GetRedirectUri(settings), GetClientSecret(settings))
         { }
 
         private static OAuth2ServerEndpoints CreateEndpoints(Uri baseUri)

--- a/src/shared/Microsoft.AzureRepos.Tests/AzureDevOpsApiTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureDevOpsApiTests.cs
@@ -274,7 +274,7 @@ namespace Microsoft.AzureRepos.Tests
             context.HttpClientFactory.MessageHandler = httpHandler;
             var api = new AzureDevOpsRestApi(context);
 
-            await Assert.ThrowsAsync<Exception>(() => api.CreatePersonalAccessTokenAsync(orgUri, accessToken, scopes));
+            await Assert.ThrowsAsync<Trace2Exception>(() => api.CreatePersonalAccessTokenAsync(orgUri, accessToken, scopes));
         }
 
         [Fact]
@@ -305,7 +305,7 @@ namespace Microsoft.AzureRepos.Tests
             context.HttpClientFactory.MessageHandler = httpHandler;
             var api = new AzureDevOpsRestApi(context);
 
-            await Assert.ThrowsAsync<Exception>(() => api.CreatePersonalAccessTokenAsync(orgUri, accessToken, scopes));
+            await Assert.ThrowsAsync<Trace2Exception>(() => api.CreatePersonalAccessTokenAsync(orgUri, accessToken, scopes));
         }
 
         [Fact]
@@ -339,7 +339,7 @@ namespace Microsoft.AzureRepos.Tests
             context.HttpClientFactory.MessageHandler = httpHandler;
             var api = new AzureDevOpsRestApi(context);
 
-            Exception exception = await Assert.ThrowsAsync<Exception>(
+            Exception exception = await Assert.ThrowsAsync<Trace2Exception>(
                 () => api.CreatePersonalAccessTokenAsync(orgUri, accessToken, scopes));
 
             Assert.Contains(serverErrorMessage, exception.Message, StringComparison.Ordinal);

--- a/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
@@ -136,7 +136,7 @@ namespace Microsoft.AzureRepos.Tests
 
             var provider = new AzureReposHostProvider(context, azDevOps, msAuth, authorityCache, userMgr);
 
-            await Assert.ThrowsAsync<Exception>(() => provider.GetCredentialAsync(input));
+            await Assert.ThrowsAsync<Trace2Exception>(() => provider.GetCredentialAsync(input));
         }
 
         [Fact]

--- a/src/shared/Microsoft.AzureRepos/AzureDevOpsRestApi.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureDevOpsRestApi.cs
@@ -142,13 +142,13 @@ namespace Microsoft.AzureRepos
                     {
                         if (TryGetFirstJsonStringField(responseText, "message", out string errorMessage))
                         {
-                            throw new Exception($"Failed to create PAT: {errorMessage}");
+                            throw new Trace2Exception(_context.Trace2, $"Failed to create PAT: {errorMessage}");
                         }
                     }
                 }
             }
 
-            throw new Exception("Failed to create PAT");
+            throw new Trace2Exception(_context.Trace2, "Failed to create PAT");
         }
 
         #region Private Methods
@@ -181,7 +181,7 @@ namespace Microsoft.AzureRepos
                 }
             }
 
-            throw new Exception("Failed to find location service");
+            throw new Trace2Exception(_context.Trace2, "Failed to find location service");
         }
 
         #endregion

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -184,7 +184,8 @@ namespace Microsoft.AzureRepos
             // We should not allow unencrypted communication and should inform the user
             if (StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "http"))
             {
-                throw new Exception("Unencrypted HTTP is not supported for Azure Repos. Ensure the repository remote URL is using HTTPS.");
+                throw new Trace2Exception(_context.Trace2,
+                    "Unencrypted HTTP is not supported for Azure Repos. Ensure the repository remote URL is using HTTPS.");
             }
 
             Uri remoteUri = input.GetRemoteUri();
@@ -227,7 +228,8 @@ namespace Microsoft.AzureRepos
             // We should not allow unencrypted communication and should inform the user
             if (StringComparer.OrdinalIgnoreCase.Equals(remoteUri.Scheme, "http"))
             {
-                throw new Exception("Unencrypted HTTP is not supported for Azure Repos. Ensure the repository remote URL is using HTTPS.");
+                throw new Trace2Exception(_context.Trace2,
+                    "Unencrypted HTTP is not supported for Azure Repos. Ensure the repository remote URL is using HTTPS.");
             }
 
             Uri orgUri = UriHelpers.CreateOrganizationUri(remoteUri, out string orgName);

--- a/src/shared/TestInfrastructure/Objects/NullTrace.cs
+++ b/src/shared/TestInfrastructure/Objects/NullTrace.cs
@@ -78,6 +78,12 @@ namespace GitCredentialManager.Tests.Objects
             string filePath = "",
             int lineNumber = 0) { }
 
+        public void WriteError(string errorMessage,
+            string parameterizedMessage = null,
+            string filePath = "",
+            int lineNumber = 0)
+        { }
+
         public string SetSid() { return ""; }
 
         #endregion


### PR DESCRIPTION
This series adds the `TRACE2` error event.

The first two commits are opportunistic fixes that remove unnecessary components of `Trace2` messages. The next four commits add `Trace2` as a dependency to certain classes where exceptions are thrown in order to capture those exceptions with the new error event. The seventh commit adds the error event, and eighth adds special exceptions that write to `Trace2`. Finally, the ninth commit adds error tracing exceptions and messages throughout the GCM codebase.