### PR TITLE
Add support for GitHub enterprise-managed user accounts

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -434,6 +434,27 @@ Defaults to undefined.
 
 ---
 
+### credential.gitHubAccountFiltering
+
+Enable or disable automatic account filtering for GitHub based on server hints
+when there are multiple available accounts. This setting is only applicable to
+GitHub.com with [Enterprise Managed Users][github-emu].
+
+Value|Description
+-|-
+`true` _(default)_|Filter available accounts based on server hints.
+`false`|Show all available accounts.
+
+#### Example
+
+```shell
+git config --global credential.gitHubAccountFiltering "false"
+```
+
+**Also see: [GCM_GITHUB_ACCOUNTFILTERING][gcm-github-accountfiltering]**
+
+---
+
 ### credential.gitHubAuthModes
 
 Override the available authentication modes presented during GitHub
@@ -863,6 +884,7 @@ Defaults to disabled.
 [gcm-credential-store]: environment.md#GCM_CREDENTIAL_STORE
 [gcm-debug]: environment.md#GCM_DEBUG
 [gcm-dpapi-store-path]: environment.md#GCM_DPAPI_STORE_PATH
+[gcm-github-accountfiltering]: environment.md#GCM_GITHUB_ACCOUNTFILTERING
 [gcm-github-authmodes]: environment.md#GCM_GITHUB_AUTHMODES
 [gcm-gitlab-authmodes]:environment.md#GCM_GITLAB_AUTHMODES
 [gcm-gui-prompt]: environment.md#GCM_GUI_PROMPT
@@ -877,6 +899,7 @@ Defaults to disabled.
 [gcm-trace]: environment.md#GCM_TRACE
 [gcm-trace-secrets]: environment.md#GCM_TRACE_SECRETS
 [gcm-trace-msauth]: environment.md#GCM_TRACE_MSAUTH
+[github-emu]: https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users
 [usage]: usage.md
 [git-config-http-proxy]: https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpproxy
 [http-proxy]: netconfig.md#http-proxy

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -525,6 +525,33 @@ Defaults to undefined.
 
 ---
 
+### GCM_GITHUB_ACCOUNTFILTERING
+
+Enable or disable automatic account filtering for GitHub based on server hints
+when there are multiple available accounts. This setting is only applicable to
+GitHub.com with [Enterprise Managed Users][github-emu].
+
+Value|Description
+-|-
+`true` _(default)_|Filter available accounts based on server hints.
+`false`|Show all available accounts.
+
+#### Windows
+
+```batch
+SET GCM_GITHUB_ACCOUNTFILTERING=false
+```
+
+#### macOS/Linux
+
+```bash
+export GCM_GITHUB_ACCOUNTFILTERING=false
+```
+
+**Also see: [credential.gitHubAccountFiltering][credential-githubaccountfiltering]**
+
+---
+
 ### GCM_GITHUB_AUTHMODES
 
 Override the available authentication modes presented during GitHub
@@ -964,6 +991,7 @@ Defaults to disabled.
 [credential-credentialstore]: configuration.md#credentialcredentialstore
 [credential-debug]: configuration.md#credentialdebug
 [credential-dpapi-store-path]: configuration.md#credentialdpapistorepath
+[credential-githubaccountfiltering]: configuration.md#credentialgitHubAccountFiltering
 [credential-githubauthmodes]: configuration.md#credentialgitHubAuthModes
 [credential-gitlabauthmodes]: configuration.md#credentialgitLabAuthModes
 [credential-guiprompt]: configuration.md#credentialguiprompt
@@ -991,6 +1019,7 @@ Defaults to disabled.
 [git-cache-options]: https://git-scm.com/docs/git-credential-cache#_options
 [git-credential-cache]: https://git-scm.com/docs/git-credential-cache
 [git-httpproxy]: https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpproxy
+[github-emu]: https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users
 [network-http-proxy]: netconfig.md#http-proxy
 [libsecret]: https://wiki.gnome.org/Projects/Libsecret
 [migration-guide]: migration.md#gcm_authority

--- a/src/shared/GitHub.Tests/GitHubAuthChallengeTests.cs
+++ b/src/shared/GitHub.Tests/GitHubAuthChallengeTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace GitHub.Tests;
+
+public class GitHubAuthChallengeTests
+{
+    [Fact]
+    public void GitHubAuthChallenge_FromHeaders_CaseInsensitive()
+    {
+        var headers = new[]
+        {
+            "BASIC REALM=\"GITHUB\"",
+            "basic realm=\"github\"",
+            "bAsIc ReAlM=\"gItHuB\"",
+        };
+
+        IList<GitHubAuthChallenge> challenges = GitHubAuthChallenge.FromHeaders(headers);
+        Assert.Equal(3, challenges.Count);
+
+        foreach (var challenge in challenges)
+        {
+            Assert.Null(challenge.Domain);
+            Assert.Null(challenge.Enterprise);
+        }
+    }
+
+    [Fact]
+    public void GitHubAuthChallenge_FromHeaders_MultipleRealms_ReturnsGitHubOnly()
+    {
+        var headers = new[]
+        {
+            "Basic realm=\"contoso\"",
+            "Basic realm=\"GitHub\"",
+            "Basic realm=\"fabrikam\"",
+        };
+
+        IList<GitHubAuthChallenge> challenges = GitHubAuthChallenge.FromHeaders(headers);
+        Assert.Single(challenges);
+
+        Assert.Null(challenges[0].Domain);
+        Assert.Null(challenges[0].Enterprise);
+    }
+
+    [Fact]
+    public void GitHubAuthChallenge_FromHeaders_NoMatchingRealms_ReturnsEmpty()
+    {
+        var headers = new[]
+        {
+            "Basic realm=\"contoso\"",
+            "Basic realm=\"fabrikam\"",
+            "Basic realm=\"example\"",
+        };
+
+        IList<GitHubAuthChallenge> challenges = GitHubAuthChallenge.FromHeaders(headers);
+        Assert.Empty(challenges);
+    }
+
+    [Theory]
+    [InlineData("Basic realm=\"GitHub\" enterprise_hint=\"contoso-corp\" domain_hint=\"contoso\"", "contoso", "contoso-corp")]
+    [InlineData("Basic realm=\"GitHub\" domain_hint=\"contoso\"", "contoso", null)]
+    [InlineData("Basic realm=\"GitHub\" enterprise_hint=\"contoso-corp\"", null, "contoso-corp")]
+    [InlineData("Basic realm=\"GitHub\" domain_hint=\"fab\" enterprise_hint=\"fabirkamopensource\"", "fab", "fabirkamopensource")]
+    [InlineData("Basic enterprise_hint=\"iana\" realm=\"GitHub\" domain_hint=\"example\"", "example", "iana")]
+    [InlineData("Basic domain_hint=\"test\" enterprise_hint=\"test-inc\" realm=\"GitHub\"", "test", "test-inc")]
+    public void GitHubAuthChallenge_FromHeaders_Hints_ReturnsWithHints(string header, string domain, string enterprise)
+    {
+        IList<GitHubAuthChallenge> challenges = GitHubAuthChallenge.FromHeaders(new[] { header });
+        Assert.Single(challenges);
+
+        Assert.Equal(domain, challenges[0].Domain);
+        Assert.Equal(enterprise, challenges[0].Enterprise);
+    }
+
+    [Fact]
+    public void GitHubAuthChallenge_FromHeaders_EmptyHeaders_ReturnsEmpty()
+    {
+        string[] headers = Array.Empty<string>();
+        IList<GitHubAuthChallenge> challenges = GitHubAuthChallenge.FromHeaders(headers);
+        Assert.Empty(challenges);
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData(" ", false)]
+    [InlineData("alice", true)]
+    [InlineData("alice_contoso", false)]
+    [InlineData("alice_CONTOSO", false)]
+    [InlineData("alice_contoso_alt", false)]
+    [InlineData("pj_nitin", true)]
+    [InlineData("up_the_irons", true)]
+    public void GitHubAuthChallenge_IsDomainMember_NoHint(string userName, bool expected)
+    {
+        var challenge = new GitHubAuthChallenge();
+        Assert.Equal(expected, challenge.IsDomainMember(userName));
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData(" ", false)]
+    [InlineData("alice", false)]
+    [InlineData("alice_contoso", true)]
+    [InlineData("alice_CONTOSO", true)]
+    [InlineData("alice_contoso_alt", false)]
+    [InlineData("pj_nitin", false)]
+    [InlineData("up_the_irons", false)]
+    public void GitHubAuthChallenge_IsDomainMember_DomainHint(string userName, bool expected)
+    {
+        var realm = new GitHubAuthChallenge("contoso", "contoso-corp");
+        Assert.Equal(expected, realm.IsDomainMember(userName));
+    }
+
+    [Fact]
+    public void GitHubAuthChallenge_Equals_Null_ReturnsFalse()
+    {
+        var challenge = new GitHubAuthChallenge("contoso", "contoso-corp");
+        Assert.False(challenge.Equals(null));
+    }
+
+    [Fact]
+    public void GitHubAuthChallenge_Equals_SameInstance_ReturnsTrue()
+    {
+        var challenge = new GitHubAuthChallenge("contoso", "contoso-corp");
+        Assert.True(challenge.Equals(challenge));
+    }
+
+    [Fact]
+    public void GitHubAuthChallenge_Equals_DifferentInstance_ReturnsTrue()
+    {
+        var challenge1 = new GitHubAuthChallenge("contoso", "constoso-corp");
+        var challenge2 = new GitHubAuthChallenge("contoso", "constoso-corp");
+        Assert.True(challenge1.Equals(challenge2));
+    }
+
+    [Fact]
+    public void GitHubAuthChallenge_Equals_DifferentCase_ReturnsTrue()
+    {
+        var challenge1 = new GitHubAuthChallenge("contoso", "contoso-corp");
+        var challenge2 = new GitHubAuthChallenge("CONTOSO", "CONTOSO-CORP");
+        Assert.True(challenge1.Equals(challenge2));
+    }
+
+    [Fact]
+    public void GitHubAuthChallenge_Equals_DifferentShortCode_ReturnsFalse()
+    {
+        var challenge1 = new GitHubAuthChallenge("contoso", "constoso-corp");
+        var challenge2 = new GitHubAuthChallenge("fab", "fabrikamopensource");
+        Assert.False(challenge1.Equals(challenge2));
+    }
+}

--- a/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
+++ b/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
@@ -64,7 +64,6 @@ namespace GitHub.Tests
             Assert.Equal(expected, provider.IsSupported(input));
         }
 
-
         [Theory]
         [InlineData("https", "github.com", "https://github.com")]
         [InlineData("https", "GitHub.Com", "https://github.com")]
@@ -149,6 +148,176 @@ namespace GitHub.Tests
             AuthenticationModes actualModes = await provider.GetSupportedAuthenticationModesAsync(targetUri);
 
             Assert.Equal(expectedModes, actualModes);
+        }
+
+        [Fact]
+        public async Task GitHubHostProvider_GetCredentialAsync_NoCredentials_NoUserNoHeaders_PromptsUser()
+        {
+            var input = new InputArguments(
+                new Dictionary<string, string>
+                {
+                    ["protocol"] = "https",
+                    ["host"] = "github.com",
+                }
+            );
+
+            var newCredential = new GitCredential("alice", "password");
+
+            var context = new TestCommandContext();
+            var ghApiMock = new Mock<IGitHubRestApi>(MockBehavior.Strict);
+            var ghAuthMock = new Mock<IGitHubAuthentication>(MockBehavior.Strict);
+            ghAuthMock.Setup(x => x.GetAuthenticationAsync(
+                    It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<AuthenticationModes>()))
+                .ReturnsAsync(new AuthenticationPromptResult(AuthenticationModes.Pat, newCredential));
+
+            var provider = new GitHubHostProvider(context, ghApiMock.Object, ghAuthMock.Object);
+
+            ICredential result = await provider.GetCredentialAsync(input);
+
+            Assert.Equal(result.Account, newCredential.Account);
+            Assert.Equal(result.Password, newCredential.Password);
+            ghAuthMock.Verify(x => x.GetAuthenticationAsync(
+                new Uri("https://github.com"), null, It.IsAny<AuthenticationModes>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GitHubHostProvider_GetCredentialAsync_InputUser_ReturnsCredentialForUser()
+        {
+            var input = new InputArguments(
+                new Dictionary<string, string>
+                {
+                    ["protocol"] = "https",
+                    ["host"]     = "github.com",
+                    ["username"] = "alice"
+                }
+            );
+
+            var context = new TestCommandContext();
+            context.CredentialStore.Add("https://github.com", "alice", "letmein123");
+            context.CredentialStore.Add("https://github.com", "bob", "secret123");
+
+            var ghApiMock = new Mock<IGitHubRestApi>(MockBehavior.Strict);
+            var ghAuthMock = new Mock<IGitHubAuthentication>(MockBehavior.Strict);
+
+            var provider = new GitHubHostProvider(context, ghApiMock.Object, ghAuthMock.Object);
+
+            ICredential result = await provider.GetCredentialAsync(input);
+
+            Assert.NotNull(result);
+            Assert.Equal("alice", result.Account);
+            Assert.Equal("letmein123", result.Password);
+        }
+
+        [Fact]
+        public async Task GitHubHostProvider_GetCredentialAsync_OneDomainAccount_ReturnsCredentialForRealmAccount()
+        {
+            var input = new InputArguments(
+                new Dictionary<string, string>
+                {
+                    ["protocol"] = "https",
+                    ["host"]     = "github.com",
+                    ["wwwauth"]  = "Basic realm=\"GitHub\" domain_hint=\"contoso\"",
+                }
+            );
+
+            var context = new TestCommandContext();
+            context.CredentialStore.Add("https://github.com", "alice", "letmein123");
+            context.CredentialStore.Add("https://github.com", "bob_contoso", "secret123");
+            context.CredentialStore.Add("https://github.com", "test_fabrikam", "hidden_value");
+
+            var ghApiMock = new Mock<IGitHubRestApi>(MockBehavior.Strict);
+            var ghAuthMock = new Mock<IGitHubAuthentication>(MockBehavior.Strict);
+
+            var provider = new GitHubHostProvider(context, ghApiMock.Object, ghAuthMock.Object);
+
+            ICredential result = await provider.GetCredentialAsync(input);
+
+            Assert.NotNull(result);
+            Assert.Equal("bob_contoso", result.Account);
+            Assert.Equal("secret123", result.Password);
+        }
+
+        [Fact]
+        public async Task GitHubHostProvider_GetCredentialAsync_MultipleDomainAccounts_PromptForAccountAndReturnCredentialForAccount()
+        {
+            var input = new InputArguments(
+                new Dictionary<string, string>
+                {
+                    ["protocol"] = "https",
+                    ["host"]     = "github.com",
+                    ["wwwauth"]  = "Basic realm=\"GitHub\" domain_hint=\"contoso\"",
+                }
+            );
+
+            var context = new TestCommandContext();
+            context.CredentialStore.Add("https://github.com", "alice", "letmein123");
+            context.CredentialStore.Add("https://github.com", "bob_contoso", "secret123");
+            context.CredentialStore.Add("https://github.com", "john_contoso", "who_knows");
+
+            var ghApiMock = new Mock<IGitHubRestApi>(MockBehavior.Strict);
+            var ghAuthMock = new Mock<IGitHubAuthentication>(MockBehavior.Strict);
+
+            ghAuthMock.Setup(x => x.SelectAccountAsync(It.IsAny<Uri>(), It.IsAny<IEnumerable<string>>()))
+                .ReturnsAsync("john_contoso");
+
+            var provider = new GitHubHostProvider(context, ghApiMock.Object, ghAuthMock.Object);
+
+            ICredential result = await provider.GetCredentialAsync(input);
+
+            Assert.NotNull(result);
+            Assert.Equal("john_contoso", result.Account);
+            Assert.Equal("who_knows", result.Password);
+
+            ghAuthMock.Verify(x => x.SelectAccountAsync(
+                    new Uri("https://github.com"), new[] { "bob_contoso", "john_contoso" }),
+                Times.Once
+            );
+        }
+
+        [Fact]
+        public async Task GitHubHostProvider_GetCredentialAsync_MultipleDomainAccounts_PromptForAccountNewAccount()
+        {
+            var input = new InputArguments(
+                new Dictionary<string, string>
+                {
+                    ["protocol"] = "https",
+                    ["host"]     = "github.com",
+                    ["wwwauth"]  = "Basic realm=\"GitHub\" domain_hint=\"contoso\"",
+                }
+            );
+
+            var newCredential = new GitCredential("alice", "password");
+
+            var context = new TestCommandContext();
+            context.CredentialStore.Add("https://github.com", "alice", "letmein123");
+            context.CredentialStore.Add("https://github.com", "bob_contoso", "secret123");
+            context.CredentialStore.Add("https://github.com", "john_contoso", "who_knows");
+
+            var ghApiMock = new Mock<IGitHubRestApi>(MockBehavior.Strict);
+            var ghAuthMock = new Mock<IGitHubAuthentication>(MockBehavior.Strict);
+
+            ghAuthMock.Setup(x => x.SelectAccountAsync(It.IsAny<Uri>(), It.IsAny<IEnumerable<string>>()))
+                .ReturnsAsync((string)null);
+
+            ghAuthMock.Setup(x => x.GetAuthenticationAsync(
+                    It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<AuthenticationModes>()))
+                .ReturnsAsync(new AuthenticationPromptResult(AuthenticationModes.Pat, newCredential));
+
+            var provider = new GitHubHostProvider(context, ghApiMock.Object, ghAuthMock.Object);
+
+            ICredential result = await provider.GetCredentialAsync(input);
+
+            Assert.Equal(newCredential.Account, result.Account);
+            Assert.Equal(newCredential.Password, result.Password);
+
+            ghAuthMock.Verify(x => x.GetAuthenticationAsync(
+                    new Uri("https://github.com"), null, It.IsAny<AuthenticationModes>()),
+                Times.Once);
+            ghAuthMock.Verify(x => x.SelectAccountAsync(
+                    new Uri("https://github.com"), new[] { "bob_contoso", "john_contoso" }),
+                Times.Once
+            );
         }
 
         [Fact]

--- a/src/shared/GitHub/GitHubAuthChallenge.cs
+++ b/src/shared/GitHub/GitHubAuthChallenge.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace GitHub;
+
+public class GitHubAuthChallenge : IEquatable<GitHubAuthChallenge>
+{
+    private static readonly Regex BasicRegex = new(@"Basic\s+(?'props1'.*)realm=""GitHub""(?'props2'.*)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    public static IList<GitHubAuthChallenge> FromHeaders(IEnumerable<string> headers)
+    {
+        var challenges = new List<GitHubAuthChallenge>();
+        foreach (string header in headers)
+        {
+            var match = BasicRegex.Match(header);
+            if (match.Success)
+            {
+                IDictionary<string, string> props = ParseProperties(match.Groups["props1"].Value + match.Groups["props2"]);
+
+                // The enterprise shortcode is provided in the `domain_hint` property, whereas the
+                // enterprise name/slug is provided in the `enterprise_hint` property.
+                props.TryGetValue("domain_hint", out string domain);
+                props.TryGetValue("enterprise_hint", out string enterprise);
+
+                var challenge = new GitHubAuthChallenge(domain, enterprise);
+
+                challenges.Add(challenge);
+            }
+        }
+
+        return challenges;
+    }
+
+    private static IDictionary<string, string> ParseProperties(string str)
+    {
+        var props = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string prop in str.Split(' '))
+        {
+            int delim = prop.IndexOf('=');
+            if (delim < 0)
+            {
+                continue;
+            }
+
+            string key = prop.Substring(0, delim).Trim();
+            string value = prop.Substring(delim + 1).Trim('"');
+
+            props[key] = value;
+        }
+
+        return props;
+    }
+
+    public GitHubAuthChallenge() { }
+
+    public GitHubAuthChallenge(string domain, string enterprise)
+    {
+        Domain = domain;
+        Enterprise = enterprise;
+    }
+
+    public string Domain { get; }
+
+    public string Enterprise { get; }
+
+    public bool IsDomainMember(string userName)
+    {
+        if (string.IsNullOrWhiteSpace(userName))
+        {
+            return false;
+        }
+
+        int delim = userName.LastIndexOf('_');
+        if (delim < 0)
+        {
+            return string.IsNullOrWhiteSpace(Domain);
+        }
+
+        // Check for users that contain underscores but are not EMU logins
+        if (GitHubConstants.InvalidUnderscoreLogins.Contains(userName, StringComparer.OrdinalIgnoreCase))
+        {
+            return string.IsNullOrWhiteSpace(Domain);
+        }
+
+        string shortCode = userName.Substring(delim + 1);
+        return StringComparer.OrdinalIgnoreCase.Equals(Domain, shortCode);
+    }
+
+    public bool Equals(GitHubAuthChallenge other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return string.Equals(Domain, other.Domain, StringComparison.OrdinalIgnoreCase) &&
+               string.Equals(Enterprise, other.Enterprise, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != GetType()) return false;
+        return Equals((GitHubAuthChallenge)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return Domain.GetHashCode() * 1019 ^
+               Enterprise.GetHashCode() * 337;
+    }
+}

--- a/src/shared/GitHub/GitHubConstants.cs
+++ b/src/shared/GitHub/GitHubConstants.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace GitHub
 {
@@ -18,6 +19,11 @@ namespace GitHub
         public static readonly Uri OAuthAuthorizationEndpointRelativeUri = new Uri("/login/oauth/authorize", UriKind.Relative);
         public static readonly Uri OAuthTokenEndpointRelativeUri = new Uri("/login/oauth/access_token", UriKind.Relative);
         public static readonly Uri OAuthDeviceEndpointRelativeUri = new Uri("/login/device/code", UriKind.Relative);
+
+        /// <summary>
+        /// GitHub user names that contain underscores but are not EMU logins.
+        /// </summary>
+        public static readonly IReadOnlyList<string> InvalidUnderscoreLogins = new[] { "pj_nitin", "up_the_irons" };
 
         /// <summary>
         /// The GitHub required HTTP accepts header value
@@ -59,6 +65,7 @@ namespace GitHub
             public const string DevOAuthClientId = "GCM_DEV_GITHUB_CLIENTID";
             public const string DevOAuthClientSecret = "GCM_DEV_GITHUB_CLIENTSECRET";
             public const string DevOAuthRedirectUri = "GCM_DEV_GITHUB_REDIRECTURI";
+            public const string AccountFiltering = "GCM_GITHUB_ACCOUNTFILTERING";
         }
 
         public static class GitConfiguration
@@ -70,6 +77,7 @@ namespace GitHub
                 public const string DevOAuthClientId = "gitHubDevClientId";
                 public const string DevOAuthClientSecret = "gitHubDevClientSecret";
                 public const string DevOAuthRedirectUri = "gitHubDevRedirectUri";
+                public const string AccountFiltering = "githubAccountFiltering";
             }
         }
     }

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -135,6 +135,7 @@ namespace GitHub
             // are multiple options.
             string userName = input.UserName;
             bool addAccount = false;
+            bool filtered = false;
             if (string.IsNullOrWhiteSpace(userName))
             {
                 IList<string> accounts = _context.CredentialStore.GetAccounts(service);
@@ -143,6 +144,8 @@ namespace GitHub
                 {
                     _context.Trace.WriteLine($"  {account}");
                 }
+
+                filtered = FilterAccounts(remoteUri, input.WwwAuth, ref accounts);
 
                 switch (accounts.Count)
                 {
@@ -159,15 +162,15 @@ namespace GitHub
                 }
             }
 
-            // Always try and locate an existing credential in the OS credential store
-            // unless we're being told to explicitly add a new account. If the account lookup
-            // failed above we should still try to lookup an existing credential.
+            // Always try and locate an existing credential in the OS credential store unless we're being
+            // told to explicitly add a new account OR have specifically filtered out irrelevant accounts.
+            // If the account lookup failed for another reason we should still try to lookup an existing credential.
             ICredential credential = null;
             if (addAccount)
             {
                 _context.Trace.WriteLine("Adding a new account!");
             }
-            else
+            else if (!string.IsNullOrWhiteSpace(userName) || !filtered)
             {
                 _context.Trace.WriteLine($"Looking for existing credential in store with service={service} account={userName}...");
                 credential = _context.CredentialStore.Get(service, userName);
@@ -188,6 +191,53 @@ namespace GitHub
             }
 
             return credential;
+        }
+
+        private bool FilterAccounts(Uri remoteUri, IEnumerable<string> wwwAuth, ref IList<string> accounts)
+        {
+            if (!IsGitHubDotCom(remoteUri))
+            {
+                _context.Trace.WriteLine("No account filtering outside of GitHub.com.");
+            }
+
+            // Allow the user to disable account filtering until this feature stabilises.
+            // Default to enabled.
+            bool enableFiltering = !_context.Settings.TryGetSetting(
+                GitHubConstants.EnvironmentVariables.AccountFiltering,
+                Constants.GitConfiguration.Credential.SectionName,
+                GitHubConstants.GitConfiguration.Credential.AccountFiltering,
+                out string enableFilteringStr
+            ) || enableFilteringStr.ToBooleanyOrDefault(true);
+
+            if (!enableFiltering)
+            {
+                _context.Trace.WriteLine("Account filtering is disabled.");
+                return false;
+            }
+
+            _context.Trace.WriteLine("Account filtering is enabled.");
+
+            // If we have a WWW-Authenticate header then we can try and use any domain hint information
+            // to filter the list of accounts to only those that are valid for that domain.
+            // We only expect one challenge header to be returned, but if we're given more we just select the first.
+            GitHubAuthChallenge authChallenge = GitHubAuthChallenge.FromHeaders(wwwAuth).FirstOrDefault();
+            if (authChallenge is not null)
+            {
+                _context.Trace.WriteLine("Filtering based on WWW-Authenticate header information...");
+                accounts = accounts.Where(authChallenge.IsDomainMember).ToList();
+
+                _context.Trace.WriteLine(string.IsNullOrWhiteSpace(authChallenge.Domain)
+                    ? $"Matched {accounts.Count} accounts with public domain:"
+                    : $"Matched {accounts.Count} accounts with domain={authChallenge.Domain}:");
+                foreach (string account in accounts)
+                {
+                    _context.Trace.WriteLine($"  {account}");
+                }
+
+                return true;
+            }
+
+            return false;
         }
 
         public virtual Task StoreCredentialAsync(InputArguments input)

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using GitHub.Diagnostics;
@@ -137,15 +138,21 @@ namespace GitHub
             if (string.IsNullOrWhiteSpace(userName))
             {
                 IList<string> accounts = _context.CredentialStore.GetAccounts(service);
-                _context.Trace.WriteLine($"Found {accounts.Count} accounts in the store for service={service}.");
+                _context.Trace.WriteLine($"Found {accounts.Count} accounts in the store for service={service}{(accounts.Count > 0 ? ":" : ".")}");
+                foreach (string account in accounts)
+                {
+                    _context.Trace.WriteLine($"  {account}");
+                }
 
                 switch (accounts.Count)
                 {
                     case 1:
+                        _context.Trace.WriteLine("Only one account available - using that one!");
                         userName = accounts[0];
                         break;
 
                     case > 1:
+                        _context.Trace.WriteLine("Multiple accounts available - prompting user to select one...");
                         userName = await _gitHubAuth.SelectAccountAsync(remoteUri, accounts);
                         addAccount = userName is null;
                         break;


### PR DESCRIPTION
Add support for GitHub [enterprise-manage users (EMU)](https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users) to the GitHub host provider.

Accounts in an 'EMU' enterprise/business are siloed from the regular, public GitHub.com accounts. EMU accounts are identified by the `_shortcode` suffix, where the `shortcode` is a moniker for the enterprise/business, for example `alice_contoso`.

When asked to recall credentials for the GitHub.com host we now attempt to filter stored accounts by the `shortcode`, given information provided in `WWW-Authenticate` headers from upcoming versions of Git that support these headers (as of https://github.com/gitgitgadget/git/commit/92c56da09683fa3331668adec073b6769da8f0b7).

The format of the header is:

```
WWW-Authenticate: Basic realm="GitHub" [domain_hint="X"] [enterprise_hint="Y"]
```

..where `X` is the shortcode, and `Y` is the enterprise name.

If multiple accounts are available for the given 'domain' then we present an account selection prompt. Users can avoid this prompt in the case of multiple user accounts by specifying the desired account in the remote URL (e.g. `https://alice@github.com/mona/test` to always use the `alice` account).

Note that GitHub.com does not yet return such `WWW-Authenticate` headers, except always `Basic realm="GitHub"`, so this may be subject to fixes later. In the case of `realm="GitHub"`, i.e., public accounts, there is no change.

### Testing

To test the new behaviour before GitHub.com returns such headers, it's possible to fake the server response using [`mitmproxy`](https://mitmproxy.org) and the following script:

```python
"""Add an HTTP header to each response."""

class AddHeader:
    # initialize a dict with shortcodes and paths
    def __init__(self):
        org1 = ("domain1", "enterprise1")
        org2 = ("domain2", "enterprise2")

        self.orgMap = {
            "org1" : enterprise1,
            "org2" : enterprise1,
            "org3" : enterprise2,
        }

    def response(self, flow):
        if flow.response.status_code == 401:
            # lookup the correct shortcode based on the org
            org = flow.request.path.split("/")[1]
            if org not in self.orgMap:
                return
            domain_hint = self.orgMap[org][0]
            enterprise_hint = self.orgMap[org][1]
            # build the header
            header = "Basic realm=\"GitHub\" enterprise_hint=\"" + enterprise_hint + "\" domain_hint=\"" + domain_hint + "\""
            # set the header
            flow.response.headers["WWW-Authenticate"] = header

addons = [
    AddHeader()
]
```

Replace `orgN` with the org names that are backed by an EMU Enterprise, and fill `domainN` for the shortcode, and `enterpriseN` for the enterprise slug/name.

Configure Git to use the proxy and run `mitmproxy` with the `--scripts` argument:

```shell
git config --global http.proxy 'http://127.0.0.1:8080'
mitmproxy --scripts <SCRIPT>
```

Now all Git interactions that touch `orgN` will include the `domain_hint` and `enterprise_hint`s as defined.

I use these two helpful aliases to quickly add and remove the local proxy from Git's config:

```shell
[alias]
	mitm = "!f(){ git config --global http.proxy 'http://127.0.0.1:8080'; }; f"
	unmitm = "!f(){ git config --global --unset http.proxy; }; f"
```