### PR TITLE
Use localhost redirect URI for GHES instances

### DIFF
--- a/src/shared/GitHub/GitHubConstants.cs
+++ b/src/shared/GitHub/GitHubConstants.cs
@@ -16,6 +16,7 @@ namespace GitHub
         // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="OAuth2 public client application 'secrets' are required and permitted to be public")]
         public const string OAuthClientSecret = "18867509d956965542b521a529a79bb883344c90";
         public static readonly Uri OAuthRedirectUri = new Uri("http://127.0.0.1/"); // Note that the trailing slash is important!
+        public static readonly Uri OAuthLegacyRedirectUri = new Uri("http://localhost/"); // Note that the trailing slash is important!
         public static readonly Uri OAuthAuthorizationEndpointRelativeUri = new Uri("/login/oauth/authorize", UriKind.Relative);
         public static readonly Uri OAuthTokenEndpointRelativeUri = new Uri("/login/oauth/access_token", UriKind.Relative);
         public static readonly Uri OAuthDeviceEndpointRelativeUri = new Uri("/login/device/code", UriKind.Relative);

--- a/src/shared/GitHub/GitHubOAuth2Client.cs
+++ b/src/shared/GitHub/GitHubOAuth2Client.cs
@@ -9,7 +9,7 @@ namespace GitHub
     {
         public GitHubOAuth2Client(HttpClient httpClient, ISettings settings, Uri baseUri, ITrace2 trace2)
             : base(httpClient, CreateEndpoints(baseUri),
-                GetClientId(settings), trace2, GetRedirectUri(settings), GetClientSecret(settings)) { }
+                GetClientId(settings), trace2, GetRedirectUri(settings, baseUri), GetClientSecret(settings)) { }
 
         private static OAuth2ServerEndpoints CreateEndpoints(Uri baseUri)
         {
@@ -37,7 +37,7 @@ namespace GitHub
             return GitHubConstants.OAuthClientId;
         }
 
-        private static Uri GetRedirectUri(ISettings settings)
+        private static Uri GetRedirectUri(ISettings settings, Uri targetUri)
         {
             // Check for developer override value
             if (settings.TryGetSetting(
@@ -48,7 +48,10 @@ namespace GitHub
                 return redirectUri;
             }
 
-            return GitHubConstants.OAuthRedirectUri;
+            // Only GitHub.com supports the new OAuth redirect URI today
+            return GitHubHostProvider.IsGitHubDotCom(targetUri)
+                ? GitHubConstants.OAuthRedirectUri
+                : GitHubConstants.OAuthLegacyRedirectUri;
         }
 
         private static string GetClientSecret(ISettings settings)


### PR DESCRIPTION
For GitHub.com we've updated the redirect URI to 127.0.0.1, whilst also keeping the localhost variant around for backwards compatibility with older GCM clients.

However, since GHES has not been updated with the new 127.0.0.1 redirect, and older GHES servers will be stuck with the old redirect we must continue to use the localhost redirect on the client for non-dotcom targets.

Fixes #1329