### PR TITLE
Add support for `httpCookieFile`

### DIFF
--- a/src/shared/Core.Tests/CurlCookieTests.cs
+++ b/src/shared/Core.Tests/CurlCookieTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Net;
 using GitCredentialManager;
 using GitCredentialManager.Tests.Objects;
-using CurlCookie;
 using Xunit;
 
 namespace Core.Tests;

--- a/src/shared/Core.Tests/CurlCookieTests.cs
+++ b/src/shared/Core.Tests/CurlCookieTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using GitCredentialManager;
+using GitCredentialManager.Tests.Objects;
+using CurlCookie;
+using Xunit;
+
+namespace Core.Tests;
+
+public class CurlCookieParserTests
+{
+    [Fact]
+    public void CurlCookieParser_EmptyFile_ReturnsNoCookies()
+    {
+        const string content = "";
+
+        var trace = new NullTrace();
+        var parser = new CurlCookieParser(trace);
+
+        IList<Cookie> actual = parser.Parse(content);
+
+        Assert.Empty(actual);
+    }
+
+    [Fact]
+    public void CurlCookieParser_Parse_MissingFields_SkipsInvalidLines()
+    {
+        const string content =
+            // Valid cookie
+            ".example.com\tTRUE\t/path/here\tTRUE\t0\tcookie1\tvalue1\n" +
+
+            // Missing several fields - not a valid cookie so should be skipped
+            ".example.com\tTRUE\tTRUE\tcookie1\tvalue1\n";
+
+        var trace = new NullTrace();
+        var parser = new CurlCookieParser(trace);
+
+        IList<Cookie> actual = parser.Parse(content);
+
+        Assert.Equal(1, actual.Count);
+        AssertCookie(actual[0], ".example.com", "/path/here", true, 0, "cookie1", "value1");
+    }
+
+    [Fact]
+    public void CurlCookieParser_Parse_MissingFields_ReturnsValidCookiesWithDefaults()
+    {
+        const string content =
+            // Empty path field (default "/")
+            ".example.com\tTRUE\t\tTRUE\t852852\tcookie1\tvalue1\n" +
+
+            // Empty expiration field (default 0)
+            ".example.com\tTRUE\t/path/here\tTRUE\t\tcookie1\tvalue1";
+
+        var trace = new NullTrace();
+        var parser = new CurlCookieParser(trace);
+
+        IList<Cookie> actual = parser.Parse(content);
+
+        Assert.Equal(2, actual.Count);
+        AssertCookie(actual[0], ".example.com", "/", true, 852852, "cookie1", "value1");
+        AssertCookie(actual[1], ".example.com", "/path/here", true, 0, "cookie1", "value1");
+    }
+
+    [Fact]
+    public void CurlCookieParser_Parse_ValidFields_ReturnsValidCookies()
+    {
+        const string content =
+            ".example.com\tTRUE\t/path\tTRUE\t0\tcookie1\tvalue1\n" +
+            ".example.com\tfAlSe\t/path\ttRuE\t0\tcookie1\tvalue1\n" +
+            ".example.com\tTRUE\t/path\tTRUE\t0\tcookie1 with spaces\tvalue1 with spaces\n" +
+            ".example.com\tFALSE\t/path\tTRUE\t0\tcookie1\tvalue1\n" +
+            "example.com\tFALSE\t/path\tTRUE\t0\tcookie1\tvalue1\n" +
+            "example.com\tTRUE\t/path\tTRUE\t0\tcookie1\tvalue1\n" +
+            ".example.com\tTRUE\t/path\tFALSE\t0\tcookie1\tvalue1\n" +
+            ".example.com\tTRUE\t/path\tFALSE\t401654\tcookie1\tvalue1\n";
+
+        var trace = new NullTrace();
+        var parser = new CurlCookieParser(trace);
+
+        IList<Cookie> actual = parser.Parse(content);
+
+        Assert.Equal(8, actual.Count);
+        AssertCookie(actual[0], ".example.com", "/path", true, 0, "cookie1", "value1");
+        AssertCookie(actual[1], "example.com", "/path", true, 0, "cookie1", "value1");
+        AssertCookie(actual[2], ".example.com", "/path", true, 0, "cookie1 with spaces", "value1 with spaces");
+        AssertCookie(actual[3], "example.com", "/path", true, 0, "cookie1", "value1");
+        AssertCookie(actual[4], "example.com", "/path", true, 0, "cookie1", "value1");
+        AssertCookie(actual[5], "example.com", "/path", true, 0, "cookie1", "value1");
+        AssertCookie(actual[6], ".example.com", "/path", false, 0, "cookie1", "value1");
+        AssertCookie(actual[7], ".example.com", "/path", false, 401654, "cookie1", "value1");
+    }
+
+    [Fact]
+    public void CurlCookieParser_Parse_Comments_ReturnsCookies()
+    {
+        const string content =
+            // Comment block
+            "# This is a cookie file with various comments!\n" +
+            "# Lines starting with # are comments, except those that\n" +
+            "# start with exactly '#HttpOnly_'.. two #s is a comment still!\n" +
+
+            // This is still a comment!
+            "##HttpOnly_ <-- this is a comment still!\n" +
+
+            // Valid line
+            ".example.com\tTRUE\t/\tTRUE\t0\tcookie1\tvalue1\n" +
+
+            // Commented out cookie line
+            "#.example.com\tTRUE\t/\tTRUE\t0\tcookie1\tvalue1\n" +
+
+            // Valid cookie but HTTP only
+            "#HttpOnly_.example.com\tTRUE\t/\tTRUE\t0\tcookie1\tvalue1\n";
+
+        var trace = new NullTrace();
+        var parser = new CurlCookieParser(trace);
+
+        IList<Cookie> actual = parser.Parse(content);
+
+        Assert.Equal(2, actual.Count);
+        AssertCookie(actual[0], ".example.com", "/", true, 0, "cookie1", "value1");
+        AssertCookie(actual[1], ".example.com", "/", true, 0, "cookie1", "value1");
+    }
+
+    private static void AssertCookie(Cookie cookie, string domain, string path, bool secureOnly, long expires, string name, string value)
+    {
+        Assert.Equal(name, cookie.Name);
+        Assert.Equal(value, cookie.Value);
+        Assert.Equal(domain, cookie.Domain);
+        Assert.Equal(path, cookie.Path);
+        Assert.Equal(secureOnly, cookie.Secure);
+        Assert.Equal(expires, cookie.Expires.Subtract(DateTime.UnixEpoch).TotalSeconds);
+    }
+}

--- a/src/shared/Core/Constants.cs
+++ b/src/shared/Core/Constants.cs
@@ -171,6 +171,7 @@ namespace GitCredentialManager
                 public const string SslVerify = "sslVerify";
                 public const string SslCaInfo = "sslCAInfo";
                 public const string SslAutoClientCert = "sslAutoClientCert";
+                public const string CookieFile = "cookieFile";
             }
 
             public static class Remote

--- a/src/shared/Core/CurlCookie.cs
+++ b/src/shared/Core/CurlCookie.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using GitCredentialManager;
 
-namespace CurlCookie
+namespace GitCredentialManager
 {
     public class CurlCookieParser
     {

--- a/src/shared/Core/CurlCookie.cs
+++ b/src/shared/Core/CurlCookie.cs
@@ -38,7 +38,7 @@ namespace GitCredentialManager
                     {
                         domain = domain.TrimStart('.');
                     }
-                    var path = parts[2] == "" ? "/" : parts[2];
+                    var path = string.IsNullOrWhiteSpace(parts[2]) ? "/" : parts[2];
                     var secureOnly = parts[3].Equals("TRUE", StringComparison.OrdinalIgnoreCase);
                     var expires = ParseExpires(parts[4]);
                     var name = parts[5];

--- a/src/shared/Core/CurlCookie.cs
+++ b/src/shared/Core/CurlCookie.cs
@@ -33,7 +33,7 @@ namespace GitCredentialManager
                 if (parts.Length >= 7 && (!parts[0].StartsWith("#") || parts[0].StartsWith(HttpOnlyPrefix)))
                 {
                     var domain = parts[0].StartsWith(HttpOnlyPrefix) ? parts[0].Substring(HttpOnlyPrefix.Length) : parts[0];
-                    var includeSubdomains = parts[1] == "TRUE";
+                    var includeSubdomains = StringComparer.OrdinalIgnoreCase.Equals(parts[1], "TRUE");
                     if (!includeSubdomains)
                     {
                         domain = domain.TrimStart('.');

--- a/src/shared/Core/CurlCookie.cs
+++ b/src/shared/Core/CurlCookie.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using GitCredentialManager;
+
+namespace CurlCookie
+{
+    public class CurlCookieParser
+    {
+        private readonly ITrace _trace;
+
+        public CurlCookieParser(ITrace trace)
+        {
+            _trace = trace;
+        }
+
+        public IList<Cookie> Parse(string content)
+        {
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return Array.Empty<Cookie>();
+            }
+
+            const string HttpOnlyPrefix = "#HttpOnly_";
+
+            var cookies = new List<Cookie>();
+
+            // Parse the cookie file content
+            var lines = content.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var line in lines)
+            {
+                var parts = line.Split(new[] { '\t' }, StringSplitOptions.None);
+                if (parts.Length >= 7 && (!parts[0].StartsWith("#") || parts[0].StartsWith(HttpOnlyPrefix)))
+                {
+                    var domain = parts[0].StartsWith(HttpOnlyPrefix) ? parts[0].Substring(HttpOnlyPrefix.Length) : parts[0];
+                    var includeSubdomains = parts[1] == "TRUE";
+                    if (!includeSubdomains)
+                    {
+                        domain = domain.TrimStart('.');
+                    }
+                    var path = parts[2] == "" ? "/" : parts[2];
+                    var secureOnly = parts[3].Equals("TRUE", StringComparison.OrdinalIgnoreCase);
+                    var expires = ParseExpires(parts[4]);
+                    var name = parts[5];
+                    var value = parts[6];
+
+                    cookies.Add(new Cookie()
+                    {
+                        Domain = domain,
+                        Path = path,
+                        Expires = expires,
+                        HttpOnly = true,
+                        Secure = secureOnly,
+                        Name = name,
+                        Value = value,
+                    });
+                }
+                else
+                {
+                    _trace.WriteLine($"Invalid cookie line: {line}");
+                }
+            }
+
+            return cookies;
+        }
+
+        private static DateTime ParseExpires(string expires)
+        {
+#if NETFRAMEWORK
+            DateTime epoch = new DateTime(1970, 01, 01, 0, 0, 0, DateTimeKind.Utc);
+#else
+            DateTime epoch = DateTime.UnixEpoch;
+#endif
+
+            if (long.TryParse(expires, out long i))
+            {
+                return epoch.AddSeconds(i);
+            }
+
+            return epoch;
+        }
+    }
+}

--- a/src/shared/Core/HttpClientFactory.cs
+++ b/src/shared/Core/HttpClientFactory.cs
@@ -220,6 +220,7 @@ namespace GitCredentialManager
                     cookieContainer.Add(uri, new Cookie(cookie.Name, cookie.Value));
                 }
                 handler.CookieContainer = cookieContainer;
+                handler.UseCookies = true;
                 
                 _trace.WriteLine("Configured to automatically send cookie header.");
 

--- a/src/shared/Core/HttpClientFactory.cs
+++ b/src/shared/Core/HttpClientFactory.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
+using CurlCookie;
 
 namespace GitCredentialManager
 {
@@ -327,82 +328,6 @@ namespace GitCredentialManager
 
             proxy = null;
             return false;
-        }
-
-        public class CurlCookieParser
-        {
-            private readonly ITrace _trace;
-
-            public CurlCookieParser(ITrace trace)
-            {
-                _trace = trace;
-            }
-
-            public IList<Cookie> Parse(string content)
-            {
-                if (string.IsNullOrWhiteSpace(content))
-                {
-                    return Array.Empty<Cookie>();
-                }
-
-                const string HttpOnlyPrefix = "#HttpOnly_";
-
-                var cookies = new List<Cookie>();
-
-                // Parse the cookie file content
-                var lines = content.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-                foreach (var line in lines)
-                {
-                    var parts = line.Split(new[] { '\t' }, StringSplitOptions.None);
-                    if (parts.Length >= 7 && (!parts[0].StartsWith("#") || parts[0].StartsWith(HttpOnlyPrefix)))
-                    {
-                        var domain = parts[0].StartsWith(HttpOnlyPrefix) ? parts[0].Substring(HttpOnlyPrefix.Length) : parts[0];
-                        var includeSubdomains = parts[1] == "TRUE";
-                        if (!includeSubdomains)
-                        {
-                            domain = domain.TrimStart('.');
-                        }
-                        var path = parts[2] == "" ? "/" : parts[2];
-                        var secureOnly = parts[3].Equals("TRUE", StringComparison.OrdinalIgnoreCase);
-                        var expires = ParseExpires(parts[4]);
-                        var name = parts[5];
-                        var value = parts[6];
-
-                        cookies.Add(new Cookie()
-                        {
-                            Domain = domain,
-                            Path = path,
-                            Expires = expires,
-                            HttpOnly = true,
-                            Secure = secureOnly,
-                            Name = name,
-                            Value = value,
-                        });
-                    }
-                    else
-                    {
-                        _trace.WriteLine($"Invalid cookie line: {line}");
-                    }
-                }
-
-                return cookies;
-            }
-
-            private static DateTime ParseExpires(string expires)
-            {
-    #if NETFRAMEWORK
-                DateTime epoch = new DateTime(1970, 01, 01, 0, 0, 0, DateTimeKind.Utc);
-    #else
-                DateTime epoch = DateTime.UnixEpoch;
-    #endif
-
-                if (long.TryParse(expires, out long i))
-                {
-                    return epoch.AddSeconds(i);
-                }
-
-                return epoch;
-            }
         }
     }
 }

--- a/src/shared/Core/HttpClientFactory.cs
+++ b/src/shared/Core/HttpClientFactory.cs
@@ -198,7 +198,7 @@ namespace GitCredentialManager
 #endif
             }
 
-            // If IsUsingCookieEnabled is enabled, set Cookie header from cookie file, which is written by libcurl
+            // If CustomCookieFilePath is set, set Cookie header from cookie file, which is written by libcurl
             if (!string.IsNullOrWhiteSpace(_settings.CustomCookieFilePath) && _fileSystem.FileExists(_settings.CustomCookieFilePath))
             {
                 // get the filename from gitconfig

--- a/src/shared/Core/HttpClientFactory.cs
+++ b/src/shared/Core/HttpClientFactory.cs
@@ -7,7 +7,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
-using CurlCookie;
 
 namespace GitCredentialManager
 {

--- a/src/shared/Core/Settings.cs
+++ b/src/shared/Core/Settings.cs
@@ -155,6 +155,12 @@ namespace GitCredentialManager
         string CustomCertificateBundlePath { get; }
 
         /// <summary>
+        // Optional path to a file containing one or more cookies.
+        /// </summary>
+        /// <remarks>The default value is null if unset.</remarks>
+        string CustomCookieFilePath { get; }
+
+        /// <summary>
         /// The SSL/TLS backend.
         /// </summary>
         TlsBackend TlsBackend { get; }
@@ -624,6 +630,9 @@ namespace GitCredentialManager
 
         public string CustomCertificateBundlePath =>
             TryGetPathSetting(KnownEnvars.GitSslCaInfo, KnownGitCfg.Http.SectionName, KnownGitCfg.Http.SslCaInfo, out string value) ? value : null;
+
+        public string CustomCookieFilePath =>
+            TryGetPathSetting(null, KnownGitCfg.Http.SectionName, KnownGitCfg.Http.CookieFile, out string value) ? value : null;
 
         public TlsBackend TlsBackend =>
             TryGetSetting(null, KnownGitCfg.Http.SectionName, KnownGitCfg.Http.SslBackend, out string config)

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -43,6 +43,8 @@ namespace GitCredentialManager.Tests.Objects
 
         public string CustomCertificateBundlePath { get; set; }
 
+        public string CustomCookieFilePath { get; set; }
+
         public TlsBackend TlsBackend { get; set; }
 
         public bool UseCustomCertificateBundleWithSchannel { get; set; }
@@ -170,6 +172,8 @@ namespace GitCredentialManager.Tests.Objects
         string ISettings.CredentialBackingStore => CredentialBackingStore;
 
         string ISettings.CustomCertificateBundlePath => CustomCertificateBundlePath;
+
+        string ISettings.CustomCookieFilePath => CustomCookieFilePath;
 
         TlsBackend ISettings.TlsBackend => TlsBackend;
 


### PR DESCRIPTION
## Contents
#1160 
I added code to support [`httpCookieFile`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpcookieFile).
If `httpCookieFile` is set in `gitconfig`, gcm will add cookie header to request headers such as requests about OAuth2.

## Note
- This does not support [`http.saveCookies`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpsaveCookies) because when it is set, built-in git will update cookie and gcm need not to update.
- If you want git via reverse proxy authentication, you can use this (https://github.com/miya789/git-via-reverse-proxy-authn). The structure image is like this:
  - https://stackoverflow.com/questions/64731848/git-cli-verification-via-saml-sso