### PR TITLE
release.yml: use correct target_commitish arg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -749,7 +749,7 @@ jobs:
               ...releaseMetadata,
               draft: true,
               tag_name: tagName,
-              tag_commitish: context.sha,
+              target_commitish: context.sha,
               name: `GCM ${version}`
             });
             releaseMetadata.release_id = createdRelease.data.id;


### PR DESCRIPTION
Use the correct name for setting the target of a tag in the release workflow, for creating a draft release.

It should be `target_commitish` not `tag_commitish`.

https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release

Thanks to @dscho for realising my error.