### PR TITLE
Trace2FileWriter: add more general exception

### DIFF
--- a/src/shared/Core/Trace2FileWriter.cs
+++ b/src/shared/Core/Trace2FileWriter.cs
@@ -31,5 +31,10 @@ public class Trace2FileWriter : Trace2Writer
             // Windows and the file is currently open for writing
             // by another process (likely Git itself.)
         }
+        catch (IOException)
+        {
+            // Do nothing, as this likely means that the file is currently
+            // open by another process (on Windows).
+        }
     }
 }


### PR DESCRIPTION
In #1340, we tried to suppress errors during the modification of a trace2 file. However, those exceptions were too specific to the errors I had discovered during local testing.

On the 2.3.1 release, I see the following stack error happening:

```
Unhandled Exception: System.IO.IOException: The process cannot access the file 'C:\Users\dstolee\Downloads\trace.txt' because it is being used by another process.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.StreamWriter.CreateFile(String path, Boolean append, Boolean checkHost)
   at System.IO.StreamWriter..ctor(String path, Boolean append, Encoding encoding, Int32 bufferSize, Boolean checkHost)
   at System.IO.StreamWriter..ctor(String path, Boolean append, Encoding encoding)
   at System.IO.File.InternalAppendAllText(String path, String contents, Encoding encoding)
   at System.IO.File.AppendAllText(String path, String contents)
   at GitCredentialManager.Trace2FileWriter.Write(Trace2Message message)
   ...
```

This very general 'IOException' catch is necessary to avoid this issue.