### PR TITLE
Target *-latest runner images in CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, windows-2019, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
We are using the `*-latest` runner images for release builds ([win](https://github.com/git-ecosystem/git-credential-manager/blob/e36952e16700cc829ea79f65a29424d164ad4e1a/.github/workflows/release.yml#L253), [linux](https://github.com/git-ecosystem/git-credential-manager/blob/e36952e16700cc829ea79f65a29424d164ad4e1a/.github/workflows/release.yml#L361)), but for CI we're instead using `ubuntu-18.04`, `ubuntu-20.04`, and `windows-2019` (alongside `macos-latest`).

Let's run CI against the latest of all three OS images to match what we're using to build release bits.

Ubuntu 18.04 is also [deprecated](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) as a GitHub hosted runner.