### PR TITLE
release: update homebrew deployment

### DIFF
--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -5,17 +5,21 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     environment: release
+    env:
+        HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
     steps:
-    - name: Update Homebrew tap
-      uses: mjcheetham/update-homebrew@v1.4
-      with:
-        token: ${{ secrets.HOMEBREW_TOKEN }}
-        tap: Homebrew/homebrew-cask
-        name: git-credential-manager
-        type: cask
-        alwaysUsePullRequest: true
-        releaseAsset: |
-          gcm-osx-x64-(.*)\.pkg
-          gcm-osx-arm64-(.*)\.pkg
+    - name: Open PR against homebrew/homebrew-cask
+      run: |
+        # Get latest version
+        version=$(curl --silent "https://api.github.com/repos/git-ecosystem/git-credential-manager/releases/latest" |
+          grep '"tag_name":' |
+          sed -E 's/.*"v([0-9\.]+).*/\1/')
+
+        # Ensure local Homebrew repository is up to date
+        cd "$(brew --repository homebrew/cask)"
+        git pull
+
+        # Open PR to update to latest version
+        brew bump-cask-pr git-credential-manager --version $version --no-audit --no-browse


### PR DESCRIPTION
Update `release-homebrew` workflow to use the [`brew bump-cask-pr` command](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request#submit-a-new-version-of-an-existing-cask). This aligns with the Homebrew project's official recommendations for creating PRs in the `Homebrew/homebrew-cask` tap and removes GCM's dependency on the [`mjcheetham/update-homebrew` task](https://github.com/mjcheetham/update-homebrew).

This workflow was tested with [this PR](https://github.com/Homebrew/homebrew-cask/pull/153302) to `Homebrew/homebrew-cask`.