### PR TITLE
platformutils: use `Version.ToString()` to get number only

### DIFF
--- a/src/shared/Core/PlatformUtils.cs
+++ b/src/shared/Core/PlatformUtils.cs
@@ -372,7 +372,7 @@ namespace GitCredentialManager
 #endif
             if (IsWindows() || IsMacOS())
             {
-                return Environment.OSVersion.VersionString;
+                return Environment.OSVersion.Version.ToString();
             }
 
             if (IsLinux())


### PR DESCRIPTION
Use `Environment.OSVersion.Version.ToString()` over `.VersionString` to get a numerical version only on Windows and macOS.

Using `.VersionString` on macOS you get values like "Unix 13.3.1" rather than "13.3.1", and on Windows you get "Microsoft Windows NT 10.x.y.z" rather than "10.x.y.z".