### PR TITLE
rename: remove git-credential-manager-core symlinks

### DIFF
--- a/src/linux/Packaging.Linux/build.sh
+++ b/src/linux/Packaging.Linux/build.sh
@@ -70,12 +70,6 @@ if [ $INSTALL_FROM_SOURCE = true ]; then
             "$LINK_TO/git-credential-manager" || exit 1
     fi
 
-    # Create legacy symlink with older name
-    if [ ! -f "$LINK_TO/git-credential-manager-core" ]; then
-        ln -s -r "$INSTALL_TO/git-credential-manager" \
-            "$LINK_TO/git-credential-manager-core" || exit 1
-    fi
-
     echo "Install complete."
 else
     # Pack

--- a/src/linux/Packaging.Linux/pack.sh
+++ b/src/linux/Packaging.Linux/pack.sh
@@ -126,12 +126,6 @@ if [ ! -f "$LINK_TO/git-credential-manager" ]; then
         "$LINK_TO/git-credential-manager" || exit 1
 fi
 
-# Create legacy symlink with older name
-if [ ! -f "$LINK_TO/git-credential-manager-core" ]; then
-    ln -s -r "$INSTALL_TO/git-credential-manager" \
-        "$LINK_TO/git-credential-manager-core" || exit 1
-fi
-
 dpkg-deb -Zxz --build "$DEBROOT" "$DEBPKG" || exit 1
 
 echo $MESSAGE

--- a/src/osx/Installer.Mac/scripts/postinstall
+++ b/src/osx/Installer.Mac/scripts/postinstall
@@ -30,9 +30,6 @@ fi
 mkdir -p /usr/local/bin
 /bin/ln -Fs "$INSTALL_DESTINATION/git-credential-manager" /usr/local/bin/git-credential-manager
 
-# Create legacy symlink to GCMCore in /usr/local/bin
-/bin/ln -Fs "$INSTALL_DESTINATION/git-credential-manager" /usr/local/bin/git-credential-manager-core
-
 # Configure GCM for the current user (running as the current user to avoid root
 # from taking ownership of ~/.gitconfig)
 sudo -u ${USER} "$INSTALL_DESTINATION/git-credential-manager" configure

--- a/src/shared/Core/Constants.cs
+++ b/src/shared/Core/Constants.cs
@@ -210,7 +210,6 @@ namespace GitCredentialManager
             public const string GcmCredentialStores    = "https://aka.ms/gcm/credstores";
             public const string GcmWamComSecurity      = "https://aka.ms/gcm/wamadmin";
             public const string GcmAutoDetect          = "https://aka.ms/gcm/autodetect";
-            public const string GcmExecRename          = "https://aka.ms/gcm/rename";
             public const string GcmDefaultAccount      = "https://aka.ms/gcm/defaultaccount";
             public const string GcmMultipleUsers       = "https://aka.ms/gcm/multipleusers";
         }

--- a/src/shared/Git-Credential-Manager/Program.cs
+++ b/src/shared/Git-Credential-Manager/Program.cs
@@ -55,36 +55,6 @@ namespace GitCredentialManager
                 // Write the start and version events
                 context.Trace2.Start(context.ApplicationPath, args);
 
-                //
-                // Git Credential Manager's executable used to be named "git-credential-manager-core" before
-                // dropping the "-core" suffix. In order to prevent "helper not found" errors for users who
-                // haven't updated their configuration, we include either a 'shim' or symlink with the old name
-                // that print warning messages about using the old name, and then continue execution of GCM.
-                //
-                // On Windows the shim is an exact copy of the main "git-credential-manager.exe" executable
-                // with the old name. We inspect argv[0] to see which executable we are launched as.
-                //
-                // On UNIX systems we do the same check, except instead of a copy we use a symlink.
-                //
-                string appPath = context.ApplicationPath;
-                if (!string.IsNullOrWhiteSpace(appPath))
-                {
-                    // Trim any (.exe) file extension if we're on Windows
-                    // Note that in some circumstances (like being called by Git when config is set
-                    // to just `helper = manager-core`) we don't always have ".exe" at the end.
-                    if (PlatformUtils.IsWindows() && appPath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
-                    {
-                        appPath = appPath.Substring(0, appPath.Length - 4);
-                    }
-                    if (appPath.EndsWith("git-credential-manager-core", StringComparison.OrdinalIgnoreCase))
-                    {
-                        context.Streams.Error.WriteLine(
-                            "warning: git-credential-manager-core was renamed to git-credential-manager");
-                        context.Streams.Error.WriteLine(
-                            $"warning: see {Constants.HelpUrls.GcmExecRename} for more information");
-                    }
-                }
-
                 // Register all supported host providers at the normal priority.
                 // The generic provider should never win against a more specific one, so register it with low priority.
                 app.RegisterProvider(new AzureReposHostProvider(context), HostProviderPriority.Normal);

--- a/src/windows/Installer.Windows/layout.ps1
+++ b/src/windows/Installer.Windows/layout.ps1
@@ -54,24 +54,17 @@ dotnet publish "$GCM_UI_SRC" `
 Write-Output "Publishing Bitbucket UI helper..."
 dotnet publish "$BITBUCKET_UI_SRC" `
 	--configuration "$CONFIGURATION" `
-	--output "$PAYLOAD" 
+	--output "$PAYLOAD"
 
 Write-Output "Publishing GitHub UI helper..."
 dotnet publish "$GITHUB_UI_SRC" `
 	--configuration "$CONFIGURATION" `
-	--output "$PAYLOAD" 
+	--output "$PAYLOAD"
 
 Write-Output "Publishing GitLab UI helper..."
 dotnet publish "$GITLAB_UI_SRC" `
 	--configuration "$CONFIGURATION" `
-	--output "$PAYLOAD" 
-
-# Create copy of main GCM executable with older "GCM Core" name
-Copy-Item -Path "$PAYLOAD/git-credential-manager.exe" `
-	-Destination "$PAYLOAD/git-credential-manager-core.exe"
-
-Copy-Item -Path "$PAYLOAD/git-credential-manager.exe.config" `
-	-Destination "$PAYLOAD/git-credential-manager-core.exe.config"
+	--output "$PAYLOAD"
 
 # Delete libraries that are not needed for Windows but find their way
 # into the publish output.


### PR DESCRIPTION
Since 2 versions of Git have released since the rename of the executable from `git-credential-manager-core` to `git-credential-manager`, remove the associated symlinks and warnings, (as outlined in `docs/rename.md`).