### PR TITLE
Return GitHub PAT token from view model

### DIFF
--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -144,7 +144,7 @@ namespace GitHub
                 case AuthenticationModes.Pat:
                     return new AuthenticationPromptResult(
                         AuthenticationModes.Pat,
-                        new GitCredential(userName, viewModel.Password)
+                        new GitCredential(userName, viewModel.Token)
                     );
 
                 default:


### PR DESCRIPTION
Fix a bug in the in-proc UI logic for returning the personal access token. We were accidentally returning the password field rather than the token field for PATs.