### PR TITLE
Return only unique accounts from credential stores

### DIFF
--- a/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
+++ b/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
@@ -39,7 +39,7 @@ namespace GitCredentialManager.Interop.Linux
 
         public IList<string> GetAccounts(string service)
         {
-            return Enumerate(service, null).Select(x => x.Account).ToList();
+            return Enumerate(service, null).Select(x => x.Account).Distinct().ToList();
         }
 
         public ICredential Get(string service, string account)

--- a/src/shared/Core/Interop/MacOS/MacOSKeychain.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSKeychain.cs
@@ -66,7 +66,7 @@ namespace GitCredentialManager.Interop.MacOS
                         if (typeId == CFArrayGetTypeID())
                         {
                             int len = (int)CFArrayGetCount(resultPtr);
-                            var accounts = new List<string>(len);
+                            var accounts = new HashSet<string>(len);
                             for (int i = 0; i < len; i++)
                             {
                                 IntPtr dict = CFArrayGetValueAtIndex(resultPtr, i);
@@ -74,7 +74,7 @@ namespace GitCredentialManager.Interop.MacOS
                                 accounts.Add(account);
                             }
 
-                            return accounts;
+                            return accounts.ToList();
                         }
 
                         throw new InteropException($"Unknown keychain search result type CFTypeID: {typeId}.", -1);

--- a/src/shared/Core/Interop/Windows/WindowsCredentialManager.cs
+++ b/src/shared/Core/Interop/Windows/WindowsCredentialManager.cs
@@ -26,7 +26,7 @@ namespace GitCredentialManager.Interop.Windows
 
         public IList<string> GetAccounts(string service)
         {
-            return Enumerate(service, null).Select(x => x.UserName).ToList();
+            return Enumerate(service, null).Select(x => x.UserName).Distinct().ToList();
         }
 
         public ICredential Get(string service, string account)

--- a/src/shared/Core/PlaintextCredentialStore.cs
+++ b/src/shared/Core/PlaintextCredentialStore.cs
@@ -25,7 +25,7 @@ namespace GitCredentialManager
 
         public IList<string> GetAccounts(string service)
         {
-            return Enumerate(service, null).Select(x => x.Account).ToList();
+            return Enumerate(service, null).Select(x => x.Account).Distinct().ToList();
         }
 
         public ICredential Get(string service, string account)

--- a/src/shared/TestInfrastructure/Objects/TestCredentialStore.cs
+++ b/src/shared/TestInfrastructure/Objects/TestCredentialStore.cs
@@ -16,7 +16,7 @@ namespace GitCredentialManager.Tests.Objects
 
         public IList<string> GetAccounts(string service)
         {
-            return Query(service, null).Select(x => x.Account).ToList();
+            return Query(service, null).Select(x => x.Account).Distinct().ToList();
         }
 
         ICredential ICredentialStore.Get(string service, string account)


### PR DESCRIPTION
If may be possible for multiple credentials for the same user account to exist in any credential store. To avoid issues with redundant account selection prompts we should ensure duplicate accounts are removed from the results of `ICredentialStore.GetAccounts`.

Call `.Distinct()` or use a `HashSet` where appropriate on all implementation of `ICredentialStore.GetAccounts`.

If there are multiple credentials for the same account, we'd only ever be able to retrieve the first enumerated credential regardless because our matching logic is to return to first credential that matches.

Fixes #1368