### PR TITLE
Fix bug passing username hint to credential lookup

### DIFF
--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -132,9 +132,9 @@ namespace GitHub
             // If we have a specific username then we can try and find an existing credential for that account.
             // If not, we should check what accounts are available in the store and prompt the user if there
             // are multiple options.
-            string userName = null;
+            string userName = input.UserName;
             bool addAccount = false;
-            if (string.IsNullOrWhiteSpace(input.UserName))
+            if (string.IsNullOrWhiteSpace(userName))
             {
                 IList<string> accounts = _context.CredentialStore.GetAccounts(service);
                 _context.Trace.WriteLine($"Found {accounts.Count} accounts in the store for service={service}.");
@@ -172,7 +172,7 @@ namespace GitHub
 
                 // No existing credential was found, create a new one
                 _context.Trace.WriteLine("Creating new credential...");
-                credential = await GenerateCredentialAsync(remoteUri, input.UserName);
+                credential = await GenerateCredentialAsync(remoteUri, userName);
                 _context.Trace.WriteLine("Credential created.");
             }
             else


### PR DESCRIPTION
In adding support for multiple-user accounts for GitHub we introduced a bug that would mean we ignored a username-hint provided by Git/remote URL when looking up an existing credential. The result is that we'd return _any_ credential rather than specifically one for the desired account!

Fix this by always passing the input username hint when first evaluating which user account to select.