### PR TITLE
Clarify to install GCM for Windows for WSL

### DIFF
--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -41,7 +41,7 @@ If you wish to use GCM inside of WSL _without installing Git for Windows_
 you must complete additional configuration so that GCM can callback to Git
 inside of your WSL installation.
 
-Start by installing the [latest GCM ⬇️][latest-gcm]
+Start by installing the [latest GCM for Windows⬇️][latest-gcm]
 
 _Inside your WSL installation_, run the following command to set GCM as the Git
 credential helper:


### PR DESCRIPTION
Previously it wasn't clear whether to install GCM for Linux or Windows when using WSL until later in the document.

Now the first step explicitly says GCM for Windows.