### PR TITLE
github: add multi-account prompt and login/logout commands

### DIFF
--- a/docs/multiple-users.md
+++ b/docs/multiple-users.md
@@ -79,3 +79,11 @@ git remote set-url origin https://employee9999@example.com/big-company/secret-re
 which you should also be aware of if you're using it.
 
 [azure-access-tokens]: azrepos-users-and-tokens.md
+
+## GitHub
+
+You can use the `github [list | login | logout]` commands to manage your GitHub
+accounts. These commands are documented in the [command-line usage][cli-usage]
+or by running `git-credential-manager github --help`.
+
+[cli-usage]: usage.md

--- a/docs/multiple-users.md
+++ b/docs/multiple-users.md
@@ -4,6 +4,15 @@ If you work with multiple different identities on a single Git hosting service,
 you may be wondering if Git Credential Manager (GCM) supports this workflow. The
 answer is yes, with a bit of complexity due to how it interoperates with Git.
 
+---
+
+**Prompted to select an account?**
+
+Read the [**TL;DR** section][tldr] below for a quick summary of how to make GCM
+remember which account to use for which repository.
+
+---
+
 ## Foundations: Git and Git hosts
 
 Git itself doesn't have a single, strong concept of "user". There's the
@@ -86,4 +95,28 @@ You can use the `github [list | login | logout]` commands to manage your GitHub
 accounts. These commands are documented in the [command-line usage][cli-usage]
 or by running `git-credential-manager github --help`.
 
+## TL;DR: Tell GCM to remember which account to use
+
+The easiest way to have GCM remember which account to use for which repository
+is to include the account name in the remote URL. If you're using HTTPS remotes,
+you can include the account name in the URL by inserting it before the `@` sign
+in the domain name.
+
+For example, if you want to always use the `alice` account for the `mona/test`
+GitHub repository, you can clone it using the `alice` account by running:
+
+```shell
+git clone https://alice@github.com/mona/test
+```
+
+To update an existing clone, you can run `git remote set-url` to update the URL:
+
+```shell
+git remote set-url origin https://alice@github.com/mona/test
+```
+
+If your account name includes an `@` then remember to escape this character
+using `%40`: `https://alice%40contoso.com@example.com/test`.
+
+[tldr]: #tldr-tell-gcm-to-remember-which-account-to-use
 [cli-usage]: usage.md

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -46,3 +46,8 @@ For more information about managing user account bindings see
 
 [azure-access-tokens-ua]: azrepos-users-and-tokens.md#useraccounts
 [git-credentials-custom-helpers]: https://git-scm.com/docs/gitcredentials#_custom_helpers
+
+### github
+
+Interact with the GitHub host provider to manage your accounts on GitHub.com and
+GitHub Enterprise Server instances.

--- a/src/shared/Core.Tests/Authentication/BasicAuthenticationTests.cs
+++ b/src/shared/Core.Tests/Authentication/BasicAuthenticationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using GitCredentialManager.Authentication;
 using GitCredentialManager.Tests.Objects;
@@ -101,7 +102,7 @@ namespace GitCredentialManager.Tests.Authentication
             auth.Setup(x => x.InvokeHelperAsync(
                     It.IsAny<string>(),
                     $"basic --resource {testResource}",
-                    It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<StreamReader>(),
                     It.IsAny<System.Threading.CancellationToken>()))
                 .ReturnsAsync(
                     new Dictionary<string, string>
@@ -147,7 +148,7 @@ namespace GitCredentialManager.Tests.Authentication
             auth.Setup(x => x.InvokeHelperAsync(
                     It.IsAny<string>(),
                     $"basic --resource {testResource} --username {testUserName}",
-                    It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<StreamReader>(),
                     It.IsAny<System.Threading.CancellationToken>()))
                 .ReturnsAsync(
                     new Dictionary<string, string>

--- a/src/shared/Core/Application.cs
+++ b/src/shared/Core/Application.cs
@@ -4,7 +4,6 @@ using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
-using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -70,6 +69,18 @@ namespace GitCredentialManager
             var rootCommand = new RootCommand();
             var diagnoseCommand = new DiagnoseCommand(Context);
 
+            // Add common options
+            var noGuiOption = new Option<bool>("--no-ui", "Do not use graphical user interface prompts");
+            rootCommand.AddGlobalOption(noGuiOption);
+
+            void NoGuiOptionHandler(InvocationContext context)
+            {
+                if (context.ParseResult.HasOption(noGuiOption))
+                {
+                    Context.Settings.IsGuiPromptsEnabled = false;
+                }
+            }
+
             // Add standard commands
             rootCommand.AddCommand(new GetCommand(Context, _providerRegistry));
             rootCommand.AddCommand(new StoreCommand(Context, _providerRegistry));
@@ -103,6 +114,7 @@ namespace GitCredentialManager
             var parser = new CommandLineBuilder(rootCommand)
                 .UseDefaults()
                 .UseExceptionHandler(OnException)
+                .AddMiddleware(NoGuiOptionHandler)
                 .Build();
 
             return await parser.InvokeAsync(args);

--- a/src/shared/Core/CommandExtensions.cs
+++ b/src/shared/Core/CommandExtensions.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Diagnostics;
+using System.Linq;
+
+namespace GitCredentialManager;
+
+public static class CommandExtensions
+{
+    /// <summary>
+    /// Add options to a command.
+    /// </summary>
+    /// <param name="command">Command to add options to.</param>
+    /// <param name="arity">Specify the required arity of the options.</param>
+    /// <param name="options">Set of options to add.</param>
+    public static void AddOptionSet(this Command command, OptionArity arity, params Option[] options)
+    {
+        foreach (Option option in options)
+        {
+            command.AddOption(option);
+        }
+
+        // No need to add a validator if 0..* options are OK
+        if (arity != OptionArity.ZeroOrMore)
+        {
+            command.AddValidator(r =>
+            {
+                int count = options.Count(o => r.FindResultFor(o) is not null);
+                string optionList = string.Join(", ", options.Select(s => $"--{s.Name}"));
+                switch (arity)
+                {
+                    case OptionArity.ZeroOrOne:
+                        if (count > 1)
+                            r.ErrorMessage = $"Can only specify one of: {optionList}";
+                        break;
+
+                    case OptionArity.ExactlyOne:
+                        if (count != 1)
+                            r.ErrorMessage = $"Require exactly one of: {optionList}";
+                        break;
+
+                    case OptionArity.Zero:
+                        if (count != 0)
+                        {
+                            IEnumerable<string> usedOptions = options.Where(o => r.FindResultFor(o) is not null)
+                                .Select(x => $"--{x.Name}");
+                            r.ErrorMessage = $"{command.Name} does not support options: {string.Join(", ", usedOptions)}";
+                        }
+                        break;
+
+                    case OptionArity.OneOrMore:
+                        if (count == 0)
+                            r.ErrorMessage = $"Require at least one of: {optionList}";
+                        break;
+
+                    case OptionArity.ZeroOrMore:
+                        Debug.Fail("Should not have a validator for an arity of ZeroOrMore.");
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(arity), arity, null);
+                }
+            });
+        }
+    }
+}
+
+public enum OptionArity
+{
+    /// <summary>
+    /// An arity that may have multiple values.
+    /// </summary>
+    ZeroOrMore = 0,
+
+    /// <summary>
+    /// An arity that must have exactly one value.
+    /// </summary>
+    ExactlyOne,
+
+    /// <summary>
+    /// An arity that does not allow any values.
+    /// </summary>
+    Zero,
+
+    /// <summary>
+    /// An arity that may have one value, but no more than one.
+    /// </summary>
+    ZeroOrOne,
+
+    /// <summary>
+    /// An arity that must have at least one value.
+    /// </summary>
+    OneOrMore,
+}

--- a/src/shared/Core/Constants.cs
+++ b/src/shared/Core/Constants.cs
@@ -211,6 +211,7 @@ namespace GitCredentialManager
             public const string GcmAutoDetect          = "https://aka.ms/gcm/autodetect";
             public const string GcmExecRename          = "https://aka.ms/gcm/rename";
             public const string GcmDefaultAccount      = "https://aka.ms/gcm/defaultaccount";
+            public const string GcmMultipleUsers       = "https://aka.ms/gcm/multipleusers";
         }
 
         private static Version _gcmVersion;

--- a/src/shared/Core/CredentialCacheStore.cs
+++ b/src/shared/Core/CredentialCacheStore.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GitCredentialManager
@@ -21,6 +22,25 @@ namespace GitCredentialManager
         }
 
         #region ICredentialStore
+
+        public IList<string> GetAccounts(string service)
+        {
+            // Listing accounts is not supported by the credential-cache store so we just attempt to retrieve
+            // the username from first credential for the given service and return an empty list if it fails.
+            var input = MakeGitCredentialsEntry(service, null);
+
+            var result = _git.InvokeHelperAsync(
+                $"credential-cache get {_options}",
+                input
+            ).GetAwaiter().GetResult();
+
+            if (result.TryGetValue("username", out string value))
+            {
+                return new List<string> { value };
+            }
+
+            return Array.Empty<string>();
+        }
 
         public ICredential Get(string service, string account)
         {

--- a/src/shared/Core/CredentialStore.cs
+++ b/src/shared/Core/CredentialStore.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using GitCredentialManager.Interop.Linux;
@@ -23,6 +24,12 @@ namespace GitCredentialManager
         }
 
         #region ICredentialStore
+
+        public IList<string> GetAccounts(string service)
+        {
+            EnsureBackingStore();
+            return _backingStore.GetAccounts(service);
+        }
 
         public ICredential Get(string service, string account)
         {

--- a/src/shared/Core/ICredentialStore.cs
+++ b/src/shared/Core/ICredentialStore.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 
 namespace GitCredentialManager
 {
@@ -6,6 +7,13 @@ namespace GitCredentialManager
     /// </summary>
     public interface ICredentialStore
     {
+        /// <summary>
+        /// Get all accounts from the store for the given service.
+        /// </summary>
+        /// <param name="service">Name of the service to match against. Use null to match all values.</param>
+        /// <returns>All accounts that match the query.</returns>
+        IList<string> GetAccounts(string service);
+
         /// <summary>
         /// Get the first credential from the store that matches the given query.
         /// </summary>

--- a/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
+++ b/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
@@ -37,6 +37,11 @@ namespace GitCredentialManager.Interop.Linux
 
         #region ICredentialStore
 
+        public IList<string> GetAccounts(string service)
+        {
+            return Enumerate(service, null).Select(x => x.Account).ToList();
+        }
+
         public ICredential Get(string service, string account)
         {
             return Enumerate(service, account).FirstOrDefault();

--- a/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
+++ b/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using static GitCredentialManager.Interop.Linux.Native.Gobject;
@@ -35,7 +37,12 @@ namespace GitCredentialManager.Interop.Linux
 
         #region ICredentialStore
 
-        public unsafe ICredential Get(string service, string account)
+        public ICredential Get(string service, string account)
+        {
+            return Enumerate(service, account).FirstOrDefault();
+        }
+
+        private unsafe IEnumerable<ICredential> Enumerate(string service, string account)
         {
             GHashTable* queryAttrs = null;
             GList* results = null;
@@ -49,7 +56,7 @@ namespace GitCredentialManager.Interop.Linux
 
                 SecretSchema schema = GetSchema();
 
-                // Execute search query and return the first result
+                // Execute search query and return all results
                 results = secret_service_search_sync(
                     secService,
                     ref schema,
@@ -65,9 +72,12 @@ namespace GitCredentialManager.Interop.Linux
                     throw new InteropException("Failed to search for credentials", code, new Exception(message));
                 }
 
-                if (results != null && results->data != IntPtr.Zero)
+                var credentials = new List<ICredential>();
+
+                GList* itemPtr = results;
+                while (itemPtr != null && itemPtr->data != IntPtr.Zero)
                 {
-                    SecretItem* item = (SecretItem*) results->data;
+                    SecretItem* item = (SecretItem*) itemPtr->data;
 
                     // Although we've unlocked the collection during the search call,
                     // an item can also be individually locked within a collection.
@@ -95,10 +105,12 @@ namespace GitCredentialManager.Interop.Linux
                         }
                     }
 
-                    return CreateCredentialFromItem(item);
+                    credentials.Add(CreateCredentialFromItem(item));
+
+                    itemPtr = (GList*)itemPtr->next;
                 }
 
-                return null;
+                return credentials;
             }
             finally
             {

--- a/src/shared/Core/Interop/MacOS/Native/SecurityFramework.cs
+++ b/src/shared/Core/Interop/MacOS/Native/SecurityFramework.cs
@@ -16,6 +16,7 @@ namespace GitCredentialManager.Interop.MacOS.Native
         public static readonly IntPtr kSecReturnRef;
         public static readonly IntPtr kSecReturnPersistentRef;
         public static readonly IntPtr kSecClassGenericPassword;
+        public static readonly IntPtr kSecMatchLimitAll;
         public static readonly IntPtr kSecMatchLimitOne;
         public static readonly IntPtr kSecMatchItemList;
         public static readonly IntPtr kSecAttrLabel;
@@ -35,6 +36,7 @@ namespace GitCredentialManager.Interop.MacOS.Native
             kSecReturnRef            = GetGlobal(Handle, "kSecReturnRef");
             kSecReturnPersistentRef  = GetGlobal(Handle, "kSecReturnPersistentRef");
             kSecClassGenericPassword = GetGlobal(Handle, "kSecClassGenericPassword");
+            kSecMatchLimitAll        = GetGlobal(Handle, "kSecMatchLimitAll");
             kSecMatchLimitOne        = GetGlobal(Handle, "kSecMatchLimitOne");
             kSecMatchItemList        = GetGlobal(Handle, "kSecMatchItemList");
             kSecAttrLabel            = GetGlobal(Handle, "kSecAttrLabel");

--- a/src/shared/Core/Interop/Windows/WindowsCredentialManager.cs
+++ b/src/shared/Core/Interop/Windows/WindowsCredentialManager.cs
@@ -24,6 +24,11 @@ namespace GitCredentialManager.Interop.Windows
             _namespace = @namespace;
         }
 
+        public IList<string> GetAccounts(string service)
+        {
+            return Enumerate(service, null).Select(x => x.UserName).ToList();
+        }
+
         public ICredential Get(string service, string account)
         {
             return Enumerate(service, account).FirstOrDefault();

--- a/src/shared/Core/PlaintextCredentialStore.cs
+++ b/src/shared/Core/PlaintextCredentialStore.cs
@@ -23,6 +23,11 @@ namespace GitCredentialManager
         protected string Namespace { get; }
         protected virtual string CredentialFileExtension => ".credential";
 
+        public IList<string> GetAccounts(string service)
+        {
+            return Enumerate(service, null).Select(x => x.Account).ToList();
+        }
+
         public ICredential Get(string service, string account)
         {
             return Enumerate(service, account).FirstOrDefault();

--- a/src/shared/Core/Settings.cs
+++ b/src/shared/Core/Settings.cs
@@ -71,7 +71,7 @@ namespace GitCredentialManager
         /// <remarks>
         /// If GUI prompts are disabled but an equivalent terminal prompt is available, the latter will be used instead.
         /// </remarks>
-        bool IsGuiPromptsEnabled { get; }
+        bool IsGuiPromptsEnabled { get; set; }
 
         /// <summary>
         /// True if it is permitted to interact with the user, false otherwise.
@@ -506,6 +506,7 @@ namespace GitCredentialManager
 
                 return defaultValue;
             }
+            set => _environment.SetEnvironmentVariable(KnownEnvars.GcmGuiPromptsEnabled, value ? bool.TrueString : bool.FalseString);
         }
 
         public bool IsInteractionAllowed

--- a/src/shared/GitHub.Tests/GitHubAuthenticationTests.cs
+++ b/src/shared/GitHub.Tests/GitHubAuthenticationTests.cs
@@ -88,7 +88,7 @@ namespace GitHub.Tests
             context.SessionManager.IsDesktopSession = true;
             context.Environment.Variables[GitHubConstants.EnvironmentVariables.AuthenticationHelper] = helperPath;
             var auth = new Mock<GitHubAuthentication>(MockBehavior.Strict, context);
-            auth.Setup(x => x.InvokeHelperAsync(It.IsAny<string>(), "prompt --all", It.IsAny<IDictionary<string, string>>(), It.IsAny<System.Threading.CancellationToken>()))
+            auth.Setup(x => x.InvokeHelperAsync(It.IsAny<string>(), "prompt --all", It.IsAny<StreamReader>(), It.IsAny<System.Threading.CancellationToken>()))
             .Returns(Task.FromResult<IDictionary<string, string>>(
                 new Dictionary<string, string>
                 {

--- a/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
+++ b/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
@@ -87,7 +87,7 @@ namespace GitHub.Tests
             });
 
             var provider = new GitHubHostProvider(new TestCommandContext());
-            Assert.Equal(expectedService, provider.GetServiceName(input));
+            Assert.Equal(expectedService, GitHubHostProvider.GetServiceName(input));
         }
 
 
@@ -154,11 +154,7 @@ namespace GitHub.Tests
         [Fact]
         public async Task GitHubHostProvider_GenerateCredentialAsync_UnencryptedHttp_ThrowsException()
         {
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "http",
-                ["host"] = "github.com",
-            });
+            var remoteUri = new Uri("http://github.com");
 
             var context = new TestCommandContext();
             var ghApi = Mock.Of<IGitHubRestApi>();
@@ -166,18 +162,13 @@ namespace GitHub.Tests
 
             var provider = new GitHubHostProvider(context, ghApi, ghAuth);
 
-            await Assert.ThrowsAsync<Trace2Exception>(() => provider.GenerateCredentialAsync(input));
+            await Assert.ThrowsAsync<Trace2Exception>(() => provider.GenerateCredentialAsync(remoteUri, null));
         }
 
         [Fact]
         public async Task GitHubHostProvider_GenerateCredentialAsync_Browser_ReturnsCredential()
         {
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"] = "github.com",
-            });
-
+            var remoteUri = new Uri("https://github.com");
             var expectedTargetUri = new Uri("https://github.com/");
             IEnumerable<string> expectedOAuthScopes = new[]
             {
@@ -205,7 +196,7 @@ namespace GitHub.Tests
 
             var provider = new GitHubHostProvider(context, ghApiMock.Object, ghAuthMock.Object);
 
-            ICredential credential = await provider.GenerateCredentialAsync(input);
+            ICredential credential = await provider.GenerateCredentialAsync(remoteUri, null);
 
             Assert.NotNull(credential);
             Assert.Equal(expectedUserName, credential.Account);
@@ -220,13 +211,6 @@ namespace GitHub.Tests
         [Fact]
         public async Task GitHubHostProvider_GenerateCredentialAsync_Browser_LoginHint_IncludesHintAndReturnsCredential()
         {
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"] = "github.com",
-                ["username"] = "john.doe"
-            });
-
             var expectedTargetUri = new Uri("https://github.com/");
             IEnumerable<string> expectedOAuthScopes = new[]
             {
@@ -254,7 +238,7 @@ namespace GitHub.Tests
 
             var provider = new GitHubHostProvider(context, ghApiMock.Object, ghAuthMock.Object);
 
-            ICredential credential = await provider.GenerateCredentialAsync(input);
+            ICredential credential = await provider.GenerateCredentialAsync(expectedTargetUri, expectedUserName);
 
             Assert.NotNull(credential);
             Assert.Equal(expectedUserName, credential.Account);
@@ -269,12 +253,7 @@ namespace GitHub.Tests
         [Fact]
         public async Task GitHubHostProvider_GenerateCredentialAsync_Basic_1FAOnly_ReturnsCredential()
         {
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"] = "github.com",
-            });
-
+            var remoteUri = new Uri("https://github.com");
             var expectedTargetUri = new Uri("https://github.com/");
             var expectedUserName = "john.doe";
             var expectedPassword = "letmein123"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
@@ -302,7 +281,7 @@ namespace GitHub.Tests
 
             var provider = new GitHubHostProvider(context, ghApiMock.Object, ghAuthMock.Object);
 
-            ICredential credential = await provider.GenerateCredentialAsync(input);
+            ICredential credential = await provider.GenerateCredentialAsync(remoteUri, null);
 
             Assert.NotNull(credential);
             Assert.Equal(expectedUserName, credential.Account);
@@ -317,12 +296,7 @@ namespace GitHub.Tests
         [Fact]
         public async Task GitHubHostProvider_GenerateCredentialAsync_Basic_2FARequired_ReturnsCredential()
         {
-            var input = new InputArguments(new Dictionary<string, string>
-            {
-                ["protocol"] = "https",
-                ["host"] = "github.com",
-            });
-
+            var remoteUri = new Uri("https://github.com");
             var expectedTargetUri = new Uri("https://github.com/");
             var expectedUserName = "john.doe";
             var expectedPassword = "letmein123";  // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Fake credential")]
@@ -356,7 +330,7 @@ namespace GitHub.Tests
 
             var provider = new GitHubHostProvider(context, ghApiMock.Object, ghAuthMock.Object);
 
-            ICredential credential = await provider.GenerateCredentialAsync(input);
+            ICredential credential = await provider.GenerateCredentialAsync(remoteUri, null);
 
             Assert.NotNull(credential);
             Assert.Equal(expectedUserName, credential.Account);

--- a/src/shared/GitHub.UI.Avalonia/Commands/SelectAccountCommandImpl.cs
+++ b/src/shared/GitHub.UI.Avalonia/Commands/SelectAccountCommandImpl.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GitHub.UI.ViewModels;
+using GitHub.UI.Views;
+using GitCredentialManager;
+using GitCredentialManager.UI;
+
+namespace GitHub.UI.Commands
+{
+    public class SelectAccountCommandImpl : SelectAccountCommand
+    {
+        public SelectAccountCommandImpl(ICommandContext context) : base(context) { }
+
+        protected override Task ShowAsync(SelectAccountViewModel viewModel, CancellationToken ct)
+        {
+            return AvaloniaUi.ShowViewAsync<SelectAccountView>(viewModel, GetParentHandle(), ct);
+        }
+    }
+}

--- a/src/shared/GitHub/GitHubHostProvider.Commands.cs
+++ b/src/shared/GitHub/GitHubHostProvider.Commands.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Threading.Tasks;
+using GitCredentialManager;
+using GitCredentialManager.Commands;
+
+namespace GitHub;
+
+public partial class GitHubHostProvider : ICommandProvider
+{
+    public ProviderCommand CreateCommand()
+    {
+        var rootCmd = new ProviderCommand(this);
+
+        var urlOpt = new Option<Uri>("--url",
+            "URL of the GitHub instance to target, otherwise use GitHub.com");
+
+        //
+        // list [--url <url>]
+        //
+        var listCmd = new Command("list", "List all known GitHub accounts.");
+        listCmd.AddOption(urlOpt);
+        listCmd.SetHandler(ListAccounts, urlOpt);
+
+        //
+        // login [--url <url>]
+        //
+        var loginCmd = new Command("login", "Add a GitHub account.");
+        loginCmd.AddOption(urlOpt);
+        loginCmd.SetHandler(AddAccountAsync, urlOpt);
+
+        //
+        // logout <account> [--url <url>]
+        //
+        var logoutCmd = new Command("logout", "Remove a GitHub account.");
+        var accountArg = new Argument<string>("account", "Account to remove")
+        {
+            Arity = ArgumentArity.ExactlyOne
+        };
+        logoutCmd.AddArgument(accountArg);
+        logoutCmd.AddOption(urlOpt);
+        logoutCmd.SetHandler(RemoveAccount, accountArg, urlOpt);
+
+        rootCmd.AddCommand(listCmd);
+        rootCmd.AddCommand(loginCmd);
+        rootCmd.AddCommand(logoutCmd);
+
+        return rootCmd;
+    }
+
+    private void ListAccounts(Uri url)
+    {
+        string service = url is null || IsGitHubDotCom(url)
+            ? $"https://{GitHubConstants.GitHubBaseUrlHost}"
+            : GetServiceName(url);
+
+        IList<string> accounts = _context.CredentialStore.GetAccounts(service);
+
+        foreach (string account in accounts)
+        {
+            _context.Streams.Out.WriteLine(account);
+        }
+    }
+
+    private async Task<int> AddAccountAsync(Uri url)
+    {
+        // Default to GitHub.com
+        url ??= new Uri($"https://{GitHubConstants.GitHubBaseUrlHost}");
+
+        string userName = url.GetUserName();
+        string service = GetServiceName(url);
+
+        ICredential credential = await GenerateCredentialAsync(url, userName);
+        _context.CredentialStore.AddOrUpdate(service, credential.Account, credential.Password);
+
+        return 0;
+    }
+
+    private Task<int> RemoveAccount(string account, Uri url)
+    {
+        string service = url is null || IsGitHubDotCom(url)
+            ? $"https://{GitHubConstants.GitHubBaseUrlHost}"
+            : GetServiceName(url);
+
+        bool result = _context.CredentialStore.Remove(service, account);
+
+        if (!result)
+        {
+            _context.Streams.Error.WriteLine($"warning: no such account '{account}' found.");
+            return Task.FromResult(-1);
+        }
+
+        return Task.FromResult(0);
+    }
+}

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -9,7 +9,7 @@ using GitCredentialManager.Diagnostics;
 
 namespace GitHub
 {
-    public class GitHubHostProvider : DisposableObject, IHostProvider, IDiagnosticProvider
+    public partial class GitHubHostProvider : DisposableObject, IHostProvider, IDiagnosticProvider
     {
         private static readonly string[] GitHubOAuthScopes =
         {

--- a/src/shared/GitHub/UI/Commands/SelectAccountCommand.cs
+++ b/src/shared/GitHub/UI/Commands/SelectAccountCommand.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Threading;
+using System.Threading.Tasks;
+using GitHub.UI.ViewModels;
+using GitCredentialManager;
+using GitCredentialManager.UI;
+
+namespace GitHub.UI.Commands
+{
+    public abstract class SelectAccountCommand : HelperCommand
+    {
+        protected SelectAccountCommand(ICommandContext context)
+            : base(context, "select-account", "Show account selection prompt. Accounts are read line-by-line from standard input.")
+        {
+            var url = new Option<string>(new[] { "--enterprise-url" }, "Enterprise URL.");
+            AddOption(url);
+
+            var noHelp = new Option<bool>(new[] { "--no-help" }, "Hide the help link.");
+            AddOption(noHelp);
+
+            this.SetHandler(ExecuteAsync, url, noHelp);
+        }
+
+        private async Task<int> ExecuteAsync(string enterpriseUrl, bool noHelp)
+        {
+            // Read accounts from standard input
+            IList<string> accounts = ReadAccounts();
+
+            var viewModel = new SelectAccountViewModel(Context.Environment, accounts)
+            {
+                EnterpriseUrl = enterpriseUrl,
+                ShowHelpLink = !noHelp
+            };
+
+            await ShowAsync(viewModel, CancellationToken.None);
+
+            if (!viewModel.WindowResult)
+            {
+                throw new Exception("User cancelled dialog.");
+            }
+
+            WriteResult(new Dictionary<string, string>
+            {
+                ["account"] = viewModel.SelectedAccount?.UserName
+            });
+
+            return 0;
+        }
+
+        private IList<string> ReadAccounts()
+        {
+            var accounts = new List<string>();
+
+            string line;
+            while (!string.IsNullOrWhiteSpace(line = Context.Streams.In.ReadLine()))
+            {
+                accounts.Add(line.Trim());
+            }
+
+            return accounts;
+        }
+
+        protected abstract Task ShowAsync(SelectAccountViewModel viewModel, CancellationToken ct);
+    }
+}

--- a/src/shared/GitHub/UI/ViewModels/SelectAccountViewModel.cs
+++ b/src/shared/GitHub/UI/ViewModels/SelectAccountViewModel.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Input;
+using GitCredentialManager;
+using GitCredentialManager.UI;
+using GitCredentialManager.UI.ViewModels;
+
+namespace GitHub.UI.ViewModels
+{
+    public class SelectAccountViewModel : WindowViewModel
+    {
+        private readonly IEnvironment _environment;
+
+        private AccountViewModel _selectedAccount;
+        private string _enterpriseUrl;
+        private ObservableCollection<AccountViewModel> _accounts;
+        private RelayCommand _continueCommand;
+        private ICommand _newAccountCommand;
+        private ICommand _learnMoreCommand;
+        private bool _showHelpLink = true;
+
+        private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case nameof(SelectedAccount):
+                    ContinueCommand.RaiseCanExecuteChanged();
+                    break;
+            }
+        }
+
+        public SelectAccountViewModel()
+        {
+            // Constructor the XAML designer
+        }
+
+        public SelectAccountViewModel(IEnvironment environment, IEnumerable<string> accounts = null)
+        {
+            EnsureArgument.NotNull(environment, nameof(environment));
+
+            _environment = environment;
+
+            Title = "Select an account";
+            ContinueCommand = new RelayCommand(Accept, CanContinue);
+            NewAccountCommand = new RelayCommand(NewAccount);
+            LearnMoreCommand = new RelayCommand(LearnMore);
+            Accounts = new ObservableCollection<AccountViewModel>();
+
+            foreach (string account in accounts ?? Enumerable.Empty<string>())
+            {
+                Accounts.Add(
+                    new AccountViewModel
+                    {
+                        UserName = account
+                    }
+                );
+            }
+
+            PropertyChanged += OnPropertyChanged;
+        }
+
+        private void NewAccount()
+        {
+            SelectedAccount = null;
+            Accept();
+        }
+
+        private void LearnMore()
+        {
+            BrowserUtils.OpenDefaultBrowser(_environment, Constants.HelpUrls.GcmMultipleUsers);
+        }
+
+        private bool CanContinue()
+        {
+            return SelectedAccount != null;
+        }
+
+        public AccountViewModel SelectedAccount
+        {
+            get => _selectedAccount;
+            set => SetAndRaisePropertyChanged(ref _selectedAccount, value);
+        }
+
+        public string EnterpriseUrl
+        {
+            get => _enterpriseUrl;
+            set => SetAndRaisePropertyChanged(ref _enterpriseUrl, value);
+        }
+
+        public ObservableCollection<AccountViewModel> Accounts
+        {
+            get => _accounts;
+            set => SetAndRaisePropertyChanged(ref _accounts, value);
+        }
+
+        public RelayCommand ContinueCommand
+        {
+            get => _continueCommand;
+            set => SetAndRaisePropertyChanged(ref _continueCommand, value);
+        }
+
+        public ICommand NewAccountCommand
+        {
+            get => _newAccountCommand;
+            set => SetAndRaisePropertyChanged(ref _newAccountCommand, value);
+        }
+
+        public ICommand LearnMoreCommand
+        {
+            get => _learnMoreCommand;
+            set => SetAndRaisePropertyChanged(ref _learnMoreCommand, value);
+        }
+
+        public bool ShowHelpLink
+        {
+            get => _showHelpLink;
+            set => SetAndRaisePropertyChanged(ref _showHelpLink, value);
+        }
+    }
+
+    public class AccountViewModel : ViewModel
+    {
+        private string _userName;
+
+        public string UserName
+        {
+            get => _userName;
+            set => SetAndRaisePropertyChanged(ref _userName, value);
+        }
+    }
+}

--- a/src/shared/GitHub/UI/Views/SelectAccountView.axaml
+++ b/src/shared/GitHub/UI/Views/SelectAccountView.axaml
@@ -48,7 +48,8 @@
                      Margin="20,0,20,10"
                      MaxHeight="200"
                      Background="Transparent"
-                     AutoScrollToSelectedItem="True">
+                     AutoScrollToSelectedItem="True"
+                     DoubleTapped="ListBox_OnDoubleTapped">
                 <ListBox.ItemTemplate>
                     <DataTemplate DataType="vm:AccountViewModel">
                         <DockPanel LastChildFill="True">

--- a/src/shared/GitHub/UI/Views/SelectAccountView.axaml
+++ b/src/shared/GitHub/UI/Views/SelectAccountView.axaml
@@ -1,0 +1,79 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:GitHub.UI.Controls"
+             xmlns:vm="clr-namespace:GitHub.UI.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="420"
+             x:Class="GitHub.UI.Views.SelectAccountView">
+    <Design.DataContext>
+        <vm:SelectAccountViewModel/>
+    </Design.DataContext>
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Margin="0,0,0,15">
+            <!-- TODO: replace with GitHub logo -->
+            <TextBlock Text="GitHub"
+                       HorizontalAlignment="Center"
+                       FontSize="20"
+                       FontWeight="Bold"/>
+            <TextBlock Text="Select an account"
+                       HorizontalAlignment="Center"
+                       FontSize="24"
+                       FontWeight="Light"
+                       Margin="0,0,0,10" />
+            <controls:HorizontalShadowDivider/>
+            <StackPanel IsVisible="{Binding EnterpriseUrl, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                        Margin="0,10,0,0">
+                <TextBlock Text="GitHub Enterprise" HorizontalAlignment="Center"/>
+                <TextBlock Text="{Binding EnterpriseUrl}"
+                           HorizontalAlignment="Center"/>
+            </StackPanel>
+        </StackPanel>
+
+        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal"
+                    HorizontalAlignment="Center"
+                    Margin="0,5,0,10"
+                    IsVisible="{Binding ShowHelpLink}">
+            <Image Source="{DynamicResource HelpIcon}"
+                   Width="16" Height="16"
+                   Margin="0,0,5,0"/>
+            <Button Content="Why am I being asked to select an account?"
+                    Command="{Binding LearnMoreCommand}"
+                    Classes="hyperlink"/>
+        </StackPanel>
+
+        <StackPanel Orientation="Vertical" VerticalAlignment="Center">
+            <ListBox Items="{Binding Accounts}"
+                     SelectedItem="{Binding SelectedAccount}"
+                     Margin="20,0,20,10"
+                     MaxHeight="200"
+                     Background="Transparent"
+                     AutoScrollToSelectedItem="True">
+                <ListBox.ItemTemplate>
+                    <DataTemplate DataType="vm:AccountViewModel">
+                        <DockPanel LastChildFill="True">
+                            <Image DockPanel.Dock="Left"
+                                   VerticalAlignment="Center"
+                                   Source="{DynamicResource PersonIcon}"
+                                   Width="24" Height="24"/>
+                            <TextBlock Text="{Binding UserName}"
+                                       Margin="10,0"
+                                       VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+            <Button Content="Continue"
+                    Command="{Binding ContinueCommand}"
+                    HorizontalAlignment="Center"
+                    IsDefault="true"
+                    Classes="accent"
+                    Margin="0,0,0,15"
+                    Padding="20,10"/>
+            <Button Content="Add a new account"
+                    Command="{Binding NewAccountCommand}"
+                    HorizontalAlignment="Center"
+                    Classes="hyperlink"/>
+        </StackPanel>
+    </DockPanel>
+</UserControl>

--- a/src/shared/GitHub/UI/Views/SelectAccountView.axaml.cs
+++ b/src/shared/GitHub/UI/Views/SelectAccountView.axaml.cs
@@ -1,6 +1,8 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Markup.Xaml;
+using GitHub.UI.ViewModels;
 
 namespace GitHub.UI.Views;
 
@@ -14,5 +16,13 @@ public partial class SelectAccountView : UserControl
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);
+    }
+
+    private void ListBox_OnDoubleTapped(object sender, TappedEventArgs e)
+    {
+        if (DataContext is SelectAccountViewModel { SelectedAccount: not null } vm)
+        {
+            vm.ContinueCommand.Execute(null);
+        }
     }
 }

--- a/src/shared/GitHub/UI/Views/SelectAccountView.axaml.cs
+++ b/src/shared/GitHub/UI/Views/SelectAccountView.axaml.cs
@@ -1,0 +1,18 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace GitHub.UI.Views;
+
+public partial class SelectAccountView : UserControl
+{
+    public SelectAccountView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/shared/TestInfrastructure/Objects/TestCredentialStore.cs
+++ b/src/shared/TestInfrastructure/Objects/TestCredentialStore.cs
@@ -14,6 +14,11 @@ namespace GitCredentialManager.Tests.Objects
 
         #region ICredentialStore
 
+        public IList<string> GetAccounts(string service)
+        {
+            return Query(service, null).Select(x => x.Account).ToList();
+        }
+
         ICredential ICredentialStore.Get(string service, string account)
         {
             return TryGet(service, account, out TestCredential credential) ? credential : null;

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -136,7 +136,11 @@ namespace GitCredentialManager.Tests.Objects
 
         bool ISettings.IsTerminalPromptsEnabled => IsTerminalPromptsEnabled;
 
-        bool ISettings.IsGuiPromptsEnabled => IsGuiPromptsEnabled;
+        bool ISettings.IsGuiPromptsEnabled
+        {
+            get => IsGuiPromptsEnabled;
+            set => IsGuiPromptsEnabled = value;
+        }
 
         bool ISettings.IsInteractionAllowed => IsInteractionAllowed;
 

--- a/src/windows/Core.UI.Windows/Assets/Styles.xaml
+++ b/src/windows/Core.UI.Windows/Assets/Styles.xaml
@@ -204,4 +204,33 @@
             </DrawingGroup>
         </DrawingImage.Drawing>
     </DrawingImage>
+    <DrawingImage x:Key="PersonIcon">
+        <DrawingImage.Drawing>
+            <DrawingGroup>
+                <DrawingGroup.Children>
+                    <GeometryDrawing Brush="#FF25292F" Geometry="M12 2.5a5.5 5.5 0 0 1 3.096 10.047 9.005 9.005 0 0 1 5.9 8.181.75.75 0 1 1-1.499.044 7.5 7.5 0 0 0-14.993 0 .75.75 0 0 1-1.5-.045 9.005 9.005 0 0 1 5.9-8.18A5.5 5.5 0 0 1 12 2.5ZM8 8a4 4 0 1 0 8 0 4 4 0 0 0-8 0Z"/>
+                </DrawingGroup.Children>
+            </DrawingGroup>
+        </DrawingImage.Drawing>
+    </DrawingImage>
+    <DrawingImage x:Key="InfoIcon">
+        <DrawingImage.Drawing>
+            <DrawingGroup>
+                <DrawingGroup.Children>
+                    <GeometryDrawing Brush="#FF25292F" Geometry="M13 7.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm-3 3.75a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v4.25h.75a.75.75 0 0 1 0 1.5h-3a.75.75 0 0 1 0-1.5h.75V12h-.75a.75.75 0 0 1-.75-.75Z"/>
+                    <GeometryDrawing Brush="#FF25292F" Geometry="M12 1c6.075 0 11 4.925 11 11s-4.925 11-11 11S1 18.075 1 12 5.925 1 12 1ZM2.5 12a9.5 9.5 0 0 0 9.5 9.5 9.5 9.5 0 0 0 9.5-9.5A9.5 9.5 0 0 0 12 2.5 9.5 9.5 0 0 0 2.5 12Z"/>
+                </DrawingGroup.Children>
+            </DrawingGroup>
+        </DrawingImage.Drawing>
+    </DrawingImage>
+    <DrawingImage x:Key="HelpIcon">
+        <DrawingImage.Drawing>
+            <DrawingGroup>
+                <DrawingGroup.Children>
+                    <GeometryDrawing Brush="#FF25292F" Geometry="M10.97 8.265a1.45 1.45 0 0 0-.487.57.75.75 0 0 1-1.341-.67c.2-.402.513-.826.997-1.148C10.627 6.69 11.244 6.5 12 6.5c.658 0 1.369.195 1.934.619a2.45 2.45 0 0 1 1.004 2.006c0 1.033-.513 1.72-1.027 2.215-.19.183-.399.358-.579.508l-.147.123a4.329 4.329 0 0 0-.435.409v1.37a.75.75 0 1 1-1.5 0v-1.473c0-.237.067-.504.247-.736.22-.28.486-.517.718-.714l.183-.153.001-.001c.172-.143.324-.27.47-.412.368-.355.569-.676.569-1.136a.953.953 0 0 0-.404-.806C12.766 8.118 12.384 8 12 8c-.494 0-.814.121-1.03.265ZM13 17a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"/>
+                    <GeometryDrawing Brush="#FF25292F" Geometry="M12 1c6.075 0 11 4.925 11 11s-4.925 11-11 11S1 18.075 1 12 5.925 1 12 1ZM2.5 12a9.5 9.5 0 0 0 9.5 9.5 9.5 9.5 0 0 0 9.5-9.5A9.5 9.5 0 0 0 12 2.5 9.5 9.5 0 0 0 2.5 12Z"/>
+                </DrawingGroup.Children>
+            </DrawingGroup>
+        </DrawingImage.Drawing>
+    </DrawingImage>
 </ResourceDictionary>

--- a/src/windows/GitHub.UI.Windows/Commands/SelectAccountCommandImpl.cs
+++ b/src/windows/GitHub.UI.Windows/Commands/SelectAccountCommandImpl.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GitHub.UI.Commands;
+using GitHub.UI.ViewModels;
+using GitHub.UI.Windows.Views;
+using GitCredentialManager;
+using GitCredentialManager.UI.Windows;
+
+namespace GitHub.UI.Windows.Commands
+{
+    public class SelectAccountCommandImpl : SelectAccountCommand
+    {
+        public SelectAccountCommandImpl(ICommandContext context) : base(context) { }
+
+        protected override Task ShowAsync(SelectAccountViewModel viewModel, CancellationToken ct)
+        {
+            return Gui.ShowDialogWindow(viewModel, () => new SelectAccountView(), GetParentHandle());
+        }
+    }
+}

--- a/src/windows/GitHub.UI.Windows/GitHub.UI.Windows.csproj
+++ b/src/windows/GitHub.UI.Windows/GitHub.UI.Windows.csproj
@@ -18,4 +18,12 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
   </ItemGroup>
   
+  <ItemGroup>
+    <Page Update="Views\SelectAccountView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <XamlRuntime>Wpf</XamlRuntime>
+      <SubType>Designer</SubType>
+    </Page>
+  </ItemGroup>
+  
 </Project>

--- a/src/windows/GitHub.UI.Windows/Program.cs
+++ b/src/windows/GitHub.UI.Windows/Program.cs
@@ -33,6 +33,7 @@ namespace GitHub.UI.Windows
                 app.RegisterCommand(new CredentialsCommandImpl(context));
                 app.RegisterCommand(new TwoFactorCommandImpl(context));
                 app.RegisterCommand(new DeviceCodeCommandImpl(context));
+                app.RegisterCommand(new SelectAccountCommandImpl(context));
 
                 int exitCode = app.RunAsync(args)
                     .ConfigureAwait(false)

--- a/src/windows/GitHub.UI.Windows/Views/SelectAccountView.xaml
+++ b/src/windows/GitHub.UI.Windows/Views/SelectAccountView.xaml
@@ -1,0 +1,99 @@
+<UserControl x:Class="GitHub.UI.Windows.Views.SelectAccountView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:viewModels="clr-namespace:GitHub.UI.ViewModels;assembly=GitHub"
+             xmlns:converters="clr-namespace:GitCredentialManager.UI.Windows.Converters;assembly=gcmcoreuiwpf"
+             xmlns:controls="clr-namespace:GitHub.UI.Windows.Controls"
+             xmlns:sharedControls="clr-namespace:GitCredentialManager.UI.Windows.Controls;assembly=gcmcoreuiwpf"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance viewModels:SelectAccountViewModel}"
+             d:DesignWidth="300">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Assets/Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <converters:NonEmptyStringToVisibleConverter x:Key="NonEmptyStringToVisibleConverter"/>
+            <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+            <converters:BooleanOrToVisibilityConverter x:Key="BooleanOrToVisibilityConverter"/>
+            <converters:BooleanOrConverter x:Key="BooleanOrConverter"/>
+            <converters:BooleanNotConverter x:Key="BooleanNotConverter"/>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Margin="0,0,0,10">
+            <!-- TODO: replace with GitHub logo -->
+            <TextBlock Text="GitHub"
+                       HorizontalAlignment="Center"
+                       FontSize="20"
+                       FontWeight="Bold"/>
+            <TextBlock Text="Select an account"
+                       HorizontalAlignment="Center"
+                       FontSize="24"
+                       FontWeight="Light"
+                       Margin="0,0,0,10" />
+            <controls:HorizontalShadowDivider/>
+            <StackPanel Visibility="{Binding EnterpriseUrl, Converter={StaticResource NonEmptyStringToVisibleConverter}}"
+                        Margin="0">
+                <TextBlock Text="GitHub Enterprise" HorizontalAlignment="Center"
+                           FontSize="14"/>
+                <TextBlock Text="{Binding EnterpriseUrl}"
+                           HorizontalAlignment="Center"
+                           FontSize="14"/>
+            </StackPanel>
+        </StackPanel>
+
+        <WrapPanel DockPanel.Dock="Top" HorizontalAlignment="Center" VerticalAlignment="Center"
+                   Margin="0,0,0,15"
+                   Visibility="{Binding ShowHelpLink, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Image Source="{StaticResource HelpIcon}"
+                   Width="16" Height="16"
+                   Margin="0,0,5,0"/>
+            <TextBlock Margin="0,0,0,0"
+                       FontSize="14">
+                <Hyperlink Command="{Binding LearnMoreCommand}">
+                    Why am I being asked to select an account?
+                </Hyperlink>
+            </TextBlock>
+        </WrapPanel>
+
+        <StackPanel Orientation="Vertical" VerticalAlignment="Center">
+            <ListBox ItemsSource="{Binding Accounts}"
+                     SelectedItem="{Binding SelectedAccount}"
+                     Margin="20,0,20,10"
+                     MaxHeight="200"
+                     Background="Transparent"
+                     BorderThickness="0">
+                <ListBox.ItemTemplate>
+                    <DataTemplate DataType="{x:Type viewModels:AccountViewModel}">
+                        <Border Padding="5,10">
+                            <DockPanel LastChildFill="True">
+                                <Image DockPanel.Dock="Left"
+                                    VerticalAlignment="Center"
+                                    Source="{StaticResource PersonIcon}"
+                                    Width="24" Height="24"/>
+                                <TextBlock Text="{Binding UserName}"
+                                        Margin="10,0"
+                                        VerticalAlignment="Center"/>
+                            </DockPanel>
+                        </Border>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+            <Button Content="Continue"
+                    IsDefault="True"
+                    Command="{Binding ContinueCommand}"
+                    HorizontalAlignment="Center"
+                    Style="{StaticResource AccentButton}"
+                    Margin="0,0,0,15"/>
+            <TextBlock FontSize="14" HorizontalAlignment="Center">
+                <Hyperlink Command="{Binding NewAccountCommand}">
+                    Add a new account
+                </Hyperlink>
+            </TextBlock>
+        </StackPanel>
+    </DockPanel>
+</UserControl>

--- a/src/windows/GitHub.UI.Windows/Views/SelectAccountView.xaml.cs
+++ b/src/windows/GitHub.UI.Windows/Views/SelectAccountView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using GitCredentialManager.UI.Controls;
+
+namespace GitHub.UI.Windows.Views
+{
+    public partial class SelectAccountView : UserControl
+    {
+        public SelectAccountView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Add multi-account support for the GitHub host provider.

Previously it was possible to use multiple accounts with GitHub, but this required prior knowledge about including the username in the remote URL (e.g. `https://mona_alt@github.com/mona/test`), and without this the incorrect account may be selected, and subsequently erased due to insufficient permissions.

This PR adds a few different features and prompts to improve discoverability and experience using multiple GitHub accounts with GCM:

1. Add `login`, `logout` and `list` commands for the GitHub provider
2. Add UI and TTY prompts to select between GitHub user accounts
3. Abridged documentation and links to quickly discover the 'user-in-remote-URL' functionality
4. (bonus!) Ability to suppress GUI prompts over text-based ones via the command-line using `--no-ui`

One thing that is absent compared to the Azure Repos provider's multi-account support is the lack of account 'binding'. This is due to lack of knowledge, by default, of the full remote URL from Git to be able to discern between different repositories or organisations on the same host.

**Command-line usage:**

```console
% git-credential-manager github --help    
Description:
  Commands for interacting with the GitHub host provider

Usage:
  git-credential-manager github [command] [options]

Options:
  --no-ui         Do not use graphical user interface prompts
  -?, -h, --help  Show help and usage information

Commands:
  list              List all known GitHub accounts.
  login             Add a GitHub account.
  logout <account>  Remove a GitHub account.
```
```console
% git-credential-manager github login --help
Description:
  Add a GitHub account.

Usage:
  git-credential-manager github login [options]

Options:
  --url <url>             URL of the GitHub instance to target, otherwise use GitHub.com
  --username <username>   User name to authenticate with
  --device                Use device flow to authenticate
  --browser, --web        Use a web browser to authenticate
  --pat, --token <token>  Use personal access token to authenticate
  --no-ui                 Do not use graphical user interface prompts
  -?, -h, --help          Show help and usage information
```
```console
% git-credential-manager github logout --help 
Description:
  Remove a GitHub account.

Usage:
  git-credential-manager github logout <account> [options]

Arguments:
  <account>  Account to remove

Options:
  --url <url>     URL of the GitHub instance to target, otherwise use GitHub.com
  --no-ui         Do not use graphical user interface prompts
  -?, -h, --help  Show help and usage information
```
```console
% git-credential-manager github list --help  
Description:
  List all known GitHub accounts.

Usage:
  git-credential-manager github list [options]

Options:
  --url <url>     URL of the GitHub instance to target, otherwise use GitHub.com
  --no-ui         Do not use graphical user interface prompts
  -?, -h, --help  Show help and usage information
```

**Select account UI prompts:**

Avalonia|Windows legacy helper (WPF)
-|-
<img width="532" alt="image" src="https://github.com/git-ecosystem/git-credential-manager/assets/5658207/e7fc0ab9-903a-466b-9424-26183c188652">|![image](https://github.com/git-ecosystem/git-credential-manager/assets/5658207/6b2fa7bb-2e62-435f-a187-72f42734ced0)