### PR TITLE
docs: fix path of user-only installation

### DIFF
--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -68,7 +68,7 @@ After updating the `WSLENV` environment variable, restart your WSL installation.
 If you have installed GCM using the user-only installer (i.e, the `gcmuser-*.exe`
 installer and not the system-wide/admin required installer), you need to modify
 the above instructions to point to
-`/mnt/c/Users/<USERNAME>/AppData/Local/Programs/Git\ Credential\ Manager\ Core/git-credential-manager.exe`
+`/mnt/c/Users/<USERNAME>/AppData/Local/Programs/Git\ Credential\ Manager/git-credential-manager.exe`
 instead.
 
 ## How it works


### PR DESCRIPTION
Fixed path for user-only installation of GCM for Windows.
Seems #551 forgot to update this path.

version: v2.1.2
imagePath: `C:\Users\user`
```
$ git config --global credential.helper "/mnt/c/Users/user/AppData/Local/Programs/Git\ Credential\ Manager/git-credential-manager.exe"
$ git pull
Already up to date.
```