### PR TITLE
Add support for Microsoft Mariner Linux.

### DIFF
--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -197,7 +197,7 @@ case "$distribution" in
 
         ensure_dotnet_installed
     ;;
-	 mariner)
+    mariner)
         $sudo_cmd tdnf update -y
 
         # Install dotnet/GCM dependencies.

--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -198,7 +198,7 @@ case "$distribution" in
         ensure_dotnet_installed
     ;;
     mariner)
-	    print_unsupported_distro "WARNING" "$distribution"
+        print_unsupported_distro "WARNING" "$distribution"
         $sudo_cmd tdnf update -y
 
         # Install dotnet/GCM dependencies.

--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -198,6 +198,7 @@ case "$distribution" in
         ensure_dotnet_installed
     ;;
     mariner)
+	    print_unsupported_distro "WARNING" "$distribution"
         $sudo_cmd tdnf update -y
 
         # Install dotnet/GCM dependencies.

--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -197,6 +197,14 @@ case "$distribution" in
 
         ensure_dotnet_installed
     ;;
+	 mariner)
+        $sudo_cmd tdnf update -y
+
+        # Install dotnet/GCM dependencies.
+        install_packages tdnf install "curl git krb5-libs libicu openssl-libs zlib findutils which bash"
+
+        ensure_dotnet_installed
+    ;;
     *)
         print_unsupported_distro "ERROR" "$distribution"
         exit


### PR DESCRIPTION
I submitted an issue couple weeks ago[ [mariner-supporting](https://github.com/lanrobin/git-credential-manager/tree/mariner-supporting)](https://github.com/git-ecosystem/git-credential-manager/issues/1257#issuecomment-1562853496). 
Usually, we used the case for "fedora | centos | rhel)", but Mariner does not have dnf, instead it has tndf.