### PR TITLE
dotnet: update install from src script to target .NET 7

### DIFF
--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -83,7 +83,7 @@ verify_existing_dotnet_installation() {
     sdks=$(dotnet --list-sdks | cut -c 1-3)
 
     # If we have a supported version installed, return.
-    supported_dotnet_versions="6.0"
+    supported_dotnet_versions="7.0"
     for v in $supported_dotnet_versions; do
         if [ $(echo $sdks | grep "$v") ]; then
             echo $sdks
@@ -150,7 +150,7 @@ case "$distribution" in
                 $sudo_cmd apt update
                 $sudo_cmd apt install apt-transport-https -y
                 $sudo_cmd apt update
-                $sudo_cmd apt install dotnet-sdk-6.0 dpkg-dev -y
+                $sudo_cmd apt install dotnet-sdk-7.0 dpkg-dev -y
             fi
         fi
     ;;

--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -68,7 +68,7 @@ ensure_dotnet_installed() {
     if [ -z "$(verify_existing_dotnet_installation)" ]; then
         curl -LO https://dot.net/v1/dotnet-install.sh
         chmod +x ./dotnet-install.sh
-        bash -c "./dotnet-install.sh"
+        bash -c "./dotnet-install.sh --channel 7.0"
 
         # Since we have to run the dotnet install script with bash, dotnet isn't
         # added to the process PATH, so we manually add it here.
@@ -134,7 +134,7 @@ case "$distribution" in
         # Install dotnet packages and dependencies if needed.
         if [ -z "$(verify_existing_dotnet_installation)" ]; then
             # First try to use native feeds (Ubuntu 22.04 and later).
-            if ! apt_install dotnet6; then
+            if ! apt_install dotnet7; then
                 # If the native feeds fail, we fall back to
                 # packages.microsoft.com. We begin by adding the dotnet package
                 # repository/signing key.


### PR DESCRIPTION
In #1274 we updated to target .NET 7, but didn't update the install from source script for Linux to use SDK 7.0.