### PR TITLE
Avoid creating external processes to read OS version info

### DIFF
--- a/src/shared/Core/PlatformUtils.cs
+++ b/src/shared/Core/PlatformUtils.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using GitCredentialManager.Interop.Posix.Native;
 
@@ -349,6 +351,8 @@ namespace GitCredentialManager
             return "Unknown";
         }
 
+        private static string _linuxDistroVersion;
+
         private static string GetOSVersion(ITrace2 trace2)
         {
             //
@@ -373,22 +377,80 @@ namespace GitCredentialManager
 
             if (IsLinux())
             {
-                var psi = new ProcessStartInfo
-                {
-                    FileName = "uname",
-                    Arguments = "-a",
-                    RedirectStandardOutput = true
-                };
+                return _linuxDistroVersion ??= GetLinuxDistroVersion();
 
-                using (var uname = new ChildProcess(trace2, psi))
+                string GetLinuxDistroVersion()
                 {
-                    uname.Start(Trace2ProcessClass.Other);
-                    uname.Process.WaitForExit();
-
-                    if (uname.ExitCode == 0)
+                    // Let's first try to get the distribution information from /etc/os-release
+                    // (or /usr/lib/os-release) which is required in systemd distributions.
+                    // https://www.freedesktop.org/software/systemd/man/os-release.html
+                    foreach (string osReleasePath in new[] { "/etc/os-release", "/usr/lib/os-release" })
                     {
-                        return uname.StandardOutput.ReadToEnd().Trim();
+                        if (!File.Exists(osReleasePath))
+                        {
+                            continue;
+                        }
+
+                        var props = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                        char[] split = { '=' };
+                        string[] lines = File.ReadAllLines(osReleasePath);
+                        foreach (string line in lines)
+                        {
+                            // Each line is a key="value" pair
+                            string[] kvp = line.Split(split, count: 2);
+                            if (kvp.Length != 2)
+                            {
+                                continue;
+                            }
+
+                            props[kvp[0]] = kvp[1].Trim('"');
+                        }
+
+                        // Try to get the PRETTY_NAME first which is a user-friendly description
+                        // including the distro name and version.
+                        if (props.TryGetValue("PRETTY_NAME", out string prettyName))
+                        {
+                            return prettyName;
+                        }
+
+                        // Fall-back to (NAME || ID) + (VERSION || VERSION_ID || VERSION_CODENAME)?
+                        if (props.TryGetValue("NAME", out string distro) ||
+                            props.TryGetValue("ID", out distro))
+                        {
+                            if (props.TryGetValue("VERSION", out string version) ||
+                                props.TryGetValue("VERSION_ID", out version) ||
+                                props.TryGetValue("VERSION_CODENAME", out version))
+                            {
+                                return $"{distro} {version}";
+                            }
+
+                            // Return just the distro name if we don't have a version
+                            return distro;
+                        }
                     }
+
+                    // If we couldn't get the distribution information from /etc/os-release
+                    // (for example if we're running on a non-systemd distribution), then let's
+                    // use `uname -a` to get at least some information.
+                    var psi = new ProcessStartInfo
+                    {
+                        FileName = "uname",
+                        Arguments = "-a",
+                        RedirectStandardOutput = true
+                    };
+
+                    using (var uname = new ChildProcess(trace2, psi))
+                    {
+                        uname.Start(Trace2ProcessClass.Other);
+                        uname.Process.WaitForExit();
+
+                        if (uname.ExitCode == 0)
+                        {
+                            return uname.StandardOutput.ReadToEnd().Trim();
+                        }
+                    }
+
+                    return "Unknown-Linux";
                 }
             }
 


### PR DESCRIPTION
We are spending about 45ms on macOS to read version information by shelling out to `sw_vers` on each run of GCM.

Let's try and be smarter and use BCL APIs, system APIs or file-based sources for the OS and distribution information before resorting to external processes.

In my testing, on macOS, we went from 45ms to 4.5ms (10x speedup).

Note that we are now also getting something a little bit more useful for Linux:

Before:
```
$ GCM_TRACE=1 ./git-credential-manager --version
20:55:36.776385 ...re/Application.cs:95 trace: [RunInternalAsync] Version: 2.1.1.0
20:55:36.787669 ...re/Application.cs:96 trace: [RunInternalAsync] Runtime: .NET 6.0.16
20:55:36.787711 ...re/Application.cs:97 trace: [RunInternalAsync] Platform: Linux (x86-64)
20:55:36.787749 ...re/Application.cs:98 trace: [RunInternalAsync] OSVersion: Linux ubuntu2204-vm1 5.15.0-1037-azure #44-Ubuntu SMP Thu Apr 20 13:19:31 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
..
```

After:
```
$ GCM_TRACE=1 ./git-credential-manager --version
20:52:12.325628 ...re/Application.cs:95 trace: [RunInternalAsync] Version: 2.1.1.0
20:52:12.337234 ...re/Application.cs:96 trace: [RunInternalAsync] Runtime: .NET 6.0.16
20:52:12.337283 ...re/Application.cs:97 trace: [RunInternalAsync] Platform: Linux (x86-64)
20:52:12.337301 ...re/Application.cs:98 trace: [RunInternalAsync] OSVersion: Ubuntu 22.04.1 LTS
..
```