### PR TITLE
Use OAuth tokens on DevBox by default for Azure Repos

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -751,11 +751,13 @@ Credential: "git:https://bob@github.com/example/myrepo" (user = bob)
 
 Specify the type of credential the Azure Repos host provider should return.
 
-Defaults to the value `pat`.
+Defaults to the value `pat`. In certain cloud hosted environments when using a
+work or school account, such as [Microsoft DevBox][devbox], the default value is
+`oauth`.
 
 Value|Description
 -|-
-`pat` _(default)_|Azure DevOps personal access tokens
+`pat`|Azure DevOps personal access tokens
 `oauth`|Microsoft identity OAuth tokens (AAD or MSA tokens)
 
 Here is more information about [Azure Access tokens][azure-tokens].

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -840,11 +840,13 @@ export GCM_MSAUTH_USEDEFAULTACCOUNT="false"
 
 Specify the type of credential the Azure Repos host provider should return.
 
-Defaults to the value `pat`.
+Defaults to the value `pat`. In certain cloud hosted environments when using a
+work or school account, such as [Microsoft DevBox][devbox], the default value is
+`oauth`.
 
 Value|Description
 -|-
-`pat` _(default)_|Azure DevOps personal access tokens
+`pat`|Azure DevOps personal access tokens
 `oauth`|Microsoft identity OAuth tokens (AAD or MSA tokens)
 
 More information about Azure Access tokens can be found [here][azure-access-tokens].

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -391,8 +391,8 @@ namespace Microsoft.AzureRepos
         /// <returns>True if Personal Access Tokens should be used, false otherwise.</returns>
         private bool UsePersonalAccessTokens()
         {
-            // Default to using PATs
-            const bool defaultValue = true;
+            // Default to using PATs except on DevBox where we prefer OAuth tokens
+            bool defaultValue = !PlatformUtils.IsDevBox();
 
             if (_context.Settings.TryGetSetting(
                 AzureDevOpsConstants.EnvironmentVariables.CredentialType,


### PR DESCRIPTION
Update the default for `credential.azreposCredentialType` or `GCM_AZREPOS_CREDENTIALTYPE` to `oauth` when on Microsoft DevBox.

#917