### PR TITLE
Use UTF-8 encoding for UI helper standard output parsing

### DIFF
--- a/src/shared/Core/Authentication/AuthenticationBase.cs
+++ b/src/shared/Core/Authentication/AuthenticationBase.cs
@@ -35,7 +35,8 @@ namespace GitCredentialManager.Authentication
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = false, // Do not redirect stderr as tracing might be enabled
-                UseShellExecute = false
+                UseShellExecute = false,
+                StandardOutputEncoding = EncodingEx.UTF8NoBom,
             };
 
             Context.Trace.WriteLine($"Starting helper process: {path} {args}");

--- a/src/shared/Core/EncodingEx.cs
+++ b/src/shared/Core/EncodingEx.cs
@@ -1,0 +1,8 @@
+using System.Text;
+
+namespace GitCredentialManager;
+
+public static class EncodingEx
+{
+    public static readonly Encoding UTF8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+}

--- a/src/shared/Core/StandardStreams.cs
+++ b/src/shared/Core/StandardStreams.cs
@@ -29,8 +29,6 @@ namespace GitCredentialManager
     {
         private const string LineFeed  = "\n";
 
-        private static readonly Encoding Utf8NoBomEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-
         private TextReader _stdIn;
         private TextWriter _stdOut;
         private TextWriter _stdErr;
@@ -41,7 +39,7 @@ namespace GitCredentialManager
             {
                 if (_stdIn == null)
                 {
-                    _stdIn = new StreamReader(Console.OpenStandardInput(), Utf8NoBomEncoding);
+                    _stdIn = new StreamReader(Console.OpenStandardInput(), EncodingEx.UTF8NoBom);
                 }
 
                 return _stdIn;
@@ -54,7 +52,7 @@ namespace GitCredentialManager
             {
                 if (_stdOut == null)
                 {
-                    _stdOut = new StreamWriter(Console.OpenStandardOutput(), Utf8NoBomEncoding)
+                    _stdOut = new StreamWriter(Console.OpenStandardOutput(), EncodingEx.UTF8NoBom)
                     {
                         AutoFlush = true,
                         NewLine = LineFeed,
@@ -71,7 +69,7 @@ namespace GitCredentialManager
             {
                 if (_stdErr == null)
                 {
-                    _stdErr = new StreamWriter(Console.OpenStandardError(), Utf8NoBomEncoding)
+                    _stdErr = new StreamWriter(Console.OpenStandardError(), EncodingEx.UTF8NoBom)
                     {
                         AutoFlush = true,
                         NewLine = LineFeed,


### PR DESCRIPTION
Ensure that we read helper UI standard output as UTF-8. Helper applications already write output with a UTF-8 encoding, so we must ensure we read using the same encoding in the core application or else non-ASCII characters may be mangled.

Fixes #1287