### PR TITLE
docs: update VERSION placeholder in rename.md

### DIFF
--- a/docs/rename.md
+++ b/docs/rename.md
@@ -8,7 +8,7 @@ project in its own [organization][gcm-org].
 ![Git Credential Manager Core renamed](img/gcmcore-rename.png)
 
 At the time, the actual exectuable name was not updated and continued to be
-`git-credential-manager-core`. As of [VERSION][rename-ver], the executable has
+`git-credential-manager-core`. As of [2.0.877][rename-ver], the executable has
 been renamed to `git-credential-manager`, matching the new project name.
 
 ## Rename transition
@@ -21,11 +21,11 @@ warning: git-credential-manager-core was renamed to git-credential-manager
 warning: see https://aka.ms/gcm/rename for more information
 ```
 
-Since the executable was renamed in VERSION, GCM has also included symlinks
+Since the executable was renamed in 2.0.877, GCM has also included symlinks
 using the old name in order to ensure no one's setups would immediately break.
 
 These links will remain until _two_ major Git versions are released after GCM
-VERSION, _**at which point the symlinks will no longer be included**_.
+2.0.877, _**at which point the symlinks will no longer be included**_.
 
 It is recommended to update your Git configuration to use the new executable
 name as soon as possible to prevent any issues in the future.
@@ -159,7 +159,7 @@ or `manager` respectively.
 [rename-pr]: https://github.com/git-ecosystem/git-credential-manager/pull/541
 [rename-blog]: https://github.blog/2022-04-07-git-credential-manager-authentication-for-everyone/#universal-git-authentication
 [gcm-org]: https://github.com/git-ecosystem
-[rename-ver]: https://github.com/git-ecosystem/git-credential-manager/releases
+[rename-ver]: https://github.com/git-ecosystem/git-credential-manager/releases/tag/v2.0.877
 [git-windows]: https://git-scm.com/download/win
 [gcm-latest]: https://aka.ms/gcm/latest
 [warnings]: #rename-transition


### PR DESCRIPTION
Update the current VERSION placeholder for the git-credential-manager-core to git-credential-manager rename to 2.0.877 (since that is the version with which this update was released).

Fixes #1318 