### PR TITLE
Add empty string in non-multi dictionary for empty lines

### DIFF
--- a/src/shared/Core.Tests/StreamExtensionsTests.cs
+++ b/src/shared/Core.Tests/StreamExtensionsTests.cs
@@ -255,6 +255,19 @@ namespace GitCredentialManager.Tests
         }
 
         [Fact]
+        public void StreamExtensions_ReadMultiDictionary_EmptyString_ReturnsKeyWithEmptyStringValue()
+        {
+            string input = "a=\n\n";
+
+            var output = ReadStringStream(input, StreamExtensions.ReadMultiDictionary);
+
+            Assert.NotNull(output);
+            Assert.Equal(1, output.Count);
+
+            AssertMultiDictionary(new[] { String.Empty,  }, "a", output);
+        }
+
+        [Fact]
         public void StreamExtensions_ReadMultiDictionary_Spaces_ReturnsCorrectKeysAndValues()
         {
             string input = "key a=value 1\n  key b  = 2 \nkey\tc\t=\t3\t\n\n";

--- a/src/shared/Core/StreamExtensions.cs
+++ b/src/shared/Core/StreamExtensions.cs
@@ -248,14 +248,15 @@ namespace GitCredentialManager
                 // Only allow one value for non-multi/array entries ("key=value")
                 // and reset the array of a multi-entry if the value is empty ("key[]=<empty>")
                 bool emptyValue = string.IsNullOrEmpty(value);
+
                 if (!multi || emptyValue)
                 {
                     list.Clear();
+                }
 
-                    if (emptyValue)
-                    {
-                        return;
-                    }
+                if (multi && emptyValue)
+                {
+                    return;
                 }
 
                 list.Add(value);


### PR DESCRIPTION
Before 2.2.0, we only accepted input arguments in the form `key=value`. To support the new `wwwauth[]` argument from Git, we added support for these multi-value args `key[]=value`.

In changing from an dictionary of `string:string` to `string:list<string>` we accidentally changed the behaviour of dictionary parsing in the case that an empty valued (non-multi) argument was provided. For example:

```text
username=\n
```

Previously this was returned as an empty string. Post 2.2.0 this became `null`, causing an error in scenarios were before there was none.

One such scenario is with Windows Integrated Authentication (for example when connecting to Azure DevOps Server/TFS instances), whereby we return an empty username and password to Git to signal this auth mode. Git then returns to us the empty username and password in a `store` call.

Update the handling in `ParseMultiLine` to restore the previous behaviour for empty-valued arguments being mapped to the empty string.

Fixes #1331

---

**Bug reproduction steps:**

```console
% printf "url=https://example.com\nusername=\npassword=\n\n" | git credential approve
fatal: Missing 'username' input argument
```
