### PR TITLE
release: remove .NET tool deployment from release workflow

### DIFF
--- a/.github/workflows/release-dotnet-tool.yaml
+++ b/.github/workflows/release-dotnet-tool.yaml
@@ -1,0 +1,22 @@
+name: release-dotnet-tool
+on:
+  release:
+    types: [released]
+
+jobs:
+  release:
+    runs-on: windows-latest
+    environment: release
+    steps:
+    - name: Download NuGet package from release and publish
+      run: |
+        # Get asset information
+        $github = Get-Content '${{ github.event_path }}' | ConvertFrom-Json
+        $asset = $github.release.assets | Where-Object -Property name -match '.nupkg$'
+
+        # Download asset
+        Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $asset.name
+
+        # Publish asset
+        dotnet nuget push $asset.name --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+      shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -791,8 +791,3 @@ jobs:
               // Upload .NET tool package
               uploadDirectoryToRelease('dotnet-tool-sign'),
             ]);
-
-      - name: Publish .NET tool to nuget.org
-        run: |
-          dotnet nuget push dotnet-tool-sign/*.nupkg \
-            --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Move deployment of .NET tool to nuget.org out of release workflow. With these changes, the .NET tool is published only after a release has been published (rather than with the creation of the release). This emulates what we currently do with Homebrew and ensures we only release the .NET tool when we are confident enough in a release's stability to publish it.

A test of this new deployment workflow targeting [NuGet's QA Gallery](https://int.nugettest.org/packages/git-credential-manager/) can be found [here](https://github.com/ldennington/git-credential-manager/actions/runs/5018996340/jobs/8999029309).