### PR TITLE
docs: update required dotnet-sdk version in install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -205,7 +205,7 @@ the preferred install method for Linux because you can use it to install on any
 distribution][dotnet-supported-distributions]. You
 can also use this method on macOS if you so choose.
 
-**Note:** Make sure you have installed [version 6.0 of the .NET
+**Note:** Make sure you have installed [version 7.0 of the .NET
 SDK][dotnet-install] before attempting to run the following `dotnet tool`
 commands. After installing, you will also need to follow the output instructions
 to add the tools directory to your `PATH`.


### PR DESCRIPTION
Update the version notation because since the release of git-credential-manager version 2.2.1, [the sdk version required for installation is .NET 7](https://www.nuget.org/packages/git-credential-manager/2.2.1).