### PR TITLE
release: update Homebrew tap

### DIFF
--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -9,12 +9,13 @@ jobs:
     environment: release
     steps:
     - name: Update Homebrew tap
-      uses: mjcheetham/update-homebrew@v1.3
+      uses: mjcheetham/update-homebrew@v1.4
       with:
         token: ${{ secrets.HOMEBREW_TOKEN }}
-        tap: microsoft/git
-        name: git-credential-manager-core
+        tap: Homebrew/homebrew-cask
+        name: git-credential-manager
         type: cask
+        alwaysUsePullRequest: true
         releaseAsset: |
           gcm-osx-x64-(.*)\.pkg
           gcm-osx-arm64-(.*)\.pkg

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,14 +14,13 @@ you have installed this using Homebrew, this installation will be unlinked
 #### Install
 
 ```shell
-brew tap microsoft/git
-brew install --cask git-credential-manager-core
+brew install --cask git-credential-manager
 ```
 
 After installing you can stay up-to-date with new releases by running:
 
 ```shell
-brew upgrade git-credential-manager-core
+brew upgrade --cask git-credential-manager
 ```
 
 #### Uninstall
@@ -29,7 +28,7 @@ brew upgrade git-credential-manager-core
 To uninstall, run the following:
 
 ```shell
-brew uninstall --cask git-credential-manager-core
+brew uninstall --cask git-credential-manager
 ```
 
 ---


### PR DESCRIPTION
GCM has migrated from the `microsoft/homebrew-git` tap to the `Homebrew/homebrew-cask` tap. This change contains two related updates:

1. The `release-homebrew` workflow now publishes to `Homebrew/homebrew-cask`.
2. The docs now instruct users to install from the new tap.

The workflow updates were [tested in my fork](https://github.com/ldennington/homebrew-cask/pull/5/files). There is also a [corresponding PR in `microsoft/homebrew-git`](https://github.com/microsoft/homebrew-git/pull/73) that will ensure users currently set up to upgrade from the `microsoft/homebrew-git` tap will be automatically re-directed to `Homebrew/homebrew-cask`.