### PR TITLE
Ensure we init IEnvironment before SessionManager

### DIFF
--- a/src/shared/Core/CommandContext.cs
+++ b/src/shared/Core/CommandContext.cs
@@ -118,8 +118,8 @@ namespace GitCredentialManager
             else if (PlatformUtils.IsMacOS())
             {
                 FileSystem        = new MacOSFileSystem();
-                SessionManager    = new MacOSSessionManager(Environment, FileSystem);
                 Environment       = new MacOSEnvironment(FileSystem);
+                SessionManager    = new MacOSSessionManager(Environment, FileSystem);
                 ProcessManager    = new ProcessManager(Trace2);
                 Terminal          = new MacOSTerminal(Trace);
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
@@ -134,8 +134,8 @@ namespace GitCredentialManager
             else if (PlatformUtils.IsLinux())
             {
                 FileSystem        = new LinuxFileSystem();
-                SessionManager    = new LinuxSessionManager(Environment, FileSystem);
                 Environment       = new PosixEnvironment(FileSystem);
+                SessionManager    = new LinuxSessionManager(Environment, FileSystem);
                 ProcessManager    = new ProcessManager(Trace2);
                 Terminal          = new LinuxTerminal(Trace);
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);

--- a/src/shared/Core/ISessionManager.cs
+++ b/src/shared/Core/ISessionManager.cs
@@ -22,6 +22,9 @@ namespace GitCredentialManager
 
         protected SessionManager(IEnvironment env, IFileSystem fs)
         {
+            EnsureArgument.NotNull(env, nameof(env));
+            EnsureArgument.NotNull(fs, nameof(fs));
+
             Environment = env;
             FileSystem = fs;
         }


### PR DESCRIPTION
Ensure we have an instance of IEnvironment before we pass it to the SessionManager contructor.

Also add some null guards to catch this problem earlier in the future.