### PR TITLE
Support managed identities and service principals

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -793,6 +793,95 @@ git config --global credential.azreposCredentialType oauth
 
 ---
 
+### credential.azreposManagedIdentity
+
+Use a [Managed Identity][managed-identity] to authenticate with Azure Repos.
+
+The value `system` will tell GCM to use the system-assigned Managed Identity.
+
+To specify a user-assigned Managed Identity, use the format `id://{clientId}`
+where `{clientId}` is the client ID of the Managed Identity. Alternatively any
+GUID-like value will also be interpreted as a user-assigned Managed Identity
+client ID.
+
+To specify a Managed Identity associated with an Azure resource, you can use the
+format `resource://{resourceId}` where `{resourceId}` is the ID of the resource.
+
+For more information about managed identities, see the Azure DevOps
+[documentation][azrepos-sp-mid].
+
+Value|Description
+-|-
+`system`|System-Assigned Managed Identity
+`[guid]`|User-Assigned Managed Identity with the specified client ID
+`id://[guid]`|User-Assigned Managed Identity with the specified client ID
+`resource://[guid]`|User-Assigned Managed Identity for the associated resource
+
+```shell
+git config --global credential.azreposManagedIdentity "id://11111111-1111-1111-1111-111111111111"
+```
+
+**Also see: [GCM_AZREPOS_MANAGEDIDENTITY][gcm-azrepos-credentialmanagedidentity]**
+
+---
+
+### credential.azreposServicePrincipal
+
+Specify the client and tenant IDs of a [service principal][service-principal]
+to use when performing Microsoft authentication for Azure Repos.
+
+The value of this setting should be in the format: `{tenantId}/{clientId}`.
+
+You must also set at least one authentication mechanism if you set this value:
+
+- [credential.azreposServicePrincipalSecret][credential-azrepos-sp-secret]
+- [credential.azreposServicePrincipalCertificateThumbprint][credential-azrepos-sp-cert-thumbprint]
+
+For more information about service principals, see the Azure DevOps
+[documentation][azrepos-sp-mid].
+
+#### Example
+
+```shell
+git config --global credential.azreposServicePrincipal "11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222"
+```
+
+**Also see: [GCM_AZREPOS_SERVICE_PRINCIPAL][gcm-azrepos-service-principal]**
+
+---
+
+### credential.azreposServicePrincipalSecret
+
+Specifies the client secret for the [service principal][service-principal] when
+performing Microsoft authentication for Azure Repos with
+[credential.azreposServicePrincipalSecret][credential-azrepos-sp] set.
+
+#### Example
+
+```shell
+git config --global credential.azreposServicePrincipalSecret "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+```
+
+**Also see: [GCM_AZREPOS_SP_SECRET][gcm-azrepos-sp-secret]**
+
+---
+
+### credential.azreposServicePrincipalCertificateThumbprint
+
+Specifies the thumbprint of a certificate to use when authenticating as a
+[service principal][service-principal] for Azure Repos when
+[GCM_AZREPOS_SERVICE_PRINCIPAL][credential-azrepos-sp] is set.
+
+#### Example
+
+```shell
+git config --global credential.azreposServicePrincipalCertificateThumbprint "9b6555292e4ea21cbc2ebd23e66e2f91ebbe92dc"
+```
+
+**Also see: [GCM_AZREPOS_SP_CERT_THUMBPRINT][gcm-azrepos-sp-cert-thumbprint]**
+
+---
+
 ### trace2.normalTarget
 
 Turns on Trace2 Normal Format tracing - see [Git's Trace2 Normal Format
@@ -878,6 +967,7 @@ Defaults to disabled.
 [gcm-authority]: environment.md#GCM_AUTHORITY-deprecated
 [gcm-autodetect-timeout]: environment.md#GCM_AUTODETECT_TIMEOUT
 [gcm-azrepos-credentialtype]: environment.md#GCM_AZREPOS_CREDENTIALTYPE
+[gcm-azrepos-credentialmanagedidentity]: environment.md#GCM_AZREPOS_MANAGEDIDENTITY
 [gcm-bitbucket-always-refresh-credentials]: environment.md#GCM_BITBUCKET_ALWAYS_REFRESH_CREDENTIALS
 [gcm-bitbucket-authmodes]: environment.md#GCM_BITBUCKET_AUTHMODES
 [gcm-credential-cache-options]: environment.md#GCM_CREDENTIAL_CACHE_OPTIONS
@@ -905,6 +995,7 @@ Defaults to disabled.
 [http-proxy]: netconfig.md#http-proxy
 [autodetect]: autodetect.md
 [libsecret]: https://wiki.gnome.org/Projects/Libsecret
+[managed-identity]: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
 [provider-migrate]: migration.md#gcm_authority
 [cache-options]: https://git-scm.com/docs/git-credential-cache#_options
 [pass]: https://www.passwordstore.org/
@@ -915,3 +1006,11 @@ Defaults to disabled.
 [trace2-performance-docs]: https://git-scm.com/docs/api-trace2#_the_performance_format_target
 [trace2-performance-env]: environment.md#GIT_TRACE2_PERF
 [wam]: windows-broker.md
+[service-principal]: https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals
+[azrepos-sp-mid]: https://learn.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/service-principal-managed-identity
+[credential-azrepos-sp]: #credentialazreposserviceprincipal
+[credential-azrepos-sp-secret]: #credentialazreposserviceprincipalsecret
+[credential-azrepos-sp-cert-thumbprint]: #credentialazreposserviceprincipalcertificatethumbprint
+[gcm-azrepos-service-principal]: environment.md#GCM_AZREPOS_SERVICE_PRINCIPAL
+[gcm-azrepos-sp-secret]: environment.md#GCM_AZREPOS_SP_SECRET
+[gcm-azrepos-sp-cert-thumbprint]: environment.md#GCM_AZREPOS_SP_CERT_THUMBPRINT

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -894,6 +894,121 @@ export GCM_AZREPOS_CREDENTIALTYPE="oauth"
 
 ---
 
+### GCM_AZREPOS_MANAGEDIDENTITY
+
+Use a [Managed Identity][managed-identity] to authenticate with Azure Repos.
+
+The value `system` will tell GCM to use the system-assigned Managed Identity.
+
+To specify a user-assigned Managed Identity, use the format `id://{clientId}`
+where `{clientId}` is the client ID of the Managed Identity. Alternatively any
+GUID-like value will also be interpreted as a user-assigned Managed Identity
+client ID.
+
+To specify a Managed Identity associated with an Azure resource, you can use the
+format `resource://{resourceId}` where `{resourceId}` is the ID of the resource.
+
+For more information about managed identities, see the Azure DevOps
+[documentation][azrepos-sp-mid].
+
+Value|Description
+-|-
+`system`|System-Assigned Managed Identity
+`[guid]`|User-Assigned Managed Identity with the specified client ID
+`id://[guid]`|User-Assigned Managed Identity with the specified client ID
+`resource://[guid]`|User-Assigned Managed Identity for the associated resource
+
+#### Windows
+
+```batch
+SET GCM_AZREPOS_MANAGEDIDENTITY="id://11111111-1111-1111-1111-111111111111"
+```
+
+#### macOS/Linux
+
+```bash
+export GCM_AZREPOS_MANAGEDIDENTITY="id://11111111-1111-1111-1111-111111111111"
+```
+
+**Also see: [credential.azreposManagedIdentity][credential-azrepos-managedidentity]**
+
+---
+
+### GCM_AZREPOS_SERVICE_PRINCIPAL
+
+Specify the client and tenant IDs of a [service principal][service-principal]
+to use when performing Microsoft authentication for Azure Repos.
+
+The value of this setting should be in the format: `{tenantId}/{clientId}`.
+
+You must also set at least one authentication mechanism if you set this value:
+
+- [GCM_AZREPOS_SP_SECRET][gcm-azrepos-sp-secret]
+- [GCM_AZREPOS_SP_CERT_THUMBPRINT][gcm-azrepos-sp-cert-thumbprint]
+
+For more information about service principals, see the Azure DevOps
+[documentation][azrepos-sp-mid].
+
+#### Windows
+
+```batch
+SET GCM_AZREPOS_SERVICE_PRINCIPAL="11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222"
+```
+
+#### macOS/Linux
+
+```bash
+export GCM_AZREPOS_SERVICE_PRINCIPAL="11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222"
+```
+
+**Also see: [credential.azreposServicePrincipal][credential-azrepos-sp]**
+
+---
+
+### GCM_AZREPOS_SP_SECRET
+
+Specifies the client secret for the [service principal][service-principal] when
+performing Microsoft authentication for Azure Repos with
+[GCM_AZREPOS_SERVICE_PRINCIPAL][gcm-azrepos-sp] set.
+
+#### Windows
+
+```batch
+SET GCM_AZREPOS_SP_SECRET="da39a3ee5e6b4b0d3255bfef95601890afd80709"
+```
+
+#### macOS/Linux
+
+```bash
+export GCM_AZREPOS_SP_SECRET="da39a3ee5e6b4b0d3255bfef95601890afd80709"
+```
+
+**Also see: [credential.azreposServicePrincipalSecret][credential-azrepos-sp-secret]**
+
+---
+
+### GCM_AZREPOS_SP_CERT_THUMBPRINT
+
+Specifies the thumbprint of a certificate to use when authenticating as a
+[service principal][service-principal] for Azure Repos when
+[GCM_AZREPOS_SERVICE_PRINCIPAL][gcm-azrepos-sp] is set.
+
+#### Windows
+
+```batch
+SET GCM_AZREPOS_SP_CERT_THUMBPRINT="9b6555292e4ea21cbc2ebd23e66e2f91ebbe92dc"
+```
+
+#### macOS/Linux
+
+```bash
+export GCM_AZREPOS_SP_CERT_THUMBPRINT="9b6555292e4ea21cbc2ebd23e66e2f91ebbe92dc"
+```
+
+**Also see: [credential.azreposServicePrincipalCertificateThumbprint][credential-azrepos-sp-cert-thumbprint]**
+
+---
+
 ### GIT_TRACE2
 
 Turns on Trace2 Normal Format tracing - see [Git's Trace2 Normal Format
@@ -985,7 +1100,8 @@ Defaults to disabled.
 [credential-allowwindowsauth]: environment.md#credentialallowWindowsAuth
 [credential-authority]: configuration.md#credentialauthority-deprecated
 [credential-autodetecttimeout]: configuration.md#credentialautodetecttimeout
-[credential-azrepos-credential-type]: configuration.md#azreposcredentialtype
+[credential-azrepos-credential-type]: configuration.md#credentialazreposcredentialtype
+[credential-azrepos-managedidentity]: configuration.md#credentialazreposmanagedidentity
 [credential-bitbucketauthmodes]: configuration.md#credentialbitbucketAuthModes
 [credential-cacheoptions]: configuration.md#credentialcacheoptions
 [credential-credentialstore]: configuration.md#credentialcredentialstore
@@ -1022,6 +1138,7 @@ Defaults to disabled.
 [github-emu]: https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users
 [network-http-proxy]: netconfig.md#http-proxy
 [libsecret]: https://wiki.gnome.org/Projects/Libsecret
+[managed-identity]: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
 [migration-guide]: migration.md#gcm_authority
 [passwordstore]: https://www.passwordstore.org/
 [trace2-normal-docs]: https://git-scm.com/docs/api-trace2#_the_normal_format_target
@@ -1031,3 +1148,11 @@ Defaults to disabled.
 [trace2-performance-docs]: https://git-scm.com/docs/api-trace2#_the_performance_format_target
 [trace2-performance-config]: configuration.md#trace2perfTarget
 [windows-broker]: windows-broker.md
+[service-principal]: https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals
+[azrepos-sp-mid]: https://learn.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/service-principal-managed-identity
+[gcm-azrepos-sp]: #gcm_azrepos_service_principal
+[gcm-azrepos-sp-secret]: #gcm_azrepos_sp_secret
+[gcm-azrepos-sp-cert-thumbprint]: #gcm_azrepos_sp_cert_thumbprint
+[credential-azrepos-sp]: configuration.md#credentialazreposserviceprincipal
+[credential-azrepos-sp-secret]: configuration.md#credentialazreposserviceprincipalsecret
+[credential-azrepos-sp-cert-thumbprint]: configuration.md#credentialazreposserviceprincipalcertificatethumbprint

--- a/src/shared/Core.Tests/Authentication/MicrosoftAuthenticationTests.cs
+++ b/src/shared/Core.Tests/Authentication/MicrosoftAuthenticationTests.cs
@@ -8,7 +8,7 @@ namespace GitCredentialManager.Tests.Authentication
     public class MicrosoftAuthenticationTests
     {
         [Fact]
-        public async System.Threading.Tasks.Task MicrosoftAuthentication_GetAccessTokenAsync_NoInteraction_ThrowsException()
+        public async System.Threading.Tasks.Task MicrosoftAuthentication_GetTokenForUserAsync_NoInteraction_ThrowsException()
         {
             const string authority = "https://login.microsoftonline.com/common";
             const string clientId = "C9E8FDA6-1D46-484C-917C-3DBD518F27C3";
@@ -24,7 +24,7 @@ namespace GitCredentialManager.Tests.Authentication
             var msAuth = new MicrosoftAuthentication(context);
 
             await Assert.ThrowsAsync<Trace2InvalidOperationException>(
-                () => msAuth.GetTokenAsync(authority, clientId, redirectUri, scopes, userName, false));
+                () => msAuth.GetTokenForUserAsync(authority, clientId, redirectUri, scopes, userName, false));
         }
     }
 }

--- a/src/shared/Core.Tests/Authentication/MicrosoftAuthenticationTests.cs
+++ b/src/shared/Core.Tests/Authentication/MicrosoftAuthenticationTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Threading.Tasks;
 using GitCredentialManager.Authentication;
 using GitCredentialManager.Tests.Objects;
+using Microsoft.Identity.Client.AppConfig;
 using Xunit;
 
 namespace GitCredentialManager.Tests.Authentication
@@ -8,7 +10,7 @@ namespace GitCredentialManager.Tests.Authentication
     public class MicrosoftAuthenticationTests
     {
         [Fact]
-        public async System.Threading.Tasks.Task MicrosoftAuthentication_GetTokenForUserAsync_NoInteraction_ThrowsException()
+        public async Task MicrosoftAuthentication_GetTokenForUserAsync_NoInteraction_ThrowsException()
         {
             const string authority = "https://login.microsoftonline.com/common";
             const string clientId = "C9E8FDA6-1D46-484C-917C-3DBD518F27C3";
@@ -25,6 +27,47 @@ namespace GitCredentialManager.Tests.Authentication
 
             await Assert.ThrowsAsync<Trace2InvalidOperationException>(
                 () => msAuth.GetTokenForUserAsync(authority, clientId, redirectUri, scopes, userName, false));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("system")]
+        [InlineData("SYSTEM")]
+        [InlineData("sYsTeM")]
+        [InlineData("00000000-0000-0000-0000-000000000000")]
+        [InlineData("id://00000000-0000-0000-0000-000000000000")]
+        [InlineData("ID://00000000-0000-0000-0000-000000000000")]
+        [InlineData("Id://00000000-0000-0000-0000-000000000000")]
+        public void MicrosoftAuthentication_GetManagedIdentity_ValidSystemId_ReturnsSystemId(string str)
+        {
+            ManagedIdentityId actual = MicrosoftAuthentication.GetManagedIdentity(str);
+            Assert.Equal(ManagedIdentityId.SystemAssigned, actual);
+        }
+
+        [Theory]
+        [InlineData("8B49DCA0-1298-4A0D-AD6D-934E40230839")]
+        [InlineData("id://8B49DCA0-1298-4A0D-AD6D-934E40230839")]
+        [InlineData("ID://8B49DCA0-1298-4A0D-AD6D-934E40230839")]
+        [InlineData("Id://8B49DCA0-1298-4A0D-AD6D-934E40230839")]
+        [InlineData("resource://8B49DCA0-1298-4A0D-AD6D-934E40230839")]
+        [InlineData("RESOURCE://8B49DCA0-1298-4A0D-AD6D-934E40230839")]
+        [InlineData("rEsOuRcE://8B49DCA0-1298-4A0D-AD6D-934E40230839")]
+        [InlineData("resource://00000000-0000-0000-0000-000000000000")]
+        public void MicrosoftAuthentication_GetManagedIdentity_ValidUserIdByClientId_ReturnsUserId(string str)
+        {
+            ManagedIdentityId actual = MicrosoftAuthentication.GetManagedIdentity(str);
+            Assert.NotNull(actual);
+            Assert.NotEqual(ManagedIdentityId.SystemAssigned, actual);
+        }
+
+        [Theory]
+        [InlineData("unknown://8B49DCA0-1298-4A0D-AD6D-934E40230839")]
+        [InlineData("this is a string")]
+        public void MicrosoftAuthentication_GetManagedIdentity_Invalid_ThrowsArgumentException(string str)
+        {
+            Assert.Throws<ArgumentException>(() => MicrosoftAuthentication.GetManagedIdentity(str));
         }
     }
 }

--- a/src/shared/Core/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Core/Authentication/MicrosoftAuthentication.cs
@@ -23,7 +23,17 @@ namespace GitCredentialManager.Authentication
 {
     public interface IMicrosoftAuthentication
     {
-        Task<IMicrosoftAuthenticationResult> GetTokenAsync(string authority, string clientId, Uri redirectUri,
+        /// <summary>
+        /// Acquire an access token for a user principal.
+        /// </summary>
+        /// <param name="authority">Azure authority.</param>
+        /// <param name="clientId">Client ID.</param>
+        /// <param name="redirectUri">Redirect URI for the client.</param>
+        /// <param name="scopes">Set of scopes to request.</param>
+        /// <param name="userName">Optional user name for an existing account.</param>
+        /// <param name="msaPt">Use MSA-Passthrough behavior when authenticating.</param>
+        /// <returns>Authentication result.</returns>
+        Task<IMicrosoftAuthenticationResult> GetTokenForUserAsync(string authority, string clientId, Uri redirectUri,
             string[] scopes, string userName, bool msaPt = false);
     }
 
@@ -59,7 +69,7 @@ namespace GitCredentialManager.Authentication
 
         #region IMicrosoftAuthentication
 
-        public async Task<IMicrosoftAuthenticationResult> GetTokenAsync(
+        public async Task<IMicrosoftAuthenticationResult> GetTokenForUserAsync(
             string authority, string clientId, Uri redirectUri, string[] scopes, string userName, bool msaPt)
         {
             // Check if we can and should use OS broker authentication

--- a/src/shared/Core/Diagnostics/MicrosoftAuthenticationDiagnostic.cs
+++ b/src/shared/Core/Diagnostics/MicrosoftAuthenticationDiagnostic.cs
@@ -20,7 +20,7 @@ namespace GitCredentialManager.Diagnostics
             log.AppendLine($"Flow type is: {msAuth.GetFlowType()}");
 
             log.Append("Gathering MSAL token cache data...");
-            StorageCreationProperties cacheProps = msAuth.CreateTokenCacheProps(true);
+            StorageCreationProperties cacheProps = msAuth.CreateUserTokenCacheProps(true);
             log.AppendLine(" OK");
             log.AppendLine($"CacheDirectory: {cacheProps.CacheDirectory}");
             log.AppendLine($"CacheFileName: {cacheProps.CacheFileName}");

--- a/src/shared/Core/X509Utils.cs
+++ b/src/shared/Core/X509Utils.cs
@@ -1,0 +1,23 @@
+using System.Security.Cryptography.X509Certificates;
+
+namespace GitCredentialManager;
+
+public static class X509Utils
+{
+    public static X509Certificate2 GetCertificateByThumbprint(string thumbprint)
+    {
+        foreach (var location in new[]{StoreLocation.CurrentUser, StoreLocation.LocalMachine})
+        {
+            using var store = new X509Store(StoreName.My, location);
+            store.Open(OpenFlags.ReadOnly);
+
+            X509Certificate2Collection certs = store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, false);
+            if (certs.Count > 0)
+            {
+                return certs[0];
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
+++ b/src/shared/Microsoft.AzureRepos.Tests/AzureReposHostProviderTests.cs
@@ -170,7 +170,7 @@ namespace Microsoft.AzureRepos.Tests
             azDevOpsMock.Setup(x => x.GetAuthorityAsync(expectedOrgUri)).ReturnsAsync(authorityUrl);
 
             var msAuthMock = new Mock<IMicrosoftAuthentication>(MockBehavior.Strict);
-            msAuthMock.Setup(x => x.GetTokenAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, urlAccount, true))
+            msAuthMock.Setup(x => x.GetTokenForUserAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, urlAccount, true))
                       .ReturnsAsync(authResult);
 
             var authorityCacheMock = new Mock<IAzureDevOpsAuthorityCache>(MockBehavior.Strict);
@@ -219,7 +219,7 @@ namespace Microsoft.AzureRepos.Tests
             azDevOpsMock.Setup(x => x.GetAuthorityAsync(expectedOrgUri)).ReturnsAsync(authorityUrl);
 
             var msAuthMock = new Mock<IMicrosoftAuthentication>(MockBehavior.Strict);
-            msAuthMock.Setup(x => x.GetTokenAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, urlAccount, true))
+            msAuthMock.Setup(x => x.GetTokenForUserAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, urlAccount, true))
                       .ReturnsAsync(authResult);
 
             var authorityCacheMock = new Mock<IAzureDevOpsAuthorityCache>(MockBehavior.Strict);
@@ -268,7 +268,7 @@ namespace Microsoft.AzureRepos.Tests
             azDevOpsMock.Setup(x => x.GetAuthorityAsync(expectedOrgUri)).ReturnsAsync(authorityUrl);
 
             var msAuthMock = new Mock<IMicrosoftAuthentication>(MockBehavior.Strict);
-            msAuthMock.Setup(x => x.GetTokenAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, null, true))
+            msAuthMock.Setup(x => x.GetTokenForUserAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, null, true))
                       .ReturnsAsync(authResult);
 
             var authorityCacheMock = new Mock<IAzureDevOpsAuthorityCache>(MockBehavior.Strict);
@@ -315,7 +315,7 @@ namespace Microsoft.AzureRepos.Tests
             var azDevOpsMock = new Mock<IAzureDevOpsRestApi>(MockBehavior.Strict);
 
             var msAuthMock = new Mock<IMicrosoftAuthentication>(MockBehavior.Strict);
-            msAuthMock.Setup(x => x.GetTokenAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, null, true))
+            msAuthMock.Setup(x => x.GetTokenForUserAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, null, true))
                       .ReturnsAsync(authResult);
 
             var authorityCacheMock = new Mock<IAzureDevOpsAuthorityCache>(MockBehavior.Strict);
@@ -363,7 +363,7 @@ namespace Microsoft.AzureRepos.Tests
             var azDevOpsMock = new Mock<IAzureDevOpsRestApi>(MockBehavior.Strict);
 
             var msAuthMock = new Mock<IMicrosoftAuthentication>(MockBehavior.Strict);
-            msAuthMock.Setup(x => x.GetTokenAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, account, true))
+            msAuthMock.Setup(x => x.GetTokenForUserAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, account, true))
                       .ReturnsAsync(authResult);
 
             var authorityCacheMock = new Mock<IAzureDevOpsAuthorityCache>(MockBehavior.Strict);
@@ -413,7 +413,7 @@ namespace Microsoft.AzureRepos.Tests
             azDevOpsMock.Setup(x => x.GetAuthorityAsync(expectedOrgUri)).ReturnsAsync(authorityUrl);
 
             var msAuthMock = new Mock<IMicrosoftAuthentication>(MockBehavior.Strict);
-            msAuthMock.Setup(x => x.GetTokenAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, null, true))
+            msAuthMock.Setup(x => x.GetTokenForUserAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, null, true))
                       .ReturnsAsync(authResult);
 
             var authorityCacheMock = new Mock<IAzureDevOpsAuthorityCache>(MockBehavior.Strict);
@@ -462,7 +462,7 @@ namespace Microsoft.AzureRepos.Tests
                         .ReturnsAsync(personalAccessToken);
 
             var msAuthMock = new Mock<IMicrosoftAuthentication>(MockBehavior.Strict);
-            msAuthMock.Setup(x => x.GetTokenAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, null, true))
+            msAuthMock.Setup(x => x.GetTokenForUserAsync(authorityUrl, expectedClientId, expectedRedirectUri, expectedScopes, null, true))
                       .ReturnsAsync(authResult);
 
             var authorityCacheMock = new Mock<IAzureDevOpsAuthorityCache>(MockBehavior.Strict);

--- a/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
@@ -8,7 +8,8 @@ namespace Microsoft.AzureRepos
         public const string AadAuthorityBaseUrl = "https://login.microsoftonline.com";
 
         // Azure DevOps's app ID + default scopes
-        public static readonly string[] AzureDevOpsDefaultScopes = {"499b84ac-1321-427f-aa17-267ca6975798/.default"};
+        public const string AzureDevOpsResourceId = "499b84ac-1321-427f-aa17-267ca6975798";
+        public static readonly string[] AzureDevOpsDefaultScopes = {$"{AzureDevOpsResourceId}/.default"};
 
         // Visual Studio's client ID
         // We share this to be able to consume existing access tokens from the VS caches
@@ -40,6 +41,10 @@ namespace Microsoft.AzureRepos
             public const string DevAadRedirectUri = "GCM_DEV_AZREPOS_REDIRECTURI";
             public const string DevAadAuthorityBaseUri = "GCM_DEV_AZREPOS_AUTHORITYBASEURI";
             public const string CredentialType = "GCM_AZREPOS_CREDENTIALTYPE";
+            public const string ServicePrincipalId = "GCM_AZREPOS_SERVICE_PRINCIPAL";
+            public const string ServicePrincipalSecret = "GCM_AZREPOS_SP_SECRET";
+            public const string ServicePrincipalCertificateThumbprint = "GCM_AZREPOS_SP_CERT_THUMBPRINT";
+            public const string ManagedIdentity = "GCM_AZREPOS_MANAGEDIDENTITY";
         }
 
         public static class GitConfiguration
@@ -51,6 +56,10 @@ namespace Microsoft.AzureRepos
                 public const string DevAadAuthorityBaseUri = "azreposDevAuthorityBaseUri";
                 public const string CredentialType = "azreposCredentialType";
                 public const string AzureAuthority = "azureAuthority";
+                public const string ServicePrincipal = "azreposServicePrincipal";
+                public const string ServicePrincipalSecret = "azreposServicePrincipalSecret";
+                public const string ServicePrincipalCertificateThumbprint = "azreposServicePrincipalCertificateThumbprint";
+                public const string ManagedIdentity = "azreposManagedIdentity";
             }
         }
     }

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -197,7 +197,7 @@ namespace Microsoft.AzureRepos
 
             // Get an AAD access token for the Azure DevOps SPS
             _context.Trace.WriteLine("Getting Azure AD access token...");
-            IMicrosoftAuthenticationResult result = await _msAuth.GetTokenAsync(
+            IMicrosoftAuthenticationResult result = await _msAuth.GetTokenForUserAsync(
                 authAuthority,
                 GetClientId(),
                 GetRedirectUri(),
@@ -289,7 +289,7 @@ namespace Microsoft.AzureRepos
 
             // Get an AAD access token for the Azure DevOps SPS
             _context.Trace.WriteLine("Getting Azure AD access token...");
-            IMicrosoftAuthenticationResult result = await _msAuth.GetTokenAsync(
+            IMicrosoftAuthenticationResult result = await _msAuth.GetTokenForUserAsync(
                 authAuthority,
                 GetClientId(),
                 GetRedirectUri(),

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.CommandLine;
 using System.Linq;
 using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using GitCredentialManager;
@@ -75,6 +76,20 @@ namespace Microsoft.AzureRepos
 
         public async Task<ICredential> GetCredentialAsync(InputArguments input)
         {
+            if (UseManagedIdentity(out string mid))
+            {
+                _context.Trace.WriteLine($"Getting Azure Access Token for managed identity {mid}...");
+                var azureResult = await _msAuth.GetTokenForManagedIdentityAsync(mid, AzureDevOpsConstants.AzureDevOpsResourceId);
+                return new GitCredential(mid, azureResult.AccessToken);
+            }
+
+            if (UseServicePrincipal(out ServicePrincipalIdentity sp))
+            {
+                _context.Trace.WriteLine($"Getting Azure Access Token for service principal {sp.TenantId}/{sp.Id}...");
+                var azureResult = await _msAuth.GetTokenForServicePrincipalAsync(sp, AzureDevOpsConstants.AzureDevOpsDefaultScopes);
+                return new GitCredential(sp.Id, azureResult.AccessToken);
+            }
+
             if (UsePersonalAccessTokens())
             {
                 Uri remoteUri = input.GetRemoteUri();
@@ -113,7 +128,15 @@ namespace Microsoft.AzureRepos
         {
             Uri remoteUri = input.GetRemoteUri();
 
-            if (UsePersonalAccessTokens())
+            if (UseManagedIdentity(out _))
+            {
+                _context.Trace.WriteLine("Nothing to store for managed identity authentication.");
+            }
+            else if (UseServicePrincipal(out _))
+            {
+                _context.Trace.WriteLine("Nothing to store for service principal authentication.");
+            }
+            else if (UsePersonalAccessTokens())
             {
                 string service = GetServiceName(remoteUri);
 
@@ -140,13 +163,22 @@ namespace Microsoft.AzureRepos
         {
             Uri remoteUri = input.GetRemoteUri();
 
-            if (UsePersonalAccessTokens())
+            if (UseManagedIdentity(out _))
+            {
+                _context.Trace.WriteLine("Nothing to erase for managed identity authentication.");
+            }
+            else if (UseServicePrincipal(out _))
+            {
+                _context.Trace.WriteLine("Nothing to erase for service principal authentication.");
+            }
+            else if (UsePersonalAccessTokens())
             {
                 string service = GetServiceName(remoteUri);
                 string account = GetAccountNameForCredentialQuery(input);
 
                 // Try to locate an existing credential
-                _context.Trace.WriteLine($"Erasing stored credential in store with service={service} account={account}...");
+                _context.Trace.WriteLine(
+                    $"Erasing stored credential in store with service={service} account={account}...");
                 if (_context.CredentialStore.Remove(service, account))
                 {
                     _context.Trace.WriteLine("Credential was successfully erased.");
@@ -459,6 +491,89 @@ namespace Microsoft.AzureRepos
             }
 
             return defaultValue;
+        }
+
+        private bool UseServicePrincipal(out ServicePrincipalIdentity sp)
+        {
+            if (!_context.Settings.TryGetSetting(
+                    AzureDevOpsConstants.EnvironmentVariables.ServicePrincipalId,
+                    Constants.GitConfiguration.Credential.SectionName,
+                    AzureDevOpsConstants.GitConfiguration.Credential.ServicePrincipal,
+                    out string spStr) || string.IsNullOrWhiteSpace(spStr))
+            {
+                sp = null;
+                return false;
+            }
+
+            string[] split = spStr.Split(new[] { '/' }, count: 2);
+
+            if (split.Length < 1 || string.IsNullOrWhiteSpace(split[0]))
+            {
+                _context.Streams.Error.WriteLine("error: unable to use configured service principal - missing tenant ID in configuration");
+                sp = null;
+                return false;
+            }
+
+            if (split.Length < 2 || string.IsNullOrWhiteSpace(split[1]))
+            {
+                _context.Streams.Error.WriteLine("error: unable to use configured service principal - missing client ID in configuration");
+                sp = null;
+                return false;
+            }
+
+            string tenantId = split[0];
+            string clientId = split[1];
+
+            sp = new ServicePrincipalIdentity
+            {
+                Id = clientId,
+                TenantId = tenantId,
+            };
+
+            bool hasClientSecret = _context.Settings.TryGetSetting(
+                AzureDevOpsConstants.EnvironmentVariables.ServicePrincipalSecret,
+                Constants.GitConfiguration.Credential.SectionName,
+                AzureDevOpsConstants.GitConfiguration.Credential.ServicePrincipalSecret,
+                out string clientSecret);
+
+            bool hasCertThumbprint = _context.Settings.TryGetSetting(
+                AzureDevOpsConstants.EnvironmentVariables.ServicePrincipalCertificateThumbprint,
+                Constants.GitConfiguration.Credential.SectionName,
+                AzureDevOpsConstants.GitConfiguration.Credential.ServicePrincipalCertificateThumbprint,
+                out string certThumbprint);
+
+            if (hasCertThumbprint && hasClientSecret)
+            {
+                _context.Streams.Error.WriteLine("warning: both service principal client secret and certificate thumbprint are configured - using certificate");
+            }
+
+            if (hasCertThumbprint)
+            {
+                X509Certificate2 cert = X509Utils.GetCertificateByThumbprint(certThumbprint);
+                if (cert is null)
+                {
+                    _context.Streams.Error.WriteLine($"error: unable to find certificate with thumbprint '{certThumbprint}' for service principal");
+                    return false;
+                }
+
+                sp.Certificate = cert;
+            }
+            else if (hasClientSecret)
+            {
+                sp.ClientSecret = clientSecret;
+            }
+
+            return true;
+        }
+
+        private bool UseManagedIdentity(out string mid)
+        {
+            return _context.Settings.TryGetSetting(
+                       AzureDevOpsConstants.EnvironmentVariables.ManagedIdentity,
+                       KnownGitCfg.Credential.SectionName,
+                       AzureDevOpsConstants.GitConfiguration.Credential.ManagedIdentity,
+                       out mid) &&
+                   !string.IsNullOrWhiteSpace(mid);
         }
 
         #endregion


### PR DESCRIPTION
Add support for both managed identities and service principals for Azure Repos authentication.

Service principals are the "service account" equivalent to normal "users" (user principals). Rather than a password+MFA, service principals (SP) authenticate either with a 'secret' or a certificate - we support both.

Managed identities (MI) are an evolution of service principals whereby the secret/certificate are hidden and managed by Azure. There are two types of managed identities: system-assigned and user-assigned. System-assigned are tied to a particular VM or resource, whereas user-assigned can be shared between VMs/resources.

Azure DevOps recently learned to support SPs and MIs as identities that can be members of orgs and projects. Note that this only applies to AAD-connected Azure DevOps orgs.

This functionality is most compelling for automated scenarios, like CI machines, that need access to Azure Repos.

Fixes #1313