### PR TITLE
Update MSAL libraries and use new MSALRuntime-based broker implementation

### DIFF
--- a/src/shared/Core/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Core/Authentication/MicrosoftAuthentication.cs
@@ -78,26 +78,25 @@ namespace GitCredentialManager.Authentication
                 }
 
                 //
-                // If we failed to acquire an AT silently (either because we don't have an existing user, or the user's RT has expired)
-                // we need to prompt the user for credentials.
+                // If we failed to acquire an AT silently (either because we don't have an existing user, or the user's
+                // RT has expired) we need to prompt the user for credentials.
                 //
-                // If the user has expressed a preference in how the want to perform the interactive authentication flows then we respect that.
-                // Otherwise, depending on the current platform and session type we try to show the most appropriate authentication interface:
+                // If the user has expressed a preference in how they want to perform the interactive authentication
+                // flows then we respect that. Otherwise, depending on the current platform and session type we try to
+                // show the most appropriate authentication interface:
                 //
-                // On Windows 10 & .NET Framework, MSAL supports the Web Account Manager (WAM) broker - we try to use that if possible
-                // in the first instance.
+                // On Windows 10+ & .NET Framework, MSAL supports the Web Account Manager (WAM) broker - we try to use
+                // that if possible in the first instance.
                 //
-                // On .NET Framework MSAL supports the WinForms based 'embedded' webview UI. For Windows + .NET Framework this is the
-                // best and natural experience.
+                // On .NET Framework MSAL supports the WinForms based 'embedded' webview UI. This experience is less
+                // jarring that the system webview flow so try that option next.
                 //
-                // On other runtimes (e.g., .NET Core) MSAL only supports the system webview flow (launch the user's browser),
-                // and the device-code flows.
+                // On other runtimes (e.g., .NET 6+) MSAL only supports the system webview flow (launch the user's
+                // browser), and the device-code flows. The system webview flow requires that the redirect URI is a
+                // loopback address, and that we are in an interactive session.
                 //
-                //     Note: .NET Core 3 allows using WinForms when run on Windows but MSAL does not yet support this.
-                //
-                // The system webview flow requires that the redirect URI is a loopback address, and that we are in an interactive session.
-                //
-                // The device code flow has no limitations other than a way to communicate to the user the code required to authenticate.
+                // The device code flow has no limitations other than a way to communicate to the user the code required
+                // to authenticate.
                 //
                 if (result is null)
                 {

--- a/src/shared/Core/Core.csproj
+++ b/src/shared/Core/Core.csproj
@@ -13,13 +13,13 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
-    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.37.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.52.0" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.37.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.19.2" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.52.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.28.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
   </ItemGroup>
 

--- a/src/shared/Core/Core.csproj
+++ b/src/shared/Core/Core.csproj
@@ -13,7 +13,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
-    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.52.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.52.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/shared/Core/Diagnostics/MicrosoftAuthenticationDiagnostic.cs
+++ b/src/shared/Core/Diagnostics/MicrosoftAuthenticationDiagnostic.cs
@@ -15,27 +15,8 @@ namespace GitCredentialManager.Diagnostics
 
         protected override async Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
         {
-            if (MicrosoftAuthentication.CanUseBroker(CommandContext))
-            {
-                log.Append("Checking broker initialization state...");
-                if (MicrosoftAuthentication.IsBrokerInitialized)
-                {
-                    log.AppendLine(" Initialized");
-                }
-                else
-                {
-                    log.AppendLine("  Not initialized");
-                    log.Append("Initializing broker...");
-                    MicrosoftAuthentication.InitializeBroker();
-                    log.AppendLine("OK");
-                }
-            }
-            else
-            {
-                log.AppendLine("Broker not supported.");
-            }
-
             var msAuth = new MicrosoftAuthentication(CommandContext);
+            log.AppendLine(msAuth.CanUseBroker() ? "Broker is enabled." : "Broker is not enabled.");
             log.AppendLine($"Flow type is: {msAuth.GetFlowType()}");
 
             log.Append("Gathering MSAL token cache data...");

--- a/src/shared/Core/Interop/Windows/Native/Kernel32.cs
+++ b/src/shared/Core/Interop/Windows/Native/Kernel32.cs
@@ -251,6 +251,16 @@ namespace GitCredentialManager.Interop.Windows.Native
         /// </returns>
         [DllImport(LibraryName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern IntPtr LocalFree(IntPtr ptr);
+
+        /// <summary>
+        /// Retrieves the window handle used by the console associated with the calling process.
+        /// </summary>
+        /// <returns>
+        /// The return value is a handle to the window used by the console associated with the calling process or
+        /// NULL if there is no such associated console.
+        /// </returns>
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr GetConsoleWindow();
     }
 
     [Flags]

--- a/src/shared/Core/Interop/Windows/Native/User32.cs
+++ b/src/shared/Core/Interop/Windows/Native/User32.cs
@@ -35,6 +35,36 @@ namespace GitCredentialManager.Interop.Windows.Native
 
         [DllImport(LibraryName, SetLastError = true)]
         public static extern bool GetClientRect(IntPtr hwnd, out RECT lpRect);
+
+        /// <summary>
+        /// Retrieves the handle to the ancestor of the specified window.
+        /// </summary>
+        /// <param name="hwnd">
+        /// A handle to the window whose ancestor is to be retrieved.
+        /// If this parameter is the desktop window, the function returns NULL.
+        /// </param>
+        /// <param name="flags">The ancestor to be retrieved.</param>
+        /// <returns>The return value is the handle to the ancestor window.</returns>
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern IntPtr GetAncestor(IntPtr hwnd, GetAncestorFlags flags);
+    }
+
+    public enum GetAncestorFlags
+    {
+        /// <summary>
+        /// Retrieves the parent window. This does not include the owner, as it does with the GetParent function.
+        /// </summary>
+        GetParent = 1,
+
+        /// <summary>
+        /// Retrieves the root window by walking the chain of parent windows.
+        /// </summary>
+        GetRoot = 2,
+
+        /// <summary>
+        /// Retrieves the owned root window by walking the chain of parent and owner windows returned by GetParent.
+        /// </summary>
+        GetRootOwner = 3
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/shared/Git-Credential-Manager/Program.cs
+++ b/src/shared/Git-Credential-Manager/Program.cs
@@ -25,22 +25,6 @@ namespace GitCredentialManager
                 // Write the start and version events
                 context.Trace2.Start(context.ApplicationPath, args);
 
-                // Workaround for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2560
-                if (MicrosoftAuthentication.CanUseBroker(context))
-                {
-                    try
-                    {
-                        MicrosoftAuthentication.InitializeBroker();
-                    }
-                    catch (Exception ex)
-                    {
-                        context.Streams.Error.WriteLine(
-                            "warning: broker initialization failed{0}{1}",
-                            Environment.NewLine, ex.Message
-                        );
-                    }
-                }
-
                 //
                 // Git Credential Manager's executable used to be named "git-credential-manager-core" before
                 // dropping the "-core" suffix. In order to prevent "helper not found" errors for users who

--- a/src/windows/Installer.Windows/Setup.iss
+++ b/src/windows/Installer.Windows/Setup.iss
@@ -125,12 +125,12 @@ Source: "{#PayloadDir}\Microsoft.AzureRepos.dll";                       DestDir:
 Source: "{#PayloadDir}\gcmcore.dll";                                    DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\gcmcoreui.dll";                                  DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\gcmcoreuiwpf.dll";                               DestDir: "{app}"; Flags: ignoreversion
-Source: "{#PayloadDir}\Microsoft.Identity.Client.Desktop.dll";          DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\Microsoft.Identity.Client.Broker.dll";           DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\Microsoft.Identity.Client.dll";                  DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\Microsoft.Identity.Client.Extensions.Msal.dll";  DestDir: "{app}"; Flags: ignoreversion
-Source: "{#PayloadDir}\Microsoft.Web.WebView2.Core.dll";                DestDir: "{app}"; Flags: ignoreversion
-Source: "{#PayloadDir}\Microsoft.Web.WebView2.WinForms.dll";            DestDir: "{app}"; Flags: ignoreversion
-Source: "{#PayloadDir}\Microsoft.Web.WebView2.Wpf.dll";                 DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\Microsoft.Identity.Client.NativeInterop.dll";    DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\Microsoft.IdentityModel.Abstractions.dll";       DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\msalruntime_x86.dll";                            DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\Newtonsoft.Json.dll";                            DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\NOTICE";                                         DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\System.Buffers.dll";                             DestDir: "{app}"; Flags: ignoreversion
@@ -138,7 +138,6 @@ Source: "{#PayloadDir}\System.CommandLine.dll";                         DestDir:
 Source: "{#PayloadDir}\System.Memory.dll";                              DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\System.Numerics.Vectors.dll";                    DestDir: "{app}"; Flags: ignoreversion
 Source: "{#PayloadDir}\System.Runtime.CompilerServices.Unsafe.dll";     DestDir: "{app}"; Flags: ignoreversion
-Source: "{#PayloadDir}\WebView2Loader.dll";                             DestDir: "{app}"; Flags: ignoreversion
 
 [Code]
 // Don't allow installing conflicting architectures


### PR DESCRIPTION
Use the new Windows broker which is based on the MSALRuntime; an export wrapper around a native, cross-platform MSAL library.

In this new set up, we drop the `.Desktop` package in favour of the `.Broker` package that also means we drop the WebView2Loader.dll, which we didn't make use of anyway. There are a few new binaries to be distributed in the new model, including a P/Invoke layer, IdentityModel abstractions library, and the native `msalruntime_x86.dll`.

Note that GCM still only support x86 on Windows, and only supports broker use on Windows. For this reason we don't bother adding the broker package on non-.NET Framework builds to keep the sizes on Mac/Linux to a minimum.

Also update the MSAL extensions library whilst we are here to pick up various bug fixes, and drop workarounds that are no longer required for this new broker implementation!