### PR TITLE
Prefer authority from `wwwauth[]` if present for Azure Repos

### DIFF
--- a/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
@@ -643,6 +643,42 @@ namespace Microsoft.AzureRepos.Tests
             Assert.False(context.Git.Configuration.Global.TryGetValue(AzDevUseHttpPathKey, out _));
         }
 
+        [Theory]
+        [InlineData(false, null, "")]
+        [InlineData(false, null, "   ")]
+        [InlineData(false, null, null)]
+        [InlineData(false, null, "Basic realm=\"test\"")]
+        [InlineData(false, null, "Basic realm=\"https://tfsprodwcus0.app.visualstudio.com/\"")]
+        [InlineData(false, null, "TFS-Federated")]
+        [InlineData(true, "https://login.microsoftonline.com/79c4d065-d599-442e-b0ea-c4ab36ad63c3",
+            "Bearer authorization_uri=https://login.microsoftonline.com/79c4d065-d599-442e-b0ea-c4ab36ad63c3")]
+        [InlineData(true, "https://login.microsoftonline.com/79c4d065-d599-442e-b0ea-c4ab36ad63c3",
+            "bEArEr auThORizAtIoN_uRi=https://login.microsoftonline.com/79c4d065-d599-442e-b0ea-c4ab36ad63c3")]
+        [InlineData(true, "https://login.microsoftonline.com/79c4d065-d599-442e-b0ea-c4ab36ad63c3",
+            "\"Bearer authorization_uri=https://login.microsoftonline.com/79c4d065-d599-442e-b0ea-c4ab36ad63c3\"")]
+        [InlineData(true, "https://login.microsoftonline.com/79c4d065-d599-442e-b0ea-c4ab36ad63c3",
+            "'Bearer authorization_uri=https://login.microsoftonline.com/79c4d065-d599-442e-b0ea-c4ab36ad63c3'")]
+        [InlineData(true, "https://login.microsoftonline.com/tenant1",
+            "Bearer authorization_uri=https://login.microsoftonline.com/tenant1",
+            "Bearer authorization_uri=https://login.microsoftonline.com/tenant2",
+            "Bearer authorization_uri=https://login.microsoftonline.com/tenant3")]
+        [InlineData(true, "https://login.microsoftonline.com/79c4d065-d599-442e-b0ea-c4ab36ad63c3",
+            "Bearer authorization_uri=https://login.microsoftonline.com/79c4d065-d599-442e-b0ea-c4ab36ad63c3",
+            "Basic realm=\"https://tfsprodwcus0.app.visualstudio.com/\"",
+            "TFS-Federated")]
+        [InlineData(true, "https://login.microsoftonline.com/79c4d065-d599-442e-b0ea-c4ab36ad63c3",
+            "TFS-Federated",
+            "Basic realm=\"https://tfsprodwcus0.app.visualstudio.com/\"",
+            "Bearer authorization_uri=https://login.microsoftonline.com/79c4d065-d599-442e-b0ea-c4ab36ad63c3")]
+        public void AzureReposHostProvider_TryGetAuthorityFromHeaders(
+            bool expectedResult, string expectedAuthority, params string[] headers)
+        {
+            bool actualResult = AzureReposHostProvider.TryGetAuthorityFromHeaders(headers, out string actualAuthority);
+
+            Assert.Equal(expectedResult, actualResult);
+            Assert.Equal(expectedAuthority, actualAuthority);
+        }
+
         private static IMicrosoftAuthenticationResult CreateAuthResult(string upn, string token)
         {
             return new MockMsAuthResult


### PR DESCRIPTION
Now that Git can forward on the `WWW-Authenticate` headers from the remote, we no longer need to make a second, redundant, `HEAD` query to the organisation URL to rediscover the header values.

If we have been provided such a header from Git, use it in the first instance! Otherwise continue to make a `HEAD` query (and cache it).

Note this only affects the OAuth mode, just as the authority caching only works here.