### PR TITLE
Add the `user` scope to OAuth token requests for GitHub

### DIFF
--- a/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
+++ b/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
@@ -172,6 +172,7 @@ namespace GitHub.Tests
             var expectedTargetUri = new Uri("https://github.com/");
             IEnumerable<string> expectedOAuthScopes = new[]
             {
+                GitHubConstants.OAuthScopes.User,
                 GitHubConstants.OAuthScopes.Repo,
                 GitHubConstants.OAuthScopes.Gist,
                 GitHubConstants.OAuthScopes.Workflow,
@@ -214,6 +215,7 @@ namespace GitHub.Tests
             var expectedTargetUri = new Uri("https://github.com/");
             IEnumerable<string> expectedOAuthScopes = new[]
             {
+                GitHubConstants.OAuthScopes.User,
                 GitHubConstants.OAuthScopes.Repo,
                 GitHubConstants.OAuthScopes.Gist,
                 GitHubConstants.OAuthScopes.Workflow,

--- a/src/shared/GitHub/GitHubConstants.cs
+++ b/src/shared/GitHub/GitHubConstants.cs
@@ -47,6 +47,7 @@ namespace GitHub
 
         public static class OAuthScopes
         {
+            public const string User = "user";
             public const string Gist = "gist";
             public const string Repo = "repo";
             public const string Workflow = "workflow";

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -13,6 +13,7 @@ namespace GitHub
     {
         private static readonly string[] GitHubOAuthScopes =
         {
+            GitHubConstants.OAuthScopes.User,
             GitHubConstants.OAuthScopes.Repo,
             GitHubConstants.OAuthScopes.Gist,
             GitHubConstants.OAuthScopes.Workflow,


### PR DESCRIPTION
Add the `user` scope to OAuth token requests for GitHub, to better align with other tooling that uses the token generated by GCM, including Visual Studio.

The next time a token needs to be generated, the user will be asked to re-consent to include the new scope. This will not invalidate any existing tokens.