### PR TITLE
install from source: designate arch linux as unsupported

### DIFF
--- a/.github/workflows/validate-install-from-source.yml
+++ b/.github/workflows/validate-install-from-source.yml
@@ -26,7 +26,6 @@ jobs:
         - image: opensuse/leap
         - image: opensuse/tumbleweed
         - image: registry.suse.com/suse/sle15:15.4.27.11.31
-        - image: archlinux
     container: ${{matrix.vector.image}}
     steps:
       - run: |

--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -114,6 +114,14 @@ apt_install() {
     $sudo_cmd apt install $pkg_name -y 2>/dev/null
 }
 
+print_unsupported_distro() {
+    prefix=$1
+    distro=$2
+
+    echo "$prefix: $distro is not officially supported by the GCM project."
+    echo "See https://gh.io/gcm/linux for details."
+}
+
 sudo_cmd=
 
 # If the user isn't root, we need to use `sudo` for certain commands
@@ -179,6 +187,8 @@ case "$distribution" in
         ensure_dotnet_installed
     ;;
     arch)
+        print_unsupported_distro "WARNING" "$distribution"
+
         # --noconfirm required when running from container
         $sudo_cmd pacman -Syu --noconfirm
 
@@ -188,7 +198,7 @@ case "$distribution" in
         ensure_dotnet_installed
     ;;
     *)
-        echo "ERROR: Unsupported Linux distribution: $distribution"
+        print_unsupported_distro "ERROR" "$distribution"
         exit
     ;;
 esac


### PR DESCRIPTION
Arch Linux was incorrectly added to the install-from-source script and
accompanying validation as a .NET-supported distribution, when this is not
actually the case. A list of supported distributions can be found here:
  
https://learn.microsoft.com/en-us/dotnet/core/install/linux
  
Instead of removing unsupported distros, we plan to print out a message
notifying users that, while they can be installed, they are not officially
validated or supported by the GCM project.