### PR TITLE
Workaround issue #1293 by avoiding setting textbox focus on Mac

### DIFF
--- a/src/shared/Atlassian.Bitbucket/UI/Views/CredentialsView.axaml.cs
+++ b/src/shared/Atlassian.Bitbucket/UI/Views/CredentialsView.axaml.cs
@@ -1,6 +1,7 @@
 using Atlassian.Bitbucket.UI.ViewModels;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using GitCredentialManager;
 using GitCredentialManager.UI.Controls;
 
 namespace Atlassian.Bitbucket.UI.Views
@@ -44,11 +45,15 @@ namespace Atlassian.Bitbucket.UI.Views
                 _tabControl.SelectedIndex = 1;
                 if (string.IsNullOrWhiteSpace(vm.UserName))
                 {
-                    _userNameTextBox.Focus();
+                    // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293
+                    if (!PlatformUtils.IsMacOS())
+                        _userNameTextBox.Focus();
                 }
                 else
                 {
-                    _passwordTextBox.Focus();
+                    // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293
+                    if (!PlatformUtils.IsMacOS())
+                        _passwordTextBox.Focus();
                 }
             }
         }

--- a/src/shared/Core/UI/Views/CredentialsView.axaml.cs
+++ b/src/shared/Core/UI/Views/CredentialsView.axaml.cs
@@ -32,11 +32,15 @@ namespace GitCredentialManager.UI.Views
 
             if (string.IsNullOrWhiteSpace(vm.UserName))
             {
-                _userNameTextBox.Focus();
+                // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293
+                if (!PlatformUtils.IsMacOS())
+                    _userNameTextBox.Focus();
             }
             else
             {
-                _passwordTextBox.Focus();
+                // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293
+                if (!PlatformUtils.IsMacOS())
+                    _passwordTextBox.Focus();
             }
         }
     }

--- a/src/shared/GitHub/UI/Controls/SixDigitInput.axaml.cs
+++ b/src/shared/GitHub/UI/Controls/SixDigitInput.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
+using GitCredentialManager;
 using GitCredentialManager.UI.Controls;
 
 namespace GitHub.UI.Controls
@@ -86,7 +87,9 @@ namespace GitHub.UI.Controls
 
         public void SetFocus()
         {
-            KeyboardDevice.Instance.SetFocusedElement(_textBoxes[0], NavigationMethod.Tab, KeyModifiers.None);
+            // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293
+            if (!PlatformUtils.IsMacOS())
+                KeyboardDevice.Instance.SetFocusedElement(_textBoxes[0], NavigationMethod.Tab, KeyModifiers.None);
         }
 
         private void SetUpTextBox(TextBox textBox)

--- a/src/shared/GitHub/UI/Views/CredentialsView.axaml.cs
+++ b/src/shared/GitHub/UI/Views/CredentialsView.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using GitCredentialManager;
 using GitHub.UI.ViewModels;
 using GitCredentialManager.UI.Controls;
 
@@ -53,7 +54,9 @@ namespace GitHub.UI.Views
             else if (vm.ShowTokenLogin)
             {
                 _tabControl.SelectedIndex = 1;
-                _tokenTextBox.Focus();
+                // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293
+                if (!PlatformUtils.IsMacOS())
+                    _tokenTextBox.Focus();
 
             }
             else if (vm.ShowBasicLogin)
@@ -61,11 +64,15 @@ namespace GitHub.UI.Views
                 _tabControl.SelectedIndex = 2;
                 if (string.IsNullOrWhiteSpace(vm.UserName))
                 {
-                    _userNameTextBox.Focus();
+                    // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293
+                    if (!PlatformUtils.IsMacOS())
+                        _userNameTextBox.Focus();
                 }
                 else
                 {
-                    _passwordTextBox.Focus();
+                    // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293
+                    if (!PlatformUtils.IsMacOS())
+                        _passwordTextBox.Focus();
                 }
             }
         }

--- a/src/shared/GitHub/UI/Views/TwoFactorView.axaml.cs
+++ b/src/shared/GitHub/UI/Views/TwoFactorView.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using GitCredentialManager;
 using GitHub.UI.Controls;
 using GitCredentialManager.UI.Controls;
 
@@ -23,7 +24,9 @@ namespace GitHub.UI.Views
 
         public void SetFocus()
         {
-            _codeInput.SetFocus();
+            // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293
+            if (!PlatformUtils.IsMacOS())
+                _codeInput.SetFocus();
         }
     }
 }

--- a/src/shared/GitLab/UI/Views/CredentialsView.axaml.cs
+++ b/src/shared/GitLab/UI/Views/CredentialsView.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using GitCredentialManager;
 using GitLab.UI.ViewModels;
 using GitCredentialManager.UI.Controls;
 
@@ -48,18 +49,24 @@ namespace GitLab.UI.Views
             else if (vm.ShowTokenLogin)
             {
                 _tabControl.SelectedIndex = 1;
-                _tokenTextBox.Focus();
+                // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293
+                if (!PlatformUtils.IsMacOS())
+                    _tokenTextBox.Focus();
             }
             else if (vm.ShowBasicLogin)
             {
                 _tabControl.SelectedIndex = 2;
                 if (string.IsNullOrWhiteSpace(vm.UserName))
                 {
-                    _userNameTextBox.Focus();
+                    // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293
+                    if (!PlatformUtils.IsMacOS())
+                        _userNameTextBox.Focus();
                 }
                 else
                 {
-                    _passwordTextBox.Focus();
+                    // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293
+                    if (!PlatformUtils.IsMacOS())
+                        _passwordTextBox.Focus();
                 }
             }
         }


### PR DESCRIPTION
There appears to be an issue with setting focus with empty textboxes on macOS. Let's put in a quick workaround for now to avoid the crash that happens otherwise. On Mac, do not attempt to set the focus to a text box.

Workaround #1293