### PR TITLE
validate-install-from-source: fix debian

### DIFF
--- a/.github/workflows/validate-install-from-source.yml
+++ b/.github/workflows/validate-install-from-source.yml
@@ -1,6 +1,7 @@
 name: validate-install-from-source
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/validate-install-from-source.yml
+++ b/.github/workflows/validate-install-from-source.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         vector:
         - image: ubuntu
-        - image: debian
+        - image: debian:bullseye
         - image: fedora
         # Centos no longer officially maintains images on Docker Hub. However,
         # tgagor is a contributor who pushes updated images weekly, which should


### PR DESCRIPTION
Based on [this documentation](https://learn.microsoft.com/en-us/dotnet/core/install/linux-debian#supported-distributions), it appears that .NET is not yet supported on Debian Bookworm (12). As a result, attempting to install .NET in a container running Bookworm [led to failures](https://github.com/ldennington/git-credential-manager/actions/runs/5326250435/jobs/9648032190). This change locks the validation workflow into using Bullseye to work around this issue. It also adds a `workflow_dispatch` trigger to make running `validate-install-from-source` easier in the future.

A successful workflow run with these changes can be found [here](https://github.com/ldennington/git-credential-manager/actions/runs/5326464820).