### PR TITLE
Ensure we start child processes created with `ProcessManager`

### DIFF
--- a/src/shared/Core/ChildProcess.cs
+++ b/src/shared/Core/ChildProcess.cs
@@ -36,7 +36,7 @@ public class ChildProcess : DisposableObject
         Process.Exited += ProcessOnExited;
     }
 
-    public void Start(Trace2ProcessClass processClass)
+    public bool Start(Trace2ProcessClass processClass)
     {
         ThrowIfDisposed();
         // Record the time just before the process starts, since:
@@ -51,7 +51,7 @@ public class ChildProcess : DisposableObject
             _startInfo.UseShellExecute,
             _startInfo.FileName,
             _startInfo.Arguments);
-        Process.Start();
+        return Process.Start();
     }
 
     public void WaitForExit() => Process.WaitForExit();

--- a/src/shared/Core/Git.cs
+++ b/src/shared/Core/Git.cs
@@ -210,7 +210,7 @@ namespace GitCredentialManager
             };
 
             var process = _processManager.CreateProcess(procStartInfo);
-            if (process is null)
+            if (!process.Start(Trace2ProcessClass.Git))
             {
                 var format = "Failed to start Git helper '{0}'";
                 var message = string.Format(format, args);

--- a/src/shared/Core/Gpg.cs
+++ b/src/shared/Core/Gpg.cs
@@ -44,7 +44,7 @@ namespace GitCredentialManager
 
             using (var gpg = _processManager.CreateProcess(psi))
             {
-                if (gpg is null)
+                if (!gpg.Start(Trace2ProcessClass.Other))
                 {
                     throw new Trace2Exception(_trace2, "Failed to start gpg.");
                 }
@@ -78,7 +78,7 @@ namespace GitCredentialManager
 
             using (var gpg = _processManager.CreateProcess(psi))
             {
-                if (gpg is null)
+                if (!gpg.Start(Trace2ProcessClass.Other))
                 {
                     throw new Trace2Exception(_trace2, "Failed to start gpg.");
                 }


### PR DESCRIPTION
Ensure that we actually start processes (and check they have started correctly) using the new ProcessManager/ChildProcess abstractions.

Fixes #1170
Replaces #1171 