### PR TITLE
Update `System.CommandLine` to latest version

### DIFF
--- a/src/shared/Atlassian.Bitbucket/UI/Commands/CredentialsCommand.cs
+++ b/src/shared/Atlassian.Bitbucket/UI/Commands/CredentialsCommand.cs
@@ -15,23 +15,19 @@ namespace Atlassian.Bitbucket.UI.Commands
         protected CredentialsCommand(ICommandContext context)
             : base(context, "prompt", "Show authentication prompt.")
         {
-            AddOption(
-                new Option<string>("--url", "Bitbucket Server or Data Center URL")
-            );
+            var url = new Option<Uri>("--url", "Bitbucket Server or Data Center URL");
+            AddOption(url);
 
-            AddOption(
-                new Option<string>("--username", "Username or email.")
-            );
+            var userName = new Option<string>("--username", "Username or email.");
+            AddOption(userName);
 
-            AddOption(
-                new Option("--show-oauth", "Show OAuth option.")
-            );
+            var oauth = new Option<bool>("--show-oauth", "Show OAuth option.");
+            AddOption(oauth);
 
-            AddOption(
-                new Option("--show-basic", "Show username/password option.")
-            );
+            var basic = new Option<bool>("--show-basic", "Show username/password option.");
+            AddOption(basic);
 
-            Handler = CommandHandler.Create<Uri, string, bool, bool>(ExecuteAsync);
+            this.SetHandler(ExecuteAsync, url, userName, oauth, basic);
         }
 
         private async Task<int> ExecuteAsync(Uri url, string userName, bool showOAuth, bool showBasic)

--- a/src/shared/Core/Commands/ConfigurationCommands.cs
+++ b/src/shared/Core/Commands/ConfigurationCommands.cs
@@ -1,5 +1,4 @@
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Threading.Tasks;
 
 namespace GitCredentialManager.Commands
@@ -15,9 +14,10 @@ namespace GitCredentialManager.Commands
             Context = context;
             ConfigurationService = configurationService;
 
-            AddOption(new Option<bool>("--system", "Modify the system-wide Git configuration instead of the current user"));
+            var system = new Option<bool>("--system", "Modify the system-wide Git configuration instead of the current user");
+            AddOption(system);
 
-            Handler = CommandHandler.Create<bool>(ExecuteAsync);
+            this.SetHandler(ExecuteAsync, system);
         }
 
         protected ICommandContext Context { get; }

--- a/src/shared/Core/Commands/DiagnoseCommand.cs
+++ b/src/shared/Core/Commands/DiagnoseCommand.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.IO;
-using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using GitCredentialManager.Diagnostics;
@@ -34,11 +32,10 @@ namespace GitCredentialManager.Commands
                 new MicrosoftAuthenticationDiagnostic(context)
             };
 
-            AddOption(
-                new Option<string>(new []{"--output", "-o"}, "Output directory for diagnostic logs.")
-            );
+            var output = new Option<string>(new[] { "--output", "-o" }, "Output directory for diagnostic logs.");
+            AddOption(output);
 
-            Handler = CommandHandler.Create<string>(ExecuteAsync);
+            this.SetHandler(ExecuteAsync, output);
         }
 
         public void AddDiagnostic(IDiagnostic diagnostic)

--- a/src/shared/Core/Commands/GitCommandBase.cs
+++ b/src/shared/Core/Commands/GitCommandBase.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Threading.Tasks;
 
 namespace GitCredentialManager.Commands
@@ -23,7 +22,7 @@ namespace GitCredentialManager.Commands
             Context = context;
             _hostProviderRegistry = hostProviderRegistry;
 
-            Handler = CommandHandler.Create(ExecuteAsync);
+            this.SetHandler(ExecuteAsync);
         }
 
         protected ICommandContext Context { get; }

--- a/src/shared/Core/Core.csproj
+++ b/src/shared/Core/Core.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.52.0" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.28.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Avalonia" Version="11.0.0-preview6" />
     <PackageReference Include="Avalonia.Skia" Version="11.0.0-preview6" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview6" />

--- a/src/shared/Core/UI/Commands/CredentialsCommand.cs
+++ b/src/shared/Core/UI/Commands/CredentialsCommand.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Threading;
 using System.Threading.Tasks;
 using GitCredentialManager.UI.ViewModels;
@@ -13,52 +11,40 @@ namespace GitCredentialManager.UI.Commands
         protected CredentialsCommand(ICommandContext context)
             : base(context, "basic", "Show basic authentication prompt.")
         {
-            AddOption(
-                new Option<string>("--title", "Window title (optional).")
-            );
+            var title = new Option<string>("--title", "Window title (optional).");
+            AddOption(title);
 
-            AddOption(
-                new Option<string>("--resource", "Resource name or URL (optional).")
-            );
+            var resource = new Option<string>("--resource", "Resource name or URL (optional).");
+            AddOption(resource);
 
-            AddOption(
-                new Option<string>("--username", "User name (optional).")
-            );
+            var userName = new Option<string>("--username", "User name (optional).");
+            AddOption(userName);
 
-            AddOption(
-                new Option("--no-logo", "Hide the Git Credential Manager logo and logotype.")
-            );
+            var noLogo = new Option<bool>("--no-logo", "Hide the Git Credential Manager logo and logotype.");
+            AddOption(noLogo);
 
-            Handler = CommandHandler.Create<CommandOptions>(ExecuteAsync);
+            this.SetHandler(ExecuteAsync, title, resource, userName, noLogo);
         }
 
-        private class CommandOptions
-        {
-            public string Title { get; set; }
-            public string Resource { get; set; }
-            public string UserName { get; set; }
-            public bool NoLogo { get; set; }
-        }
-
-        private async Task<int> ExecuteAsync(CommandOptions options)
+        private async Task<int> ExecuteAsync(string title, string resource, string userName, bool noLogo)
         {
             var viewModel = new CredentialsViewModel();
 
-            if (!string.IsNullOrWhiteSpace(options.Title))
+            if (!string.IsNullOrWhiteSpace(title))
             {
-                viewModel.Title = options.Title;
+                viewModel.Title = title;
             }
 
-            viewModel.Description = !string.IsNullOrWhiteSpace(options.Resource)
-                ? $"Enter your credentials for '{options.Resource}'"
+            viewModel.Description = !string.IsNullOrWhiteSpace(resource)
+                ? $"Enter your credentials for '{resource}'"
                 : "Enter your credentials";
 
-            if (!string.IsNullOrWhiteSpace(options.UserName))
+            if (!string.IsNullOrWhiteSpace(userName))
             {
-                viewModel.UserName = options.UserName;
+                viewModel.UserName = userName;
             }
 
-            viewModel.ShowProductHeader = !options.NoLogo;
+            viewModel.ShowProductHeader = !noLogo;
 
             await ShowAsync(viewModel, CancellationToken.None);
 

--- a/src/shared/Core/UI/Commands/DefaultAccountCommand.cs
+++ b/src/shared/Core/UI/Commands/DefaultAccountCommand.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Threading;
 using System.Threading.Tasks;
 using GitCredentialManager.UI.ViewModels;
@@ -12,40 +11,30 @@ public abstract class DefaultAccountCommand : HelperCommand
     protected DefaultAccountCommand(ICommandContext context)
         : base(context, "default-account", "Show prompt to confirm use of the default OS account.")
     {
-        AddOption(
-            new Option<string>("--title", "Window title (optional).")
-        );
+        var title = new Option<string>("--title", "Window title (optional).");
+        AddOption(title);
 
-        AddOption(
-            new Option<string>("--username", "User name to display.")
-            {
-                IsRequired = true
-            }
-        );
+        var userName = new Option<string>("--username", "User name to display.")
+        {
+            IsRequired = true
+        };
+        AddOption(userName);
 
-        AddOption(
-            new Option("--no-logo", "Hide the Git Credential Manager logo and logotype.")
-        );
+        var noLogo = new Option<bool>("--no-logo", "Hide the Git Credential Manager logo and logotype.");
+        AddOption(noLogo);
 
-        Handler = CommandHandler.Create(ExecuteAsync);
+        this.SetHandler(ExecuteAsync, title, userName, noLogo);
     }
 
-    private class CommandOptions
-    {
-        public string Title { get; set; }
-        public string UserName { get; set; }
-        public bool NoLogo { get; set; }
-    }
-
-    private async Task<int> ExecuteAsync(CommandOptions options)
+    private async Task<int> ExecuteAsync(string title, string userName, bool noLogo)
     {
         var viewModel = new DefaultAccountViewModel(Context.Environment)
         {
-            Title = !string.IsNullOrWhiteSpace(options.Title)
-                ? options.Title
+            Title = !string.IsNullOrWhiteSpace(title)
+                ? title
                 : "Git Credential Manager",
-            UserName = options.UserName,
-            ShowProductHeader = !options.NoLogo
+            UserName = userName,
+            ShowProductHeader = !noLogo
         };
 
         await ShowAsync(viewModel, CancellationToken.None);

--- a/src/shared/Core/UI/Commands/DeviceCodeCommand.cs
+++ b/src/shared/Core/UI/Commands/DeviceCodeCommand.cs
@@ -1,6 +1,4 @@
-using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Threading;
 using System.Threading.Tasks;
 using GitCredentialManager.UI.ViewModels;
@@ -12,19 +10,16 @@ namespace GitCredentialManager.UI.Commands
         protected DeviceCodeCommand(ICommandContext context)
             : base(context, "device", "Show device code prompt.")
         {
-            AddOption(
-                new Option<string>("--code", "User code.")
-            );
+            var code = new Option<string>("--code", "User code.");
+            AddOption(code);
 
-            AddOption(
-                new Option<string>("--url", "Verification URL.")
-            );
+            var url =new Option<string>("--url", "Verification URL.");
+            AddOption(url);
 
-            AddOption(
-                new Option("--no-logo", "Hide the Git Credential Manager logo and logotype.")
-            );
+            var noLogo = new Option<bool>("--no-logo", "Hide the Git Credential Manager logo and logotype.");
+            AddOption(noLogo);
 
-            Handler = CommandHandler.Create<string, string, bool>(ExecuteAsync);
+            this.SetHandler(ExecuteAsync, code, url, noLogo);
         }
 
         private async Task<int> ExecuteAsync(string code, string url, bool noLogo)

--- a/src/shared/Core/UI/Commands/OAuthCommand.cs
+++ b/src/shared/Core/UI/Commands/OAuthCommand.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Threading;
 using System.Threading.Tasks;
 using GitCredentialManager.Authentication;
@@ -14,54 +13,40 @@ namespace GitCredentialManager.UI.Commands
         protected OAuthCommand(ICommandContext context)
             : base(context, "oauth", "Show OAuth authentication prompt.")
         {
-            AddOption(
-                new Option<string>("--title", "Window title (optional).")
-            );
+            var title = new Option<string>("--title", "Window title (optional).");
+            AddOption(title);
 
-            AddOption(
-                new Option<string>("--resource", "Resource name or URL (optional).")
-            );
+            var resource = new Option<string>("--resource", "Resource name or URL (optional).");
+            AddOption(resource);
 
-            AddOption(
-                new Option("--browser", "Show browser authentication option.")
-            );
+            var browser = new Option<bool>("--browser", "Show browser authentication option.");
+            AddOption(browser);
 
-            AddOption(
-                new Option("--device-code", "Show device code authentication option.")
-            );
+            var deviceCode = new Option<bool>("--device-code", "Show device code authentication option.");
+            AddOption(deviceCode);
 
-            AddOption(
-                new Option("--no-logo", "Hide the Git Credential Manager logo and logotype.")
-            );
+            var noLogo = new Option<bool>("--no-logo", "Hide the Git Credential Manager logo and logotype.");
+            AddOption(noLogo);
 
-            Handler = CommandHandler.Create<CommandOptions>(ExecuteAsync);
+            this.SetHandler(ExecuteAsync, title, resource, browser, deviceCode, noLogo);
         }
 
-        private class CommandOptions
-        {
-            public string Title { get; set; }
-            public string Resource { get; set; }
-            public bool Browser { get; set; }
-            public bool DeviceCode { get; set; }
-            public bool NoLogo { get; set; }
-        }
-
-        private async Task<int> ExecuteAsync(CommandOptions options)
+        private async Task<int> ExecuteAsync(string title, string resource, bool browser, bool deviceCode, bool noLogo)
         {
             var viewModel = new OAuthViewModel();
 
-            if (!string.IsNullOrWhiteSpace(options.Title))
+            if (!string.IsNullOrWhiteSpace(title))
             {
-                viewModel.Title = options.Title;
+                viewModel.Title = title;
             }
 
-            viewModel.Description = !string.IsNullOrWhiteSpace(options.Resource)
-                ? $"Sign in to '{options.Resource}'"
+            viewModel.Description = !string.IsNullOrWhiteSpace(resource)
+                ? $"Sign in to '{resource}'"
                 : "Select a sign-in option";
 
-            viewModel.ShowBrowserLogin = options.Browser;
-            viewModel.ShowDeviceCodeLogin = options.DeviceCode;
-            viewModel.ShowProductHeader = !options.NoLogo;
+            viewModel.ShowBrowserLogin = browser;
+            viewModel.ShowDeviceCodeLogin = deviceCode;
+            viewModel.ShowProductHeader = !noLogo;
 
             await ShowAsync(viewModel, CancellationToken.None);
 

--- a/src/shared/GitHub/UI/Commands/CredentialsCommand.cs
+++ b/src/shared/GitHub/UI/Commands/CredentialsCommand.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Threading;
 using System.Threading.Tasks;
 using GitHub.UI.ViewModels;
@@ -15,66 +14,49 @@ namespace GitHub.UI.Commands
         protected CredentialsCommand(ICommandContext context)
             : base(context, "prompt", "Show authentication prompt.")
         {
-            AddOption(
-                new Option<string>("--enterprise-url", "GitHub Enterprise URL.")
-            );
+            var url = new Option<string>("--enterprise-url", "GitHub Enterprise URL.");
+            AddOption(url);
 
-            AddOption(
-                new Option<string>("--username", "Username or email.")
-            );
+            var userName = new Option<string>("--username", "Username or email.");
+            AddOption(userName);
 
-            AddOption(
-                new Option("--basic", "Enable username/password (basic) authentication.")
-            );
+            var basic = new Option<bool>("--basic", "Enable username/password (basic) authentication.");
+            AddOption(basic);
 
-            AddOption(
-                new Option("--browser", "Enable browser-based OAuth authentication.")
-            );
+            var browser = new Option<bool>("--browser", "Enable browser-based OAuth authentication.");
+            AddOption(browser);
 
-            AddOption(
-                new Option("--device", "Enable device code OAuth authentication.")
-            );
+            var device = new Option<bool>("--device", "Enable device code OAuth authentication.");
+            AddOption(device);
 
-            AddOption(
-                new Option("--pat", "Enable personal access token authentication.")
-            );
+            var pat = new Option<bool>("--pat", "Enable personal access token authentication.");
+            AddOption(pat);
 
-            AddOption(
-                new Option("--all", "Enable all available authentication options.")
-            );
+            var all = new Option<bool>("--all", "Enable all available authentication options.");
+            AddOption(all);
 
-            Handler = CommandHandler.Create<CommandOptions>(ExecuteAsync);
+            this.SetHandler(ExecuteAsync, url, userName, basic, browser, device, pat, all);
         }
 
-        private class CommandOptions
-        {
-            public string UserName { get; set; }
-            public string EnterpriseUrl { get; set; }
-            public bool Basic { get; set; }
-            public bool Browser { get; set; }
-            public bool Device { get; set; }
-            public bool Pat { get; set; }
-            public bool All { get; set; }
-        }
-
-        private async Task<int> ExecuteAsync(CommandOptions options)
+        private async Task<int> ExecuteAsync(string userName, string enterpriseUrl,
+            bool basic, bool browser, bool device, bool pat, bool all)
         {
             var viewModel = new CredentialsViewModel(Context.Environment, Context.ProcessManager)
             {
-                ShowBrowserLogin = options.All || options.Browser,
-                ShowDeviceLogin  = options.All || options.Device,
-                ShowTokenLogin   = options.All || options.Pat,
-                ShowBasicLogin   = options.All || options.Basic,
+                ShowBrowserLogin = all || browser,
+                ShowDeviceLogin  = all || device,
+                ShowTokenLogin   = all || pat,
+                ShowBasicLogin   = all || basic,
             };
 
-            if (!GitHubHostProvider.IsGitHubDotCom(options.EnterpriseUrl))
+            if (!GitHubHostProvider.IsGitHubDotCom(enterpriseUrl))
             {
-                viewModel.EnterpriseUrl = options.EnterpriseUrl;
+                viewModel.EnterpriseUrl = enterpriseUrl;
             }
 
-            if (!string.IsNullOrWhiteSpace(options.UserName))
+            if (!string.IsNullOrWhiteSpace(userName))
             {
-                viewModel.UserName = options.UserName;
+                viewModel.UserName = userName;
             }
 
             await ShowAsync(viewModel, CancellationToken.None);

--- a/src/shared/GitHub/UI/Commands/DeviceCommand.cs
+++ b/src/shared/GitHub/UI/Commands/DeviceCommand.cs
@@ -1,6 +1,4 @@
-using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Threading;
 using System.Threading.Tasks;
 using GitHub.UI.ViewModels;
@@ -14,15 +12,13 @@ namespace GitHub.UI.Commands
         protected DeviceCodeCommand(ICommandContext context)
             : base(context, "device", "Show device code prompt.")
         {
-            AddOption(
-                new Option<string>("--code", "User code.")
-            );
+            var code = new Option<string>("--code", "User code.");
+            AddOption(code);
 
-            AddOption(
-                new Option<string>("--url", "Verification URL.")
-            );
+            var url = new Option<string>("--url", "Verification URL.");
+            AddOption(url);
 
-            Handler = CommandHandler.Create<string, string>(ExecuteAsync);
+            this.SetHandler(ExecuteAsync, code, url);
         }
 
         private async Task<int> ExecuteAsync(string code, string url)

--- a/src/shared/GitHub/UI/Commands/TwoFactorCommand.cs
+++ b/src/shared/GitHub/UI/Commands/TwoFactorCommand.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Threading;
 using System.Threading.Tasks;
 using GitHub.UI.ViewModels;
@@ -15,11 +13,10 @@ namespace GitHub.UI.Commands
         protected TwoFactorCommand(ICommandContext context)
             : base(context, "2fa", "Show two-factor prompt.")
         {
-            AddOption(
-                new Option("--sms", "Two-factor code was sent via SMS.")
-            );
+            var sms = new Option<bool>("--sms", "Two-factor code was sent via SMS.");
+            AddOption(sms);
 
-            Handler = CommandHandler.Create<bool>(ExecuteAsync);
+            this.SetHandler(ExecuteAsync, sms);
         }
 
         private async Task<int> ExecuteAsync(bool sms)

--- a/src/shared/GitLab/UI/Commands/CredentialsCommand.cs
+++ b/src/shared/GitLab/UI/Commands/CredentialsCommand.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Threading;
 using System.Threading.Tasks;
 using GitLab.UI.ViewModels;
@@ -15,61 +14,45 @@ namespace GitLab.UI.Commands
         protected CredentialsCommand(ICommandContext context)
             : base(context, "prompt", "Show authentication prompt.")
         {
-            AddOption(
-                new Option<string>("--url", "GitLab instance URL.")
-            );
+            var url = new Option<string>("--url", "GitLab instance URL.");
+            AddOption(url);
 
-            AddOption(
-                new Option<string>("--username", "Username or email.")
-            );
+            var userName = new Option<string>("--username", "Username or email.");
+            AddOption(userName);
 
-            AddOption(
-                new Option("--basic", "Enable username/password (basic) authentication.")
-            );
+            var basic = new Option<bool>("--basic", "Enable username/password (basic) authentication.");
+            AddOption(basic);
 
-            AddOption(
-                new Option("--browser", "Enable browser-based OAuth authentication.")
-            );
+            var browser = new Option<bool>("--browser", "Enable browser-based OAuth authentication.");
+            AddOption(browser);
 
-            AddOption(
-                new Option("--pat", "Enable personal access token authentication.")
-            );
+            var pat = new Option<bool>("--pat", "Enable personal access token authentication.");
+            AddOption(pat);
 
-            AddOption(
-                new Option("--all", "Enable all available authentication options.")
-            );
+            var all = new Option<bool>("--all", "Enable all available authentication options.");
+            AddOption(all);
 
-            Handler = CommandHandler.Create<CommandOptions>(ExecuteAsync);
+            this.SetHandler(ExecuteAsync, url, userName, basic, browser, pat, all);
         }
 
-        private class CommandOptions
-        {
-            public string UserName { get; set; }
-            public string Url { get; set; }
-            public bool Basic { get; set; }
-            public bool Browser { get; set; }
-            public bool Pat { get; set; }
-            public bool All { get; set; }
-        }
-
-        private async Task<int> ExecuteAsync(CommandOptions options)
+        private async Task<int> ExecuteAsync(string userName, string url, bool basic, bool browser, bool pat, bool all)
         {
             var viewModel = new CredentialsViewModel(Context.Environment)
             {
-                ShowBrowserLogin = options.All || options.Browser,
-                ShowTokenLogin   = options.All || options.Pat,
-                ShowBasicLogin   = options.All || options.Basic,
+                ShowBrowserLogin = all || browser,
+                ShowTokenLogin   = all || pat,
+                ShowBasicLogin   = all || basic,
             };
 
-            if (Uri.TryCreate(options.Url, UriKind.Absolute, out Uri uri) && !GitLabConstants.IsGitLabDotCom(uri))
+            if (Uri.TryCreate(url, UriKind.Absolute, out Uri uri) && !GitLabConstants.IsGitLabDotCom(uri))
             {
-                viewModel.Url = options.Url;
+                viewModel.Url = url;
             }
 
-            if (!string.IsNullOrWhiteSpace(options.UserName))
+            if (!string.IsNullOrWhiteSpace(userName))
             {
-                viewModel.UserName = options.UserName;
-                viewModel.TokenUserName = options.UserName;
+                viewModel.UserName = userName;
+                viewModel.TokenUserName = userName;
             }
 
             await ShowAsync(viewModel, CancellationToken.None);


### PR DESCRIPTION
Update `System.CommandLine` to the latest version. There have been some changes to the API since the last version around binding a command to a handler, and the removal of the model binding.

We now explicitly specify the options when setting the handlers. This means we should be able to avoid the use of reflection inside of the package, making it trimable in the future!