### PR TITLE
diagnose: add http fallback uri

### DIFF
--- a/src/shared/Core.Tests/Commands/DiagnoseCommandTests.cs
+++ b/src/shared/Core.Tests/Commands/DiagnoseCommandTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Net.Http;
+using System.Security.AccessControl;
+using System.Text;
+using GitCredentialManager.Diagnostics;
+using GitCredentialManager.Tests.Objects;
+using Xunit;
+
+namespace Core.Tests.Commands;
+
+public class DiagnoseCommandTests
+{
+    [Fact]
+    public void NetworkingDiagnostic_SendHttpRequest_Primary_OK()
+    {
+        var primaryUriString = "http://example.com";
+        var sb = new StringBuilder();
+        var context = new TestCommandContext();
+        var networkingDiagnostic = new NetworkingDiagnostic(context);
+        var primaryUri = new Uri(primaryUriString);
+        var httpHandler = new TestHttpMessageHandler();
+        var httpResponse = new HttpResponseMessage();
+        var expected = $"Sending HEAD request to {primaryUriString}... OK{Environment.NewLine}";
+
+        httpHandler.Setup(HttpMethod.Head, primaryUri, httpResponse);
+
+        networkingDiagnostic.SendHttpRequest(sb, new HttpClient(httpHandler));
+
+        httpHandler.AssertRequest(HttpMethod.Head, primaryUri, expectedNumberOfCalls: 1);
+        Assert.Contains(expected, sb.ToString());
+    }
+
+    [Fact]
+    public void NetworkingDiagnostic_SendHttpRequest_Backup_OK()
+    {
+        var primaryUriString = "http://example.com";
+        var backupUriString = "http://httpforever.com";
+        var sb = new StringBuilder();
+        var context = new TestCommandContext();
+        var networkingDiagnostic = new NetworkingDiagnostic(context);
+        var primaryUri = new Uri(primaryUriString);
+        var backupUri = new Uri(backupUriString);
+        var httpHandler = new TestHttpMessageHandler { SimulatePrimaryUriFailure = true };
+        var httpResponse = new HttpResponseMessage();
+        var expected = $"Sending HEAD request to {primaryUriString}... warning: HEAD request failed{Environment.NewLine}" +
+                       $"Sending HEAD request to {backupUriString}... OK{Environment.NewLine}";
+
+        httpHandler.Setup(HttpMethod.Head, primaryUri, httpResponse);
+        httpHandler.Setup(HttpMethod.Head, backupUri, httpResponse);
+
+        networkingDiagnostic.SendHttpRequest(sb, new HttpClient(httpHandler));
+
+        httpHandler.AssertRequest(HttpMethod.Head, primaryUri, expectedNumberOfCalls: 1);
+        httpHandler.AssertRequest(HttpMethod.Head, backupUri, expectedNumberOfCalls: 1);
+        Assert.Contains(expected, sb.ToString());
+    }
+
+    [Fact]
+    public void NetworkingDiagnostic_SendHttpRequest_No_Network()
+    {
+        var primaryUriString = "http://example.com";
+        var backupUriString = "http://httpforever.com";
+        var sb = new StringBuilder();
+        var context = new TestCommandContext();
+        var networkingDiagnostic = new NetworkingDiagnostic(context);
+        var primaryUri = new Uri(primaryUriString);
+        var backupUri = new Uri(backupUriString);
+        var httpHandler = new TestHttpMessageHandler { SimulateNoNetwork = true };
+        var httpResponse = new HttpResponseMessage();
+        var expected = $"Sending HEAD request to {primaryUriString}... warning: HEAD request failed{Environment.NewLine}" +
+                       $"Sending HEAD request to {backupUriString}... warning: HEAD request failed{Environment.NewLine}";
+
+        httpHandler.Setup(HttpMethod.Head, primaryUri, httpResponse);
+        httpHandler.Setup(HttpMethod.Head, backupUri, httpResponse);
+
+        networkingDiagnostic.SendHttpRequest(sb, new HttpClient(httpHandler));
+
+        httpHandler.AssertRequest(HttpMethod.Head, primaryUri, expectedNumberOfCalls: 1);
+        httpHandler.AssertRequest(HttpMethod.Head, backupUri, expectedNumberOfCalls: 1);
+        Assert.Contains(expected, sb.ToString());
+    }
+}

--- a/src/shared/TestInfrastructure/Objects/TestHttpMessageHandler.cs
+++ b/src/shared/TestInfrastructure/Objects/TestHttpMessageHandler.cs
@@ -23,6 +23,8 @@ namespace GitCredentialManager.Tests.Objects
         public bool ThrowOnUnexpectedRequest { get; set; }
         public bool SimulateNoNetwork { get; set; }
 
+        public bool SimulatePrimaryUriFailure { get; set; }
+
         public IDictionary<(HttpMethod method, Uri uri), int> RequestCounts => _requestCounts;
 
         public void Setup(HttpMethod method, Uri uri, AsyncRequestHandler handler)
@@ -78,6 +80,12 @@ namespace GitCredentialManager.Tests.Objects
             if (SimulateNoNetwork)
             {
                 throw new HttpRequestException("Simulated no network");
+            }
+
+            if (SimulatePrimaryUriFailure && request.RequestUri != null  &&
+                request.RequestUri.ToString().Equals("http://example.com/"))
+            {
+                throw new HttpRequestException("Simulated http failure.");
             }
 
             foreach (var kvp in _handlers)


### PR DESCRIPTION
Currently, failure to access http://example.com causes failure of the Networking Diagnostic portion of the `diagnose` command. To improve the experience for users who are unable to access http://example.com, this change:

1. Adds a fallback URI - if accessing http://example.com throws an exception, we now try http://httpforever.com.
2. Prints a warning when either the primary or both the primary and fallback uris throw an exception (instead of failing the Networking Diagnostic).

Fixes #1215 