### PR TITLE
Replace DNF's deprecated 'dnf update' alias with 'dnf upgrade'

### DIFF
--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -163,7 +163,7 @@ case "$distribution" in
         fi
     ;;
     fedora | centos | rhel)
-        $sudo_cmd dnf update -y
+        $sudo_cmd dnf upgrade -y
 
         # Install dotnet/GCM dependencies.
         install_packages dnf install "curl git krb5-libs libicu openssl-libs zlib findutils which bash"


### PR DESCRIPTION
Addresses #1298.  According to the [DNF manpages](https://man7.org/linux/man-pages/man8/dnf.8.html), `update` is a deprecated alias.