### PR TITLE
Read new `wwwauth[]` input from Git 2.41

### DIFF
--- a/src/shared/Core.Tests/InputArgumentsTests.cs
+++ b/src/shared/Core.Tests/InputArgumentsTests.cs
@@ -9,19 +9,25 @@ namespace GitCredentialManager.Tests
         [Fact]
         public void InputArguments_Ctor_Null_ThrowsArgNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new InputArguments(null));
+            Assert.Throws<ArgumentNullException>(() => new InputArguments((IDictionary<string, string>)null));
+            Assert.Throws<ArgumentNullException>(() => new InputArguments((IDictionary<string, IList<string>>)null));
         }
 
         [Fact]
         public void InputArguments_CommonArguments_ValuePresent_ReturnsValues()
         {
-            var dict = new Dictionary<string, string>
+            var dict = new Dictionary<string, IList<string>>
             {
-                ["protocol"] = "https",
-                ["host"]     = "example.com",
-                ["path"]     = "an/example/path",
-                ["username"] = "john.doe",
-                ["password"] = "password123"
+                ["protocol"] = new[] { "https" },
+                ["host"]     = new[] { "example.com" },
+                ["path"]     = new[] { "an/example/path" },
+                ["username"] = new[] { "john.doe" },
+                ["password"] = new[] { "password123" },
+                ["wwwauth"]  = new[]
+                {
+                    "basic realm=\"example.com\"",
+                    "bearer authorize_uri=https://id.example.com p=1 q=0"
+                }
             };
 
             var inputArgs = new InputArguments(dict);
@@ -31,10 +37,16 @@ namespace GitCredentialManager.Tests
             Assert.Equal("an/example/path", inputArgs.Path);
             Assert.Equal("john.doe",        inputArgs.UserName);
             Assert.Equal("password123",     inputArgs.Password);
+            Assert.Equal(new[]
+                {
+                    "basic realm=\"example.com\"",
+                    "bearer authorize_uri=https://id.example.com p=1 q=0"
+                },
+                inputArgs.WwwAuth);
         }
 
         [Fact]
-        public void InputArguments_CommonArguments_ValueMissing_ReturnsNull()
+        public void InputArguments_CommonArguments_ValueMissing_ReturnsNullOrEmptyCollection()
         {
             var dict = new Dictionary<string, string>();
 
@@ -45,20 +57,23 @@ namespace GitCredentialManager.Tests
             Assert.Null(inputArgs.Path);
             Assert.Null(inputArgs.UserName);
             Assert.Null(inputArgs.Password);
+            Assert.Empty(inputArgs.WwwAuth);
         }
 
         [Fact]
         public void InputArguments_OtherArguments()
         {
-            var dict = new Dictionary<string, string>
+            var dict = new Dictionary<string, IList<string>>
             {
-                ["foo"] = "bar"
+                ["foo"] = new[] { "bar" },
+                ["multi"] = new[] { "val1", "val2", "val3" },
             };
 
             var inputArgs = new InputArguments(dict);
 
             Assert.Equal("bar", inputArgs["foo"]);
             Assert.Equal("bar", inputArgs.GetArgumentOrDefault("foo"));
+            Assert.Equal(new[] { "val1", "val2", "val3" }, inputArgs.GetMultiArgumentOrDefault("multi"));
         }
 
         [Fact]

--- a/src/shared/Core.Tests/StreamExtensionsTests.cs
+++ b/src/shared/Core.Tests/StreamExtensionsTests.cs
@@ -33,9 +33,9 @@ namespace GitCredentialManager.Tests
 
             Assert.NotNull(output);
             Assert.Equal(3, output.Count);
-            Assert.Contains(KeyValuePair.Create("a", "1"), output);
-            Assert.Contains(KeyValuePair.Create("b", "2"), output);
-            Assert.Contains(KeyValuePair.Create("c", "3"), output);
+            AssertDictionary("1", "a", output);
+            AssertDictionary("2", "b", output);
+            AssertDictionary("3", "c", output);
         }
 
         [Fact]
@@ -47,9 +47,9 @@ namespace GitCredentialManager.Tests
 
             Assert.NotNull(output);
             Assert.Equal(3, output.Count);
-            Assert.Contains(KeyValuePair.Create("a", "1"), output);
-            Assert.Contains(KeyValuePair.Create("b", "2"), output);
-            Assert.Contains(KeyValuePair.Create("c", "3"), output);
+            AssertDictionary("1", "a", output);
+            AssertDictionary("2", "b", output);
+            AssertDictionary("3", "c", output);
         }
 
         [Fact]
@@ -61,8 +61,8 @@ namespace GitCredentialManager.Tests
 
             Assert.NotNull(output);
             Assert.Equal(2, output.Count);
-            Assert.Contains(KeyValuePair.Create("a", "1"), output);
-            Assert.Contains(KeyValuePair.Create("A", "2"), output);
+            AssertDictionary("1", "a", output);
+            AssertDictionary("2", "A", output);
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace GitCredentialManager.Tests
 
             Assert.NotNull(output);
             Assert.Equal(1, output.Count);
-            Assert.Contains(KeyValuePair.Create("a", "2"), output);
+            AssertDictionary("2", "a", output);
         }
 
         [Fact]
@@ -86,9 +86,9 @@ namespace GitCredentialManager.Tests
 
             Assert.NotNull(output);
             Assert.Equal(3, output.Count);
-            Assert.Contains(KeyValuePair.Create("key a", "value 1"), output);
-            Assert.Contains(KeyValuePair.Create("  key b  ", " 2 "), output);
-            Assert.Contains(KeyValuePair.Create("key\tc\t", "\t3\t"), output);
+            AssertDictionary("value 1", "key a", output);
+            AssertDictionary(" 2 ", "  key b  ", output);
+            AssertDictionary("\t3\t", "key\tc\t", output);
         }
 
         [Fact]
@@ -100,9 +100,9 @@ namespace GitCredentialManager.Tests
 
             Assert.NotNull(output);
             Assert.Equal(3, output.Count);
-            Assert.Contains(KeyValuePair.Create("a", "value=1"), output);
-            Assert.Contains(KeyValuePair.Create("b", "value=2"), output);
-            Assert.Contains(KeyValuePair.Create("c", "value=3"), output);
+            AssertDictionary("value=1", "a", output);
+            AssertDictionary("value=2", "b", output);
+            AssertDictionary("value=3", "c", output);
         }
 
         [Fact]

--- a/src/shared/Core.Tests/StreamExtensionsTests.cs
+++ b/src/shared/Core.Tests/StreamExtensionsTests.cs
@@ -11,6 +11,8 @@ namespace GitCredentialManager.Tests
         private const string LF   = "\n";
         private const string CRLF = "\r\n";
 
+        #region Dictionary
+
         [Fact]
         public void StreamExtensions_ReadDictionary_EmptyString_ReturnsEmptyDictionary()
         {
@@ -183,11 +185,204 @@ namespace GitCredentialManager.Tests
             Assert.Equal("key a=value 1\r\n  key b  = value 2 \r\n\tvalue\tc\t=\t3\t\r\n\r\n", output);
         }
 
+        #endregion
+
+        #region MultiDictionary
+
+        [Fact]
+        public void StreamExtensions_ReadMultiDictionary_EmptyString_ReturnsEmptyDictionary()
+        {
+            string input = string.Empty;
+
+            var output = ReadStringStream(input, StreamExtensions.ReadMultiDictionary);
+
+            Assert.NotNull(output);
+            Assert.Equal(0, output.Count);
+        }
+
+        [Fact]
+        public void StreamExtensions_ReadMultiDictionary_TerminatedLF_ReturnsDictionary()
+        {
+            string input = "a=1\nb=2\nc=3\n\n";
+
+            var output = ReadStringStream(input, StreamExtensions.ReadMultiDictionary);
+
+            Assert.NotNull(output);
+            Assert.Equal(3, output.Count);
+
+            AssertMultiDictionary(new[] { "1" }, "a", output);
+            AssertMultiDictionary(new[] { "2" }, "b", output);
+            AssertMultiDictionary(new[] { "3" }, "c", output);
+        }
+
+        [Fact]
+        public void StreamExtensions_ReadMultiDictionary_TerminatedCRLF_ReturnsDictionary()
+        {
+            string input = "a=1\r\nb=2\r\nc=3\r\n\r\n";
+
+            var output = ReadStringStream(input, StreamExtensions.ReadMultiDictionary);
+
+            Assert.NotNull(output);
+            Assert.Equal(3, output.Count);
+            AssertMultiDictionary(new[] { "1" }, "a", output);
+            AssertMultiDictionary(new[] { "2" }, "b", output);
+            AssertMultiDictionary(new[] { "3" }, "c", output);
+        }
+
+        [Fact]
+        public void StreamExtensions_ReadMultiDictionary_CaseSensitive_ReturnsDictionaryWithMultipleEntries()
+        {
+            string input = "a=1\nA=2\n\n";
+
+            var output = ReadStringStream(input, x => StreamExtensions.ReadMultiDictionary(x, StringComparer.Ordinal));
+
+            Assert.NotNull(output);
+            Assert.Equal(2, output.Count);
+            AssertMultiDictionary(new[] { "1" }, "a", output);
+            AssertMultiDictionary(new[] { "2" }, "A", output);
+        }
+
+        [Fact]
+        public void StreamExtensions_ReadMultiDictionary_CaseInsensitive_ReturnsDictionaryWithLastValue()
+        {
+            string input = "a=1\nA=2\n\n";
+
+            var output = ReadStringStream(input, x => StreamExtensions.ReadMultiDictionary(x, StringComparer.OrdinalIgnoreCase));
+
+            Assert.NotNull(output);
+            Assert.Equal(1, output.Count);
+            AssertMultiDictionary(new[] { "2" }, "a", output);
+        }
+
+        [Fact]
+        public void StreamExtensions_ReadMultiDictionary_Spaces_ReturnsCorrectKeysAndValues()
+        {
+            string input = "key a=value 1\n  key b  = 2 \nkey\tc\t=\t3\t\n\n";
+
+            var output = ReadStringStream(input, StreamExtensions.ReadMultiDictionary);
+
+            Assert.NotNull(output);
+            Assert.Equal(3, output.Count);
+
+            AssertMultiDictionary(new[] { "value 1" }, "key a", output);
+            AssertMultiDictionary(new[] { " 2 " }, "  key b  ", output);
+            AssertMultiDictionary(new[] { "\t3\t" }, "key\tc\t", output);
+        }
+
+        [Fact]
+        public void StreamExtensions_ReadMultiDictionary_EqualsInValues_ReturnsCorrectKeysAndValues()
+        {
+            string input = "a=value=1\nb=value=2\nc=value=3\n\n";
+
+            var output = ReadStringStream(input, StreamExtensions.ReadMultiDictionary);
+
+            Assert.NotNull(output);
+            Assert.Equal(3, output.Count);
+            AssertMultiDictionary(new[] { "value=1" }, "a", output);
+            AssertMultiDictionary(new[] { "value=2" }, "b", output);
+            AssertMultiDictionary(new[] { "value=3" }, "c", output);
+        }
+
+        [Fact]
+        public void StreamExtensions_ReadMultiDictionary_MultiValue_ReturnsDictionary()
+        {
+            string input = "odd[]=1\neven[]=2\neven[]=4\nodd[]=3\n\n";
+
+            var output = ReadStringStream(input, StreamExtensions.ReadMultiDictionary);
+
+            Assert.NotNull(output);
+            Assert.Equal(2, output.Count);
+            AssertMultiDictionary(new[] { "1", "3" }, "odd", output);
+            AssertMultiDictionary(new[] { "2", "4" }, "even", output);
+        }
+
+        [Fact]
+        public void StreamExtensions_WriteDictionary_TextWriterLF_EmptyMultiDictionary_WritesLineLF()
+        {
+            var input = new Dictionary<string, IList<string>>();
+
+            string output = WriteStringStream(input, StreamExtensions.WriteDictionary, newLine: LF);
+
+            Assert.Equal(LF, output);
+        }
+
+        [Fact]
+        public void StreamExtensions_WriteDictionary_TextWriterCRLF_EmptyMultiDictionary_WritesLineCRLF()
+        {
+            var input = new Dictionary<string, IList<string>>();
+
+            string output = WriteStringStream(input, StreamExtensions.WriteDictionary, newLine: CRLF);
+
+            Assert.Equal(CRLF, output);
+        }
+
+        [Fact]
+        public void StreamExtensions_WriteDictionary_TextWriterLF_MultiEntries_WritesKVPListsAndLF()
+        {
+            var input = new Dictionary<string, IList<string>>
+            {
+                ["a"] = new[] { "1", "2", "3" },
+                ["b"] = new[] { "4", "5", },
+                ["c"] = new[] { "6" }
+            };
+
+            string output = WriteStringStream(input, StreamExtensions.WriteDictionary, newLine: LF);
+
+            Assert.Equal("a[]=1\na[]=2\na[]=3\nb[]=4\nb[]=5\nc=6\n\n", output);
+        }
+
+        [Fact]
+        public void StreamExtensions_WriteDictionary_TextWriterCRLF_MultiEntries_WritesKVPListsAndCRLF()
+        {
+            var input = new Dictionary<string, IList<string>>
+            {
+                ["a"] = new[] { "1", "2", "3" },
+                ["b"] = new[] { "4", "5", },
+                ["c"] = new[] { "6" }
+            };
+
+            string output = WriteStringStream(input, StreamExtensions.WriteDictionary, newLine: CRLF);
+
+            Assert.Equal("a[]=1\r\na[]=2\r\na[]=3\r\nb[]=4\r\nb[]=5\r\nc=6\r\n\r\n", output);
+        }
+
+        [Fact]
+        public void StreamExtensions_WriteDictionary_NoMultiEntries_WritesKVPsAndLF()
+        {
+            var input = new Dictionary<string, IList<string>>
+            {
+                ["a"] = new[] {"1"},
+                ["b"] = new[] {"2"},
+                ["c"] = new[] {"3"}
+            };
+
+            string output = WriteStringStream(input, StreamExtensions.WriteDictionary, newLine: LF);
+
+            Assert.Equal("a=1\nb=2\nc=3\n\n", output);
+        }
+
+        [Fact]
+        public void StreamExtensions_WriteDictionary_MultiEntriesWithEmpty_WritesKVPListsAndLF()
+        {
+            var input = new Dictionary<string, IList<string>>
+            {
+                ["a"] = new[] {"1", "2", "", "3", "4"},
+                ["b"] = new[] {"5"},
+                ["c"] = new[] {"6", "7", ""}
+            };
+
+            string output = WriteStringStream(input, StreamExtensions.WriteDictionary, newLine: LF);
+
+            Assert.Equal("a[]=3\na[]=4\nb=5\n\n", output);
+        }
+
+        #endregion
+
         #region Helpers
 
-        private static IDictionary<string, string> ReadStringStream(string input, Func<TextReader, IDictionary<string, string>> func)
+        private static T ReadStringStream<T>(string input, Func<TextReader, T> func)
         {
-            IDictionary<string, string> output;
+            T output;
             using (var reader = new StringReader(input))
             {
                 output = func(reader);
@@ -196,7 +391,7 @@ namespace GitCredentialManager.Tests
             return output;
         }
 
-        private static string WriteStringStream(IDictionary<string, string> input, Action<TextWriter, IDictionary<string, string>> action, string newLine)
+        private static string WriteStringStream<T>(T input, Action<TextWriter, T> action, string newLine)
         {
             var output = new StringBuilder();
             using (var writer = new StringWriter(output){NewLine = newLine})
@@ -205,6 +400,20 @@ namespace GitCredentialManager.Tests
             }
 
             return output.ToString();
+        }
+
+        private static void AssertDictionary(string expectedValue, string key, IDictionary<string, string> dict)
+        {
+            Assert.True(dict.TryGetValue(key, out string actualValue));
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        private static void AssertMultiDictionary(IList<string> expectedValues,
+            string key,
+            IDictionary<string, IList<string>> dict)
+        {
+            Assert.True(dict.TryGetValue(key, out IList<string> actualValues));
+            Assert.Equal(expectedValues, actualValues);
         }
 
         #endregion

--- a/src/shared/Core/Commands/GitCommandBase.cs
+++ b/src/shared/Core/Commands/GitCommandBase.cs
@@ -33,7 +33,7 @@ namespace GitCredentialManager.Commands
 
             // Parse standard input arguments
             // git-credential treats the keys as case-sensitive; so should we.
-            IDictionary<string, string> inputDict = await Context.Streams.In.ReadDictionaryAsync(StringComparer.Ordinal);
+            IDictionary<string, IList<string>> inputDict = await Context.Streams.In.ReadMultiDictionaryAsync(StringComparer.Ordinal);
             var input = new InputArguments(inputDict);
 
             // Validate minimum arguments are present

--- a/src/shared/Core/StreamExtensions.cs
+++ b/src/shared/Core/StreamExtensions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace GitCredentialManager
@@ -43,6 +42,40 @@ namespace GitCredentialManager
         }
 
         /// <summary>
+        /// Read a multi-dictionary in the form `key1=value\nkey2=value\n\n` from the specified <see cref="TextReader"/>.
+        /// </summary>
+        /// <remarks>
+        /// Uses the <see cref="StringComparer.Ordinal"/> comparer for dictionary keys.
+        /// <para/>
+        /// Also accepts dictionary lines terminated using \r\n (CR LF) as well as \n (LF).
+        /// </remarks>
+        /// <param name="reader">Text reader to read a dictionary from.</param>
+        /// <returns>Dictionary read from the text reader.</returns>
+        public static IDictionary<string, IList<string>> ReadMultiDictionary(this TextReader reader) =>
+            ReadMultiDictionary(reader, StringComparer.Ordinal);
+
+        /// <summary>
+        /// Read a multi-dictionary in the form `key1=value\nkey2=value\n\n` from the specified <see cref="TextReader"/>,
+        /// with the specified <see cref="StringComparer"/> used to compare dictionary keys.
+        /// </summary>
+        /// <remarks>Also accepts dictionary lines terminated using \r\n (CR LF) as well as \n (LF).</remarks>
+        /// <param name="reader">Text reader to read a dictionary from.</param>
+        /// <param name="comparer">Comparer to use when comparing dictionary keys.</param>
+        /// <returns>Dictionary read from the text reader.</returns>
+        public static IDictionary<string, IList<string>> ReadMultiDictionary(this TextReader reader, StringComparer comparer)
+        {
+            var dict = new Dictionary<string, IList<string>>(comparer);
+
+            string line;
+            while ((line = reader.ReadLine()) != null && !string.IsNullOrWhiteSpace(line))
+            {
+                ParseMultiLine(dict, line);
+            }
+
+            return dict;
+        }
+
+        /// <summary>
         /// Asynchronously read a dictionary in the form `key1=value\nkey2=value\n\n` from the specified <see cref="TextReader"/>.
         /// </summary>
         /// <remarks>
@@ -54,6 +87,19 @@ namespace GitCredentialManager
         /// <returns>Dictionary read from the text reader.</returns>
         public static Task<IDictionary<string, string>> ReadDictionaryAsync(this TextReader reader) =>
             ReadDictionaryAsync(reader, StringComparer.Ordinal);
+
+        /// <summary>
+        /// Asynchronously read a multi-dictionary in the form `key1=value\nkey2=value\n\n` from the specified <see cref="TextReader"/>.
+        /// </summary>
+        /// <remarks>
+        /// Uses the <see cref="StringComparer.Ordinal"/> comparer for dictionary keys.
+        /// <para/>
+        /// Also accepts dictionary lines terminated using \r\n (CR LF) as well as \n (LF).
+        /// </remarks>
+        /// <param name="reader">Text reader to read a dictionary from.</param>
+        /// <returns>Dictionary read from the text reader.</returns>
+        public static Task<IDictionary<string, IList<string>>> ReadMultiDictionaryAsync(this TextReader reader) =>
+            ReadMultiDictionaryAsync(reader, StringComparer.Ordinal);
 
         /// <summary>
         /// Asynchronously read a dictionary in the form `key1=value\nkey2=value\n\n` from the specified <see cref="TextReader"/>,
@@ -77,17 +123,72 @@ namespace GitCredentialManager
         }
 
         /// <summary>
+        /// Asynchronously read a multi-dictionary in the form `key1=value\nkey2=value\n\n` from the specified <see cref="TextReader"/>,
+        /// with the specified <see cref="StringComparer"/> used to compare dictionary keys.
+        /// </summary>
+        /// <remarks>Also accepts dictionary lines terminated using \r\n (CR LF) as well as \n (LF).</remarks>
+        /// <param name="reader">Text reader to read a dictionary from.</param>
+        /// <param name="comparer">Comparer to use when comparing dictionary keys.</param>
+        /// <returns>Dictionary read from the text reader.</returns>
+        public static async Task<IDictionary<string, IList<string>>> ReadMultiDictionaryAsync(this TextReader reader, StringComparer comparer)
+        {
+            var dict = new Dictionary<string, IList<string>>(comparer);
+
+            string line;
+            while ((line = await reader.ReadLineAsync()) != null && !string.IsNullOrWhiteSpace(line))
+            {
+                ParseMultiLine(dict, line);
+            }
+
+            return dict;
+        }
+
+        /// <summary>
         /// Write a dictionary in the form `key1=value\nkey2=value\n\n` to the specified <see cref="TextWriter"/>,
         /// where \n is the configured new-line (see <see cref="TextWriter.NewLine"/>).
         /// </summary>
         /// <remarks>The output dictionary new-lines are determined by the <see cref="TextWriter.NewLine"/> property.</remarks>
-        /// <param name="reader">Text writer to write a dictionary to.</param>
+        /// <param name="writer">Text writer to write a dictionary to.</param>
         /// <param name="dict">Dictionary to write to the text writer.</param>
         public static void WriteDictionary(this TextWriter writer, IDictionary<string, string> dict)
         {
             foreach (var kvp in dict)
             {
-                WriteKeyValuePair(writer, kvp);
+                writer.WriteLine($"{kvp.Key}={kvp.Value}");
+            }
+
+            // Write terminating line
+            writer.WriteLine();
+        }
+
+        /// <summary>
+        /// Write a dictionary in the form `key1=value\nkey2=value\n\n` to the specified <see cref="TextWriter"/>,
+        /// where \n is the configured new-line (see <see cref="TextWriter.NewLine"/>).
+        /// </summary>
+        /// <remarks>The output dictionary new-lines are determined by the <see cref="TextWriter.NewLine"/> property.</remarks>
+        /// <param name="writer">Text writer to write a dictionary to.</param>
+        /// <param name="dict">Dictionary to write to the text writer.</param>
+        public static void WriteDictionary(this TextWriter writer, IDictionary<string, IList<string>> dict)
+        {
+            foreach (var kvp in dict)
+            {
+                IList<string> values = GetNormalizedValueList(kvp.Value);
+                switch (values.Count)
+                {
+                    case 0:
+                        break;
+
+                    case 1:
+                        writer.WriteLine($"{kvp.Key}={kvp.Value[0]}");
+                        break;
+
+                    default:
+                        foreach (string value in values)
+                        {
+                            writer.WriteLine($"{kvp.Key}[]={value}");
+                        }
+                        break;
+                }
             }
 
             // Write terminating line
@@ -99,36 +200,20 @@ namespace GitCredentialManager
         /// where \n is the configured new-line (see <see cref="TextWriter.NewLine"/>).
         /// </summary>
         /// <remarks>The output dictionary new-lines are determined by the <see cref="TextWriter.NewLine"/> property.</remarks>
-        /// <param name="reader">Text writer to write a dictionary to.</param>
+        /// <param name="writer">Text writer to write a dictionary to.</param>
         /// <param name="dict">Dictionary to write to the text writer.</param>
         public static async Task WriteDictionaryAsync(this TextWriter writer, IDictionary<string, string> dict)
         {
             foreach (var kvp in dict)
             {
-                await WriteKeyValuePairAsync(writer, kvp);
+                await writer.WriteLineAsync($"{kvp.Key}={kvp.Value}");
             }
 
             // Write terminating line
             await writer.WriteLineAsync();
         }
 
-        private static void WriteKeyValuePair(this TextWriter writer, KeyValuePair<string, string> kvp)
-            => WriteKeyValuePair(writer, kvp.Key, kvp.Value);
-
-        private static void WriteKeyValuePair(this TextWriter writer, string key, string value)
-        {
-            writer.WriteLine($"{key}={value}");
-        }
-
-        private static Task WriteKeyValuePairAsync(this TextWriter writer, KeyValuePair<string, string> kvp)
-            => WriteKeyValuePairAsync(writer, kvp.Key, kvp.Value);
-
-        private static Task WriteKeyValuePairAsync(this TextWriter writer, string key, string value)
-        {
-            return writer.WriteLineAsync($"{key}={value}");
-        }
-
-        private static void ParseLine(IDictionary<string,string> dict, string line)
+        private static void ParseLine(IDictionary<string, string> dict, string line)
         {
             int splitIndex = line.IndexOf('=');
             if (splitIndex > 0)
@@ -138,6 +223,62 @@ namespace GitCredentialManager
 
                 dict[key] = value;
             }
+        }
+
+        private static void ParseMultiLine(IDictionary<string, IList<string>> dict, string line)
+        {
+            int splitIndex = line.IndexOf('=');
+            if (splitIndex > 0)
+            {
+                string key = line.Substring(0, splitIndex);
+                string value = line.Substring(splitIndex + 1);
+
+                bool multi = key.EndsWith("[]");
+                if (multi)
+                {
+                    key = key.Substring(0, key.Length - 2);
+                }
+
+                if (!dict.TryGetValue(key, out IList<string> list))
+                {
+                    list = new List<string>();
+                    dict[key] = list;
+                }
+
+                // Only allow one value for non-multi/array entries ("key=value")
+                // and reset the array of a multi-entry if the value is empty ("key[]=<empty>")
+                bool emptyValue = string.IsNullOrEmpty(value);
+                if (!multi || emptyValue)
+                {
+                    list.Clear();
+
+                    if (emptyValue)
+                    {
+                        return;
+                    }
+                }
+
+                list.Add(value);
+            }
+        }
+
+        private static IList<string> GetNormalizedValueList(IEnumerable<string> values)
+        {
+            var result = new List<string>();
+
+            foreach (string value in values)
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    result.Clear();
+                }
+                else
+                {
+                    result.Add(value);
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/src/shared/Core/Trace.cs
+++ b/src/shared/Core/Trace.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -215,13 +216,25 @@ namespace GitCredentialManager
             {
                 bool isSecretEntry = !(secretKeys is null) &&
                                      secretKeys.Contains(entry.Key, keyComparer ?? EqualityComparer<TKey>.Default);
-                if (isSecretEntry && !this.IsSecretTracingEnabled)
+
+                void WriteSecretLine(object value)
                 {
-                    WriteLine($"\t{entry.Key}={SecretMask}", filePath, lineNumber, memberName);
+                    var message = isSecretEntry && !IsSecretTracingEnabled
+                        ? $"\t{entry.Key}={SecretMask}"
+                        : $"\t{entry.Key}={value}";
+                    WriteLine(message, filePath, lineNumber, memberName);
+                }
+
+                if (entry.Value is IEnumerable<string> values)
+                {
+                    foreach (string value in values)
+                    {
+                        WriteSecretLine(value);
+                    }
                 }
                 else
                 {
-                    WriteLine($"\t{entry.Key}={entry.Value}", filePath, lineNumber, memberName);
+                    WriteSecretLine(entry.Value);
                 }
             }
         }

--- a/src/shared/Core/Trace.cs
+++ b/src/shared/Core/Trace.cs
@@ -217,24 +217,25 @@ namespace GitCredentialManager
                 bool isSecretEntry = !(secretKeys is null) &&
                                      secretKeys.Contains(entry.Key, keyComparer ?? EqualityComparer<TKey>.Default);
 
-                void WriteSecretLine(object value)
+                void WriteSecretLine(string keySuffix, object value)
                 {
                     var message = isSecretEntry && !IsSecretTracingEnabled
-                        ? $"\t{entry.Key}={SecretMask}"
-                        : $"\t{entry.Key}={value}";
+                        ? $"\t{entry.Key}{keySuffix}={SecretMask}"
+                        : $"\t{entry.Key}{keySuffix}={value}";
                     WriteLine(message, filePath, lineNumber, memberName);
                 }
 
                 if (entry.Value is IEnumerable<string> values)
                 {
-                    foreach (string value in values)
+                    List<string> valueList = values.ToList();
+                    foreach (string value in valueList)
                     {
-                        WriteSecretLine(value);
+                        WriteSecretLine(valueList.Count > 1 ? "[]" : string.Empty, value);
                     }
                 }
                 else
                 {
-                    WriteSecretLine(entry.Value);
+                    WriteSecretLine(string.Empty, entry.Value);
                 }
             }
         }


### PR DESCRIPTION
Add the new `wwwauth[]` credential property to the input arguments surfaced to providers and commands. This optional property is available as of Git 2.41.

```
Git v2.41 Release Notes
=======================

UI, Workflows & Features

 * Allow information carried on the WWW-Authenticate header to be
   passed to the credential helpers.
```

https://lore.kernel.org/git/xmqqleh3a3wm.fsf@gitster.g/

This new property may contain multiple values, as identified by a trailing `[]` on the property name. Extend our `Dictionary/Stream(Reader|Writer)` methods to allow for these multi-valued properties and add a convenience property to the `InputArguments` to get `wwwauth[]`.