### PR TITLE
Upload artifacts from CI builds

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,20 +1,19 @@
-name: GCM
+name: ci
 
 on:
   workflow_dispatch:
   push:
-    branches: [ main, linux ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, linux ]
+    branches: [ main ]
 
 jobs:
-  validate_gcm:
-    name: "CI"
-
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+# ================================
+#              Windows
+# ================================
+  windows:
+    name: Windows
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v3
@@ -27,17 +26,107 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
 
-    - name: Build Windows
-      if: contains(matrix.os, 'windows')
+    - name: Build
       run: dotnet build --configuration WindowsRelease
 
-    - name: Build Linux
-      if: contains(matrix.os, 'ubuntu')
+    - name: Test
+      run: |
+        dotnet test --verbosity normal --configuration=WindowsRelease
+
+    - name: Prepare artifacts
+      shell: bash
+      run: |
+        mkdir -p artifacts/bin
+        mv out/windows/Installer.Windows/bin/Release/net472/win-x86 artifacts/bin/
+        cp out/windows/Installer.Windows/bin/Release/net472/win-x86.sym/* artifacts/bin/win-x86/
+        mv out/windows/Installer.Windows/bin/Release/net472/gcm*.exe artifacts/
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: win-x86
+        path: |
+          artifacts
+
+# ================================
+#              Linux
+# ================================
+  linux:
+    name: Linux
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3.2.0
+      with:
+        dotnet-version: 6.0.201
+
+    - name: Install dependencies
+      run: dotnet restore
+
+    - name: Build
       run: dotnet build --configuration LinuxRelease
 
-    - name: Build macOS
-      if: contains(matrix.os, 'macos')
-      run: dotnet build --configuration MacRelease
+    - name: Test
+      run: |
+        dotnet test --verbosity normal --configuration=LinuxRelease
+
+    - name: Prepare artifacts
+      run: |
+        mkdir -p artifacts
+        mv out/linux/Packaging.Linux/Release/deb/*.deb artifacts/
+        mv out/linux/Packaging.Linux/Release/tar/*.tar.gz artifacts/
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: linux-x64
+        path: |
+          artifacts
+
+# ================================
+#              macOS
+# ================================
+  osx:
+    name: macOS
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        runtime: [ osx-x64, osx-arm64 ]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3.2.0
+      with:
+        dotnet-version: 6.0.201
+
+    - name: Install dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: |
+        dotnet build src/osx/Installer.Mac/*.csproj \
+         --configuration=Release --no-self-contained \
+         --runtime=${{ matrix.runtime }}
 
     - name: Test
-      run: dotnet test --verbosity normal
+      run: |
+        dotnet test --verbosity normal --configuration=MacRelease
+
+    - name: Prepare artifacts
+      run: |
+        mkdir -p artifacts/bin
+        mv out/osx/Installer.Mac/pkg/Release/payload "artifacts/bin/${{ matrix.runtime }}"
+        cp out/osx/Installer.Mac/pkg/Release/payload.sym/* "artifacts/bin/${{ matrix.runtime }}/"
+        mv out/osx/Installer.Mac/pkg/Release/gcm*.pkg artifacts/
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.runtime }}
+        path: |
+          artifacts


### PR DESCRIPTION
We currently don't capture or upload artifacts from our CI builds.. we should do this! This will help with testing PRs and the tip of `main`.