### PR TITLE
Set release tag target in draft release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -749,6 +749,7 @@ jobs:
               ...releaseMetadata,
               draft: true,
               tag_name: tagName,
+              tag_commitish: context.sha,
               name: `GCM ${version}`
             });
             releaseMetadata.release_id = createdRelease.data.id;


### PR DESCRIPTION
When creating the initial draft release, also set the target commit to the currently built commit (the merge in to `release` typically) so that we don't accidentally create a release tag against the wrong target.