### PR TITLE
Use 127.0.0.1 redirect over localhost for GitHub

### DIFF
--- a/src/shared/GitHub/GitHubConstants.cs
+++ b/src/shared/GitHub/GitHubConstants.cs
@@ -14,7 +14,7 @@ namespace GitHub
 
         // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="OAuth2 public client application 'secrets' are required and permitted to be public")]
         public const string OAuthClientSecret = "18867509d956965542b521a529a79bb883344c90";
-        public static readonly Uri OAuthRedirectUri = new Uri("http://localhost/"); // Note that the trailing slash is important!
+        public static readonly Uri OAuthRedirectUri = new Uri("http://127.0.0.1/"); // Note that the trailing slash is important!
         public static readonly Uri OAuthAuthorizationEndpointRelativeUri = new Uri("/login/oauth/authorize", UriKind.Relative);
         public static readonly Uri OAuthTokenEndpointRelativeUri = new Uri("/login/oauth/access_token", UriKind.Relative);
         public static readonly Uri OAuthDeviceEndpointRelativeUri = new Uri("/login/device/code", UriKind.Relative);


### PR DESCRIPTION
Use an IPv4 loopback redirect URL instead of the `localhost` name. This is in accordance with the recommendation in the OAuth spec[^1][^2] and also GitHub's documentation[^3].

Note that this change depends on an update to the Git Credential Manager OAuth application on GitHub to add the "http://127.0.0.1/" redirect (with a trailing slash!). We will be strictly adding the new URL, and keep the older localhost-based redirect URL untouched for older clients.

The change to the OAuth app registration can occur before this is merged.

Fixes #594 

[^1]: https://datatracker.ietf.org/doc/html/rfc8252#section-7.3
[^2]: https://datatracker.ietf.org/doc/html/rfc8252#section-8.3
[^3]: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#loopback-redirect-urls