### PR TITLE
Add support for using the current Windows user for WAM on DevBox

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -543,7 +543,10 @@ git config --global credential.msauthFlow devicecode
 
 Use the operating system account manager where available.
 
-Defaults to `false`. This default is subject to change in the future.
+Defaults to `false`. In certain cloud hosted environments when using a work or
+school account, such as [Microsoft DevBox][devbox], the default is `true`.
+
+These defaults are subject to change in the future.
 
 _**Note:** before you enable this option on Windows, please review the
 [Windows Broker][wam] details for what this means to your local Windows user
@@ -568,7 +571,10 @@ git config --global credential.msauthUseBroker true
 
 Use the current operating system account by default when the broker is enabled.
 
-Defaults to `false`. This default is subject to change in the future.
+Defaults to `false`. In certain cloud hosted environments when using a work or
+school account, such as [Microsoft DevBox][devbox], the default is `true`.
+
+These defaults are subject to change in the future.
 
 Value|Description
 -|-
@@ -692,6 +698,7 @@ git config --global credential.azreposCredentialType oauth
 [credential-plaintextstorepath]: #credentialplaintextstorepath
 [credential-cache]: https://git-scm.com/docs/git-credential-cache
 [cred-stores]: credstores.md
+[devbox]: https://azure.microsoft.com/en-us/products/dev-box
 [enterprise-config]: enterprise-config.md
 [envars]: environment.md
 [freedesktop-ss]: https://specifications.freedesktop.org/secret-service/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -564,6 +564,27 @@ git config --global credential.msauthUseBroker true
 
 ---
 
+### credential.msauthUseDefaultAccount _(experimental)_
+
+Use the current operating system account by default when the broker is enabled.
+
+Defaults to `false`. This default is subject to change in the future.
+
+Value|Description
+-|-
+`true`|Use the current operating system account by default.
+`false` _(default)_|Do not assume any account to use by default.
+
+#### Example
+
+```shell
+git config --global credential.msauthUseDefaultAccount true
+```
+
+**Also see: [GCM_MSAUTH_USEDEFAULTACCOUNT][gcm-msauth-usedefaultaccount]**
+
+---
+
 ### credential.useHttpPath
 
 Tells Git to pass the entire repository URL, rather than just the hostname, when
@@ -690,6 +711,7 @@ git config --global credential.azreposCredentialType oauth
 [gcm-interactive]: environment.md#GCM_INTERACTIVE
 [gcm-msauth-flow]: environment.md#GCM_MSAUTH_FLOW
 [gcm-msauth-usebroker]: environment.md#GCM_MSAUTH_USEBROKER-experimental
+[gcm-msauth-usedefaultaccount]: environment.md#GCM_MSAUTH_USEDEFAULTACCOUNT-experimental
 [gcm-namespace]: environment.md#GCM_NAMESPACE
 [gcm-plaintext-store-path]: environment.md#GCM_PLAINTEXT_STORE_PATH
 [gcm-provider]: environment.md#GCM_PROVIDER

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -776,7 +776,10 @@ export GCM_MSAUTH_FLOW="devicecode"
 
 Use the operating system account manager where available.
 
-Defaults to `false`. This default is subject to change in the future.
+Defaults to `false`. In certain cloud hosted environments when using a work or
+school account, such as [Microsoft DevBox][devbox], the default is `true`.
+
+These defaults are subject to change in the future.
 
 _**Note:** before you enable this option on Windows, please
 [review the details][windows-broker] about what this means to your local Windows
@@ -807,7 +810,10 @@ export GCM_MSAUTH_USEBROKER="false"
 
 Use the current operating system account by default when the broker is enabled.
 
-Defaults to `false`. This default is subject to change in the future.
+Defaults to `false`. In certain cloud hosted environments when using a work or
+school account, such as [Microsoft DevBox][devbox], the default is `true`.
+
+These defaults are subject to change in the future.
 
 Value|Description
 -|-
@@ -881,6 +887,7 @@ export GCM_AZREPOS_CREDENTIALTYPE="oauth"
 [credential-provider]: configuration.md#credentialprovider
 [credential-stores]: credstores.md
 [default-values]: enterprise-config.md
+[devbox]: https://azure.microsoft.com/en-us/products/dev-box
 [freedesktop-ss]: https://specifications.freedesktop.org/secret-service/
 [gcm]: usage.md
 [gcm-interactive]: #gcm_interactive

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -803,6 +803,33 @@ export GCM_MSAUTH_USEBROKER="false"
 
 ---
 
+### GCM_MSAUTH_USEDEFAULTACCOUNT _(experimental)_
+
+Use the current operating system account by default when the broker is enabled.
+
+Defaults to `false`. This default is subject to change in the future.
+
+Value|Description
+-|-
+`true`|Use the current operating system account by default.
+`false` _(default)_|Do not assume any account to use by default.
+
+#### Windows
+
+```batch
+SET GCM_MSAUTH_USEDEFAULTACCOUNT="true"
+```
+
+#### macOS/Linux
+
+```bash
+export GCM_MSAUTH_USEDEFAULTACCOUNT="false"
+```
+
+**Also see: [credential.msauthUseDefaultAccount][credential-msauth-usedefaultaccount]**
+
+---
+
 ### GCM_AZREPOS_CREDENTIALTYPE
 
 Specify the type of credential the Azure Repos host provider should return.
@@ -849,6 +876,7 @@ export GCM_AZREPOS_CREDENTIALTYPE="oauth"
 [credential-namespace]: configuration.md#credentialnamespace
 [credential-msauth-flow]: configuration.md#credentialmsauthflow
 [credential-msauth-usebroker]: configuration.md#credentialmsauthusebroker-experimental
+[credential-msauth-usedefaultaccount]: configuration.md#credentialmsauthusedefaultaccount-experimental
 [credential-plain-text-store]: configuration.md#credentialplaintextstorepath
 [credential-provider]: configuration.md#credentialprovider
 [credential-stores]: credstores.md

--- a/docs/windows-broker.md
+++ b/docs/windows-broker.md
@@ -43,6 +43,14 @@ variable or set the
 [`credential.msauthUseDefaultAccount`][credential.msauthUseDefaultAccount] Git
 configuration value to `true`.
 
+In certain cloud hosted environments when using a work or school account, such
+as [Microsoft Dev Box][devbox], this setting is **_automatically enabled_**.
+
+To disable this behavior, set the environment variable
+[`GCM_MSAUTH_USEDEFAULTACCOUNT`][GCM_MSAUTH_USEDEFAULTACCOUNT] or the
+[`credential.msauthUseDefaultAccount`][credential.msauthUseDefaultAccount] Git
+configuration value explicitly to `false`.
+
 ## Surprising behaviors
 
 The WAM and Windows identity systems are complex, addressing a very broad range
@@ -183,10 +191,10 @@ In order to fix the problem, there are a few options:
 [azure-refresh-token-terms]: https://docs.microsoft.com/azure/active-directory/devices/concept-primary-refresh-token#key-terminology-and-components
 [azure-conditional-access]: https://docs.microsoft.com/azure/active-directory/conditional-access/overview
 [azure-devops]: https://dev.azure.com
-[GCM_MSAUTH_USEBROKER]: environment.md#GCM_MSAUTH_USEBROKER
-[GCM_MSAUTH_USEDEFAULTACCOUNTR]: environment.md#GCM_MSAUTH_USEDEFAULTACCOUNTR
-[credential.msauthUseBroker]: configuration.md#credentialmsauthusebroker
-[credential.msauthUseDefaultAccount]: configuration.md#credentialmsauthusedefaultaccount
+[GCM_MSAUTH_USEBROKER]: environment.md#GCM_MSAUTH_USEBROKER-experimental
+[GCM_MSAUTH_USEDEFAULTACCOUNT]: environment.md#GCM_MSAUTH_USEDEFAULTACCOUNT-experimental
+[credential.msauthUseBroker]: configuration.md#credentialmsauthusebroker-experimental
+[credential.msauthUseDefaultAccount]: configuration.md#credentialmsauthusedefaultaccount-experimental
 [aad-questions]: img/aad-questions.png
 [aad-questions-21h1]: img/aad-questions-21H1.png
 [aad-bitlocker]: img/aad-bitlocker.png
@@ -197,3 +205,4 @@ In order to fix the problem, there are a few options:
 [apps-must-ask]: img/apps-must-ask.png
 [ms-com]: https://docs.microsoft.com/en-us/windows/win32/com/the-component-object-model
 [msal-dotnet]: https://aka.ms/msal-net
+[devbox]: https://azure.microsoft.com/en-us/products/dev-box

--- a/docs/windows-broker.md
+++ b/docs/windows-broker.md
@@ -34,6 +34,15 @@ fewer multi-factor authentication prompts, and the ability to use additional
 authentication technologies like smart cards and Windows Hello. These
 convenience and security features make a good case for enabling WAM.
 
+## Using the current OS account by default
+
+Enabling WAM does not currently automatically use the current Windows account
+for authentication. In order to opt-in to this behavior you can set the
+[`GCM_MSAUTH_USEDEFAULTACCOUNT`][GCM_MSAUTH_USEDEFAULTACCOUNT] environment
+variable or set the
+[`credential.msauthUseDefaultAccount`][credential.msauthUseDefaultAccount] Git
+configuration value to `true`.
+
 ## Surprising behaviors
 
 The WAM and Windows identity systems are complex, addressing a very broad range
@@ -175,7 +184,9 @@ In order to fix the problem, there are a few options:
 [azure-conditional-access]: https://docs.microsoft.com/azure/active-directory/conditional-access/overview
 [azure-devops]: https://dev.azure.com
 [GCM_MSAUTH_USEBROKER]: environment.md#GCM_MSAUTH_USEBROKER
+[GCM_MSAUTH_USEDEFAULTACCOUNTR]: environment.md#GCM_MSAUTH_USEDEFAULTACCOUNTR
 [credential.msauthUseBroker]: configuration.md#credentialmsauthusebroker
+[credential.msauthUseDefaultAccount]: configuration.md#credentialmsauthusedefaultaccount
 [aad-questions]: img/aad-questions.png
 [aad-questions-21h1]: img/aad-questions-21H1.png
 [aad-bitlocker]: img/aad-bitlocker.png

--- a/src/shared/Core/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Core/Authentication/MicrosoftAuthentication.cs
@@ -557,8 +557,8 @@ namespace GitCredentialManager.Authentication
                 return false;
             }
 
-            // Default to not using the OS broker
-            const bool defaultValue = false;
+            // Default to using the OS broker only on DevBox for the time being
+            bool defaultValue = PlatformUtils.IsDevBox();
 
             if (Context.Settings.TryGetSetting(Constants.EnvironmentVariables.MsAuthUseBroker,
                     Constants.GitConfiguration.Credential.SectionName,

--- a/src/shared/Core/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Core/Authentication/MicrosoftAuthentication.cs
@@ -6,8 +6,11 @@ using System.Threading.Tasks;
 using GitCredentialManager.Interop.Windows.Native;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Extensions.Msal;
+using System.Text;
 using System.Threading;
-using System.Runtime.InteropServices;
+using GitCredentialManager.UI;
+using GitCredentialManager.UI.ViewModels;
+using GitCredentialManager.UI.Views;
 
 #if NETFRAMEWORK
 using System.Drawing;
@@ -72,7 +75,8 @@ namespace GitCredentialManager.Authentication
                 AuthenticationResult result = null;
 
                 // Try silent authentication first if we know about an existing user
-                if (!string.IsNullOrWhiteSpace(userName))
+                bool hasExistingUser = !string.IsNullOrWhiteSpace(userName);
+                if (hasExistingUser)
                 {
                     result = await GetAccessTokenSilentlyAsync(app, scopes, userName);
                 }
@@ -106,12 +110,29 @@ namespace GitCredentialManager.Authentication
                     // If we're using the OS broker then delegate everything to that
                     if (useBroker)
                     {
-                        Context.Trace.WriteLine("Performing interactive auth with broker...");
-                        result = await app.AcquireTokenInteractive(scopes)
-                            .WithPrompt(Prompt.SelectAccount)
-                            // We must configure the system webview as a fallback
-                            .WithSystemWebViewOptions(GetSystemWebViewOptions())
-                            .ExecuteAsync();
+                        // If the user has enabled the default account feature then we can try to acquire an access
+                        // token 'silently' without knowing the user's UPN. Whilst this could be done truly silently,
+                        // we still prompt the user to confirm this action because if the OS account is the incorrect
+                        // account then the user may become stuck in a loop of authentication failures.
+                        if (!hasExistingUser && Context.Settings.UseMsAuthDefaultAccount)
+                        {
+                            result = await GetAccessTokenSilentlyAsync(app, scopes, null);
+
+                            if (result is null || !await UseDefaultAccountAsync(result.Account.Username))
+                            {
+                                result = null;
+                            }
+                        }
+
+                        if (result is null)
+                        {
+                            Context.Trace.WriteLine("Performing interactive auth with broker...");
+                            result = await app.AcquireTokenInteractive(scopes)
+                                .WithPrompt(Prompt.SelectAccount)
+                                // We must configure the system webview as a fallback
+                                .WithSystemWebViewOptions(GetSystemWebViewOptions())
+                                .ExecuteAsync();
+                        }
                     }
                     else
                     {
@@ -173,6 +194,61 @@ namespace GitCredentialManager.Authentication
             }
         }
 
+        private async Task<bool> UseDefaultAccountAsync(string userName)
+        {
+            ThrowIfUserInteractionDisabled();
+
+            if (Context.SessionManager.IsDesktopSession && Context.Settings.IsGuiPromptsEnabled)
+            {
+                if (TryFindHelperCommand(out string command, out string args))
+                {
+                    var sb = new StringBuilder(args);
+                    sb.Append("default-account");
+                    sb.AppendFormat(" --username {0}", QuoteCmdArg(userName));
+
+                    IDictionary<string, string> result = await InvokeHelperAsync(command, sb.ToString());
+
+                    if (result.TryGetValue("use_default_account", out string str) && !string.IsNullOrWhiteSpace(str))
+                    {
+                        return str.ToBooleanyOrDefault(false);
+                    }
+                    else
+                    {
+                        throw new Trace2Exception(Context.Trace2, "Missing use_default_account in response");
+                    }
+                }
+
+                var viewModel = new DefaultAccountViewModel(Context.Environment)
+                {
+                    UserName = userName
+                };
+
+                await AvaloniaUi.ShowViewAsync<DefaultAccountView>(
+                    viewModel, GetParentWindowHandle(), CancellationToken.None);
+
+                ThrowIfWindowCancelled(viewModel);
+
+                return viewModel.UseDefaultAccount;
+            }
+            else
+            {
+                string question = $"Continue with current account ({userName})?";
+
+                var menu = new TerminalMenu(Context.Terminal, question);
+                TerminalMenuItem yesItem = menu.Add("Yes");
+                TerminalMenuItem noItem = menu.Add("No, use another account");
+                TerminalMenuItem choice = menu.Show();
+
+                if (choice == yesItem)
+                    return true;
+
+                if (choice == noItem)
+                    return false;
+
+                throw new Exception();
+            }
+        }
+
         internal MicrosoftAuthenticationFlowType GetFlowType()
         {
             if (Context.Settings.TryGetSetting(
@@ -209,11 +285,20 @@ namespace GitCredentialManager.Authentication
         {
             try
             {
-                Context.Trace.WriteLine($"Attempting to acquire token silently for user '{userName}'...");
+                if (userName is null)
+                {
+                    Context.Trace.WriteLine("Attempting to acquire token silently for current operating system account...");
 
-                // We can either call `app.GetAccountsAsync` and filter through the IAccount objects for the instance with the correct user name,
-                // or we can just pass the user name string we have as the `loginHint` and let MSAL do exactly that for us instead!
-                return await app.AcquireTokenSilent(scopes, loginHint: userName).ExecuteAsync();
+                    return await app.AcquireTokenSilent(scopes, PublicClientApplication.OperatingSystemAccount).ExecuteAsync();
+                }
+                else
+                {
+                    Context.Trace.WriteLine($"Attempting to acquire token silently for user '{userName}'...");
+
+                    // We can either call `app.GetAccountsAsync` and filter through the IAccount objects for the instance with the correct user name,
+                    // or we can just pass the user name string we have as the `loginHint` and let MSAL do exactly that for us instead!
+                    return await app.AcquireTokenSilent(scopes, loginHint: userName).ExecuteAsync();
+                }
             }
             catch (MsalUiRequiredException)
             {
@@ -427,6 +512,16 @@ namespace GitCredentialManager.Authentication
         private void OnMsalLogMessage(LogLevel level, string message, bool containspii)
         {
             Context.Trace.WriteLine($"[{level.ToString()}] {message}", memberName: "MSAL");
+        }
+
+        private bool TryFindHelperCommand(out string command, out string args)
+        {
+            return TryFindHelperCommand(
+                Constants.EnvironmentVariables.GcmUiHelper,
+                Constants.GitConfiguration.Credential.UiHelper,
+                Constants.DefaultUiHelper,
+                out command,
+                out args);
         }
 
         private class MsalHttpClientFactoryAdaptor : IMsalHttpClientFactory

--- a/src/shared/Core/Constants.cs
+++ b/src/shared/Core/Constants.cs
@@ -16,6 +16,8 @@ namespace GitCredentialManager
 
         public const string GcmDataDirectoryName = ".gcm";
 
+        public static readonly Guid DevBoxPartnerId = new("e3171dd9-9a5f-e5be-b36c-cc7c4f3f3bcf");
+
         public static class CredentialStoreNames
         {
             public const string WindowsCredentialManager = "wincredman";
@@ -187,6 +189,10 @@ namespace GitCredentialManager
         {
             public const string HKAppBasePath = @"SOFTWARE\GitCredentialManager";
             public const string HKConfigurationPath = HKAppBasePath + @"\Configuration";
+
+            public const string HKWindows365Path = @"SOFTWARE\Microsoft\Windows365";
+            public const string IsW365EnvironmentKeyName = "IsW365Environment";
+            public const string W365PartnerIdKeyName = "PartnerId";
         }
 
         public static class HelpUrls

--- a/src/shared/Core/Constants.cs
+++ b/src/shared/Core/Constants.cs
@@ -83,6 +83,7 @@ namespace GitCredentialManager
             public const string GcmParentWindow       = "GCM_MODAL_PARENTHWND";
             public const string MsAuthFlow            = "GCM_MSAUTH_FLOW";
             public const string MsAuthUseBroker       = "GCM_MSAUTH_USEBROKER";
+            public const string MsAuthUseDefaultAccount = "GCM_MSAUTH_USEDEFAULTACCOUNT";
             public const string GcmCredNamespace      = "GCM_NAMESPACE";
             public const string GcmCredentialStore    = "GCM_CREDENTIAL_STORE";
             public const string GcmCredCacheOptions   = "GCM_CREDENTIAL_CACHE_OPTIONS";
@@ -141,6 +142,7 @@ namespace GitCredentialManager
                 public const string GuiPromptsEnabled = "guiPrompt";
                 public const string UiHelper = "uiHelper";
                 public const string DevUseLegacyUiHelpers = "devUseLegacyUiHelpers";
+                public const string MsAuthUseDefaultAccount = "msauthUseDefaultAccount";
 
                 public const string OAuthAuthenticationModes = "oauthAuthModes";
                 public const string OAuthClientId            = "oauthClientId";
@@ -198,6 +200,7 @@ namespace GitCredentialManager
             public const string GcmWamComSecurity      = "https://aka.ms/gcm/wamadmin";
             public const string GcmAutoDetect          = "https://aka.ms/gcm/autodetect";
             public const string GcmExecRename          = "https://aka.ms/gcm/rename";
+            public const string GcmDefaultAccount      = "https://aka.ms/gcm/defaultaccount";
         }
 
         private static Version _gcmVersion;

--- a/src/shared/Core/Settings.cs
+++ b/src/shared/Core/Settings.cs
@@ -781,7 +781,7 @@ namespace GitCredentialManager
                 KnownGitCfg.Credential.MsAuthUseDefaultAccount,
                 out string str)
             ? str.IsTruthy()
-            : false;
+            : PlatformUtils.IsDevBox(); // default to true in DevBox environment
 
         #region IDisposable
 

--- a/src/shared/Core/Settings.cs
+++ b/src/shared/Core/Settings.cs
@@ -173,6 +173,12 @@ namespace GitCredentialManager
         int AutoDetectProviderTimeout { get; }
 
         /// <summary>
+        /// Automatically use the default/current operating system account if no other account information is given
+        /// for Microsoft Authentication.
+        /// </summary>
+        bool UseMsAuthDefaultAccount { get; }
+
+        /// <summary>
         /// Get TRACE2 settings.
         /// </summary>
         /// <returns>TRACE2 settings object.</returns>
@@ -767,6 +773,15 @@ namespace GitCredentialManager
                 out string credStore)
                 ? credStore
                 : null;
+
+        public bool UseMsAuthDefaultAccount =>
+            TryGetSetting(
+                KnownEnvars.MsAuthUseDefaultAccount,
+                KnownGitCfg.Credential.SectionName,
+                KnownGitCfg.Credential.MsAuthUseDefaultAccount,
+                out string str)
+            ? str.IsTruthy()
+            : false;
 
         #region IDisposable
 

--- a/src/shared/Core/UI/Assets/Images.axaml
+++ b/src/shared/Core/UI/Assets/Images.axaml
@@ -1,11 +1,51 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Default">
+            <Color x:Key="IconColor">#FF25292F</Color>
+            <SolidColorBrush x:Key="IconBrush" Color="{StaticResource IconColor}"/>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Dark">
+            <Color x:Key="IconColor">White</Color>
+            <SolidColorBrush x:Key="IconBrush" Color="{StaticResource IconColor}"/>
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+
     <DrawingImage x:Key="GcmLogo">
         <DrawingImage.Drawing>
             <DrawingGroup>
                 <DrawingGroup.Children>
                     <GeometryDrawing Brush="#FFF05033" Geometry="m 127.74219 0 c -4.21881 0 -8.43843 1.6093415 -11.65821 4.828125 L 92.875 28.041016 122.31445 57.482422 c 6.84425 -2.310946 14.68947 -0.761046 20.14258 4.693359 5.48141 5.488392 7.0192 13.400136 4.65039 20.267578 l 28.37696 28.376951 c 6.86492 -2.36579 14.78398 -0.83727 20.26562 4.6543 7.66374 7.66179 7.66374 20.07642 0 27.74023 -7.66486 7.66631 -20.07893 7.66631 -27.74805 0 -5.76254 -5.76724 -7.18821 -14.23373 -4.26953 -21.33398 l -26.46289 -26.464844 -0.002 69.640624 c 1.8684 0.92496 3.63248 2.16064 5.18945 3.71094 7.66148 7.6609 7.66148 20.07236 0 27.74609 -7.66374 7.66066 -20.08459 7.66066 -27.74023 0 -7.66262 -7.67305 -7.66262 -20.08452 0 -27.74609 1.89369 -1.89039 4.08382 -3.32218 6.42187 -4.28125 V 94.199219 c -2.33912 -0.955028 -4.52734 -2.375687 -6.42383 -4.28125 -5.80409 -5.799832 -7.20125 -14.319608 -4.22461 -21.447266 L 81.466797 39.443359 4.8300781 116.08203 c -6.4393305 6.44252 -6.4393305 16.88229 0 23.32031 L 42.5 177.07227 V 162.70508 C 35.078345 157.16403 29.678851 149.02425 27.328125 140.07617 19.76286 115.647 40.902921 87.908596 66.359375 88.345703 76.747705 88.003924 87.132367 91.94485 94.875 98.837891 c 18.78493 15.372969 17.87151 47.496839 -0.888672 62.484379 l -2.566406 1.3457 0.222656 12.46503 -8.160156 8.24395 v 34.67578 l 33.119138 33.11915 c 6.43505 6.43757 16.87041 6.43757 23.31446 0 L 251.17188 139.92969 c 6.43732 -6.4407 6.43732 -16.88336 0 -23.32227 l 0.002 -0.01 L 139.39453 4.828125 C 136.1788 1.6093415 131.96099 0 127.74219 0 Z" />
                     <GeometryDrawing Brush="#FF4D4D4D" Geometry="M 67.333984 94.333984 A 35.333332 35.333332 0 0 0 32 129.66602 A 35.333332 35.333332 0 0 0 48.5 159.54688 L 48.5 234.5 L 54.5 240 L 67 240 L 79 228 L 79 216.5 L 73 210 L 79 203.5 L 73 197 L 79 191 L 73 185.5 L 85.5 173 L 85.5 159.92188 A 35.333332 35.333332 0 0 0 102.66602 129.66602 A 35.333332 35.333332 0 0 0 67.333984 94.333984 z M 66.777344 109 A 9 9 0 0 1 75.777344 118 A 9 9 0 0 1 66.777344 127 A 9 9 0 0 1 57.777344 118 A 9 9 0 0 1 66.777344 109 z M 54.5 168 L 60.5 173 L 60.5 234.5 L 54.5 228 L 54.5 168 z " />
+                </DrawingGroup.Children>
+            </DrawingGroup>
+        </DrawingImage.Drawing>
+    </DrawingImage>
+    <DrawingImage x:Key="PersonIcon">
+        <DrawingImage.Drawing>
+            <DrawingGroup>
+                <DrawingGroup.Children>
+                    <GeometryDrawing Brush="{DynamicResource IconBrush}" Geometry="M12 2.5a5.5 5.5 0 0 1 3.096 10.047 9.005 9.005 0 0 1 5.9 8.181.75.75 0 1 1-1.499.044 7.5 7.5 0 0 0-14.993 0 .75.75 0 0 1-1.5-.045 9.005 9.005 0 0 1 5.9-8.18A5.5 5.5 0 0 1 12 2.5ZM8 8a4 4 0 1 0 8 0 4 4 0 0 0-8 0Z"/>
+                </DrawingGroup.Children>
+            </DrawingGroup>
+        </DrawingImage.Drawing>
+    </DrawingImage>
+    <DrawingImage x:Key="InfoIcon">
+        <DrawingImage.Drawing>
+            <DrawingGroup>
+                <DrawingGroup.Children>
+                    <GeometryDrawing Brush="{DynamicResource IconBrush}" Geometry="M13 7.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm-3 3.75a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v4.25h.75a.75.75 0 0 1 0 1.5h-3a.75.75 0 0 1 0-1.5h.75V12h-.75a.75.75 0 0 1-.75-.75Z"/>
+                    <GeometryDrawing Brush="{DynamicResource IconBrush}" Geometry="M12 1c6.075 0 11 4.925 11 11s-4.925 11-11 11S1 18.075 1 12 5.925 1 12 1ZM2.5 12a9.5 9.5 0 0 0 9.5 9.5 9.5 9.5 0 0 0 9.5-9.5A9.5 9.5 0 0 0 12 2.5 9.5 9.5 0 0 0 2.5 12Z"/>
+                </DrawingGroup.Children>
+            </DrawingGroup>
+        </DrawingImage.Drawing>
+    </DrawingImage>
+    <DrawingImage x:Key="HelpIcon">
+        <DrawingImage.Drawing>
+            <DrawingGroup>
+                <DrawingGroup.Children>
+                    <GeometryDrawing Brush="{DynamicResource IconBrush}" Geometry="M10.97 8.265a1.45 1.45 0 0 0-.487.57.75.75 0 0 1-1.341-.67c.2-.402.513-.826.997-1.148C10.627 6.69 11.244 6.5 12 6.5c.658 0 1.369.195 1.934.619a2.45 2.45 0 0 1 1.004 2.006c0 1.033-.513 1.72-1.027 2.215-.19.183-.399.358-.579.508l-.147.123a4.329 4.329 0 0 0-.435.409v1.37a.75.75 0 1 1-1.5 0v-1.473c0-.237.067-.504.247-.736.22-.28.486-.517.718-.714l.183-.153.001-.001c.172-.143.324-.27.47-.412.368-.355.569-.676.569-1.136a.953.953 0 0 0-.404-.806C12.766 8.118 12.384 8 12 8c-.494 0-.814.121-1.03.265ZM13 17a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"/>
+                    <GeometryDrawing Brush="{DynamicResource IconBrush}" Geometry="M12 1c6.075 0 11 4.925 11 11s-4.925 11-11 11S1 18.075 1 12 5.925 1 12 1ZM2.5 12a9.5 9.5 0 0 0 9.5 9.5 9.5 9.5 0 0 0 9.5-9.5A9.5 9.5 0 0 0 12 2.5 9.5 9.5 0 0 0 2.5 12Z"/>
                 </DrawingGroup.Children>
             </DrawingGroup>
         </DrawingImage.Drawing>

--- a/src/shared/Core/UI/Commands/DefaultAccountCommand.cs
+++ b/src/shared/Core/UI/Commands/DefaultAccountCommand.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Threading;
+using System.Threading.Tasks;
+using GitCredentialManager.UI.ViewModels;
+
+namespace GitCredentialManager.UI.Commands;
+
+public abstract class DefaultAccountCommand : HelperCommand
+{
+    protected DefaultAccountCommand(ICommandContext context)
+        : base(context, "default-account", "Show prompt to confirm use of the default OS account.")
+    {
+        AddOption(
+            new Option<string>("--title", "Window title (optional).")
+        );
+
+        AddOption(
+            new Option<string>("--username", "User name to display.")
+            {
+                IsRequired = true
+            }
+        );
+
+        AddOption(
+            new Option("--no-logo", "Hide the Git Credential Manager logo and logotype.")
+        );
+
+        Handler = CommandHandler.Create(ExecuteAsync);
+    }
+
+    private class CommandOptions
+    {
+        public string Title { get; set; }
+        public string UserName { get; set; }
+        public bool NoLogo { get; set; }
+    }
+
+    private async Task<int> ExecuteAsync(CommandOptions options)
+    {
+        var viewModel = new DefaultAccountViewModel(Context.Environment)
+        {
+            Title = !string.IsNullOrWhiteSpace(options.Title)
+                ? options.Title
+                : "Git Credential Manager",
+            UserName = options.UserName,
+            ShowProductHeader = !options.NoLogo
+        };
+
+        await ShowAsync(viewModel, CancellationToken.None);
+
+        if (!viewModel.WindowResult)
+        {
+            throw new Trace2Exception(Context.Trace2, "User cancelled dialog.");
+        }
+
+        WriteResult(
+            new Dictionary<string, string>
+            {
+                ["use_default_account"] = viewModel.UseDefaultAccount ? "1" : "0"
+            }
+        );
+
+        return 0;
+    }
+
+    protected abstract Task ShowAsync(DefaultAccountViewModel viewModel, CancellationToken ct);
+}

--- a/src/shared/Core/UI/ViewModels/DefaultAccountViewModel.cs
+++ b/src/shared/Core/UI/ViewModels/DefaultAccountViewModel.cs
@@ -1,0 +1,79 @@
+using System.Windows.Input;
+
+namespace GitCredentialManager.UI.ViewModels;
+
+public class DefaultAccountViewModel : WindowViewModel
+{
+    private readonly IEnvironment _env;
+
+    private bool _showProductHeader = true;
+    private string _userName;
+    private ICommand _continueCommand;
+    private ICommand _otherAccountCommand;
+    private ICommand _learnMoreCommand;
+
+    public DefaultAccountViewModel()
+    {
+        // For designer only
+    }
+    
+    public DefaultAccountViewModel(IEnvironment environment) : this()
+    {
+        _env = environment;
+
+        ContinueCommand = new RelayCommand(Continue);
+        OtherAccountCommand = new RelayCommand(OtherAccount);
+        LearnMoreCommand = new RelayCommand(OpenLink);
+    }
+
+    private void OtherAccount()
+    {
+        UseDefaultAccount = false;
+        Accept();
+    }
+
+    private void Continue()
+    {
+        UseDefaultAccount = true;
+        Accept();
+    }
+
+    private void OpenLink()
+    {
+        BrowserUtils.OpenDefaultBrowser(_env, Link);
+    }
+
+    public bool UseDefaultAccount { get; private set; }
+
+    public string Link => Constants.HelpUrls.GcmDefaultAccount;
+
+    public bool ShowProductHeader
+    {
+        get => _showProductHeader;
+        set => SetAndRaisePropertyChanged(ref _showProductHeader, value);
+    }
+
+    public string UserName
+    {
+        get => _userName;
+        set => SetAndRaisePropertyChanged(ref _userName, value);
+    }
+
+    public ICommand ContinueCommand
+    {
+        get => _continueCommand;
+        set => SetAndRaisePropertyChanged(ref _continueCommand, value);
+    }
+
+    public ICommand OtherAccountCommand
+    {
+        get => _otherAccountCommand;
+        set => SetAndRaisePropertyChanged(ref _otherAccountCommand, value);
+    }
+
+    public ICommand LearnMoreCommand
+    {
+        get => _learnMoreCommand;
+        set => SetAndRaisePropertyChanged(ref _learnMoreCommand, value);
+    }
+}

--- a/src/shared/Core/UI/Views/DefaultAccountView.axaml
+++ b/src/shared/Core/UI/Views/DefaultAccountView.axaml
@@ -1,0 +1,73 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:GitCredentialManager.UI.ViewModels;assembly=gcmcore"
+             xmlns:converters="clr-namespace:GitCredentialManager.UI.Converters;assembly=gcmcore"
+             mc:Ignorable="d" d:DesignWidth="420"
+             x:Class="GitCredentialManager.UI.Views.DefaultAccountView">
+    <Design.DataContext>
+        <vm:DefaultAccountViewModel/>
+    </Design.DataContext>
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Margin="10,0,10,10">
+            <StackPanel Margin="0"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Center"
+                        IsVisible="{Binding ShowProductHeader}">
+                <Image Margin="0,0,10,0"
+                       VerticalAlignment="Center"
+                       Source="{DynamicResource GcmLogo}"
+                       Width="32" Height="32" />
+                <TextBlock Text="Git Credential Manager"
+                           VerticalAlignment="Center"
+                           FontSize="18"
+                           FontWeight="Light"/>
+            </StackPanel>
+
+            <TextBlock FontSize="14"
+                       HorizontalAlignment="Center"
+                       TextWrapping="Wrap"
+                       Margin="0,15,0,15">
+                Do you want to continue with the current account?
+            </TextBlock>
+        </StackPanel>
+
+        <StackPanel DockPanel.Dock="Bottom"
+                    Margin="0,20,0,0"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Center">
+            <Image Source="{StaticResource HelpIcon}"
+                   Width="16" Height="16"
+                   Margin="0,0,5,0"/>
+            <Button Content="Learn more about operating system accounts"
+                    Command="{Binding LearnMoreCommand}"
+                    HorizontalAlignment="Center"
+                    Classes="hyperlink"/>
+        </StackPanel>
+
+        <StackPanel Margin="20,0">
+            <StackPanel Orientation="Horizontal"
+                        HorizontalAlignment="Center"
+                        Margin="0,0,0,20">
+                <Image Source="{StaticResource PersonIcon}"
+                       Width="32" Height="32"
+                       VerticalAlignment="Center"
+                       Margin="0,0,10,0"/>
+                <TextBlock Text="{Binding UserName}"
+                           VerticalAlignment="Center"/>
+            </StackPanel>
+            <Button Content="Continue"
+                    IsDefault="True"
+                    Command="{Binding ContinueCommand}"
+                    HorizontalAlignment="Center"
+                    Margin="0,0,0,10"
+                    Padding="16,8"
+                    Classes="accent"/>
+            <Button Content="Use another account"
+                    Command="{Binding OtherAccountCommand}"
+                    Padding="8,5"
+                    HorizontalAlignment="Center"/>
+        </StackPanel>
+    </DockPanel>
+</UserControl>

--- a/src/shared/Core/UI/Views/DefaultAccountView.axaml.cs
+++ b/src/shared/Core/UI/Views/DefaultAccountView.axaml.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace GitCredentialManager.UI.Views
+{
+    public partial class DefaultAccountView : UserControl
+    {
+        public DefaultAccountView()
+        {
+            InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -48,6 +48,9 @@ namespace GitCredentialManager.Tests.Objects
         public bool UseCustomCertificateBundleWithSchannel { get; set; }
 
         public int AutoDetectProviderTimeout { get; set; } = Constants.DefaultAutoDetectProviderTimeoutMs;
+
+        public bool UseMsAuthDefaultAccount { get; set; }
+
         public Trace2Settings GetTrace2Settings()
         {
             return new Trace2Settings()
@@ -173,6 +176,8 @@ namespace GitCredentialManager.Tests.Objects
         bool ISettings.UseCustomCertificateBundleWithSchannel => UseCustomCertificateBundleWithSchannel;
 
         int ISettings.AutoDetectProviderTimeout => AutoDetectProviderTimeout;
+
+        bool ISettings.UseMsAuthDefaultAccount => UseMsAuthDefaultAccount;
 
         #endregion
 

--- a/src/windows/Git-Credential-Manager.UI.Windows/Commands/DefaultAccountCommandImpl.cs
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Commands/DefaultAccountCommandImpl.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GitCredentialManager.UI.Commands;
+using GitCredentialManager.UI.ViewModels;
+using GitCredentialManager.UI.Windows.Views;
+
+namespace GitCredentialManager.UI.Windows.Commands
+{
+    public class DefaultAccountCommandImpl : DefaultAccountCommand
+    {
+        public DefaultAccountCommandImpl(ICommandContext context) : base(context) { }
+
+        protected override Task ShowAsync(DefaultAccountViewModel viewModel, CancellationToken ct)
+        {
+            return Gui.ShowDialogWindow(viewModel, () => new DefaultAccountView(), GetParentHandle());
+        }
+    }
+}

--- a/src/windows/Git-Credential-Manager.UI.Windows/Program.cs
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Program.cs
@@ -30,6 +30,7 @@ namespace GitCredentialManager.UI.Windows
                 app.RegisterCommand(new CredentialsCommandImpl(context));
                 app.RegisterCommand(new OAuthCommandImpl(context));
                 app.RegisterCommand(new DeviceCodeCommandImpl(context));
+                app.RegisterCommand(new DefaultAccountCommandImpl(context));
 
                 int exitCode = app.RunAsync(args)
                     .ConfigureAwait(false)

--- a/src/windows/Git-Credential-Manager.UI.Windows/Views/DefaultAccountView.xaml
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Views/DefaultAccountView.xaml
@@ -1,0 +1,74 @@
+<UserControl x:Class="GitCredentialManager.UI.Windows.Views.DefaultAccountView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:converters="clr-namespace:GitCredentialManager.UI.Windows.Converters;assembly=gcmcoreuiwpf"
+             xmlns:sharedControls="clr-namespace:GitCredentialManager.UI.Windows.Controls;assembly=gcmcoreuiwpf"
+             xmlns:viewModels="clr-namespace:GitCredentialManager.UI.ViewModels;assembly=gcmcore"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance viewModels:DefaultAccountViewModel}"
+             d:DesignWidth="300"
+             x:Name="view">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Assets/Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Margin="10,0,0,10">
+            <StackPanel Margin="0"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Center"
+                        Visibility="{Binding ShowProductHeader, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Image Source="{StaticResource GcmLogo}"
+                       Height="32" VerticalAlignment="Center"
+                       Margin="0,0,10,0"/>
+                <TextBlock Text="Git Credential Manager"
+                           VerticalAlignment="Center"
+                           FontSize="18"
+                           FontWeight="Light" />
+            </StackPanel>
+
+            <TextBlock HorizontalAlignment="Center"
+                       Margin="0,15,0,15">
+                Do you want to continue with the current account?
+            </TextBlock>
+        </StackPanel>
+
+        <StackPanel DockPanel.Dock="Bottom"
+                    Margin="0,20,0,0"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Center">
+            <TextBlock FontSize="14"
+                       HorizontalAlignment="Center">
+                <Hyperlink Command="{Binding LearnMoreCommand}">
+                    <Run Text="Learn more about operating system accounts"/>
+                </Hyperlink>
+            </TextBlock>
+        </StackPanel>
+
+        <StackPanel Margin="20,0">
+            <StackPanel Orientation="Horizontal"
+                        HorizontalAlignment="Center"
+                        Margin="0,0,0,20">
+                <TextBlock Text="{Binding UserName}"
+                           VerticalAlignment="Center"/>
+            </StackPanel>
+            <Button Content="Continue"
+                    IsDefault="True"
+                    Margin="0,0,0,10"
+                    Padding="16,8"
+                    Command="{Binding ContinueCommand}"
+                    HorizontalAlignment="Center"
+                    Style="{StaticResource AccentButton}"/>
+            <Button Content="Use another account"
+                    Command="{Binding OtherAccountCommand}"
+                    HorizontalAlignment="Center"/>
+        </StackPanel>
+    </DockPanel>
+</UserControl>

--- a/src/windows/Git-Credential-Manager.UI.Windows/Views/DefaultAccountView.xaml.cs
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Views/DefaultAccountView.xaml.cs
@@ -1,0 +1,13 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace GitCredentialManager.UI.Windows.Views
+{
+    public partial class DefaultAccountView : UserControl
+    {
+        public DefaultAccountView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Add the ability to configure MSAL to use the default OS account when the broker is enabled.
Also detect when we are in a Microsoft Dev Box environment, and if we are, then default to enabling the new setting (and enable WAM).

Show a confirmation prompt before continuing to use the current OS account, which is similar to how Microsoft Teams operates.

<img width="888" alt="windows-defaultaccount" src="https://user-images.githubusercontent.com/5658207/234346956-b08eb43f-c964-4978-84ec-a0f75f021f08.png">

Left: Avalonia UI, Right: fallback WPF window

Fixes #917