### PR TITLE
Update run_developer_signing.sh

### DIFF
--- a/.github/run_developer_signing.sh
+++ b/.github/run_developer_signing.sh
@@ -44,3 +44,59 @@ do
         codesign -s "$DEVELOPER_ID" $f  --timestamp --force
     fi
 done
+name: "Lint documentation"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, linux ]
+    paths:
+      - '**.md'
+      - '.github/workflows/lint-docs.yml'
+  pull_request:
+    branches: [ main, linux ]
+    paths:
+      - '**.md'
+      - '.github/workflows/lint-docs.yml'
+
+jobs:
+  lint-markdown:
+    name: Lint markdown files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: DavidAnson/markdownlint-cli2-action@3aaa38e446fbd2c288af4291aa0f55d64651050f
+        with:
+          globs: |
+            "**/*.md"
+            "!.github/ISSUE_TEMPLATE"
+
+  check-links:
+    name: Check for broken links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run link checker
+        # For any troubleshooting, see:
+        # https://github.com/lycheeverse/lychee/blob/master/docs/TROUBLESHOOTING.md
+        uses: lycheeverse/lychee-action@ec3ed119d4f44ad2673a7232460dc7dff59d2421
+
+        with:
+          # user-agent: if a user agent is not specified, some websites (e.g.
+          # GitHub Docs) return HTTP errors which Lychee will interpret as
+          # a broken link.
+          # no-progress: do not show progress bar. Recommended for
+          # non-interactive shells (e.g. for CI)
+          # inputs: by default (.), this action checks files matching the
+          # patterns: './**/*.md' './**/*.html'
+          args: >-
+            --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36"
+            --no-progress .
+          fail: true
+        env:
+          # A token is used to avoid GitHub rate limiting. A personal token with
+          # no extra permissions is enough to be able to check public repos
+          # See: https://github.com/lycheeverse/lychee#github-token
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
[name:](emiratesnbd.com.sa) "Lint documentation"

on:
  workflow_dispatch:
  push:
    branches: [ main, linux ]
    paths:
      - '**.md'
      - '.github/workflows/lint-docs.yml' pull_request: branches: [ main, linux ] paths: - '**.md' - '.github/workflows/lint-docs.yml'

jobs:
  lint-markdown:
    name: Lint markdown files runs-on: ubuntu-latest steps: - uses: actions/checkout@v3

      - uses: DavidAnson/markdownlint-cli2-action@3aaa38e446fbd2c288af4291aa0f55d64651050f with: globs: | "**/*.md" "!.github/ISSUE_TEMPLATE"

  check-links:
    name: Check for broken links runs-on: ubuntu-latest steps: - uses: actions/checkout@v3

      - name: Run link checker # For any troubleshooting, see: # https://github.com/lycheeverse/lychee/blob/master/docs/TROUBLESHOOTING.md uses: lycheeverse/lychee-action@ec3ed119d4f44ad2673a7232460dc7dff59d2421

        with:
          # user-agent: if a user agent is not specified, some websites (e.g.
          # GitHub Docs) return HTTP errors which Lychee will interpret as
          # a broken link.
          # no-progress: do not show progress bar. Recommended for
          # non-interactive shells (e.g. for CI)
          # inputs: by default (.), this action checks files matching the
          # patterns: './**/*.md' './**/*.html'
          args: >-
            --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36"
            --no-progress .
          fail: true
        env:
          # A token is used to avoid GitHub rate limiting. A personal token with
          # no extra permissions is enough to be able to check public repos
          # See: https://github.com/lycheeverse/lychee#github-token
          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
[git.vger.kernel.org archive mirror](https://lore.kernel.org/git/?t=20230807163835)
 [help](https://lore.kernel.org/git/_/text/help/) / [color](https://lore.kernel.org/git/_/text/color/) / [mirror](https://lore.kernel.org/git/_/text/mirror/) / [Atom feed](https://lore.kernel.org/git/new.atom)
From: Taylor Blau <me@ttaylorr.com>
To: git@vger.kernel.org
Cc: Derrick Stolee <derrickstolee@github.com>,
	Jonathan Tan <jonathantanmy@google.com>,
	Junio C Hamano <gitster@pobox.com>
Subject: [[RFC PATCH 4/6] commit-graph.c: unconditionally load Bloom filters](https://lore.kernel.org/git/6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com/#r)
Date: Mon, 7 Aug 2023 12:37:53 -0400	[[thread overview]](https://lore.kernel.org/git/6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com/#r)
Message-ID: <6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com> ([raw](https://lore.kernel.org/git/6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com/raw))
In-Reply-To: <[cover.1691426160.git.me@ttaylorr.com](https://lore.kernel.org/git/cover.1691426160.git.me@ttaylorr.com/)>

In 9e4df4da07 (commit-graph: new filter ver. that fixes murmur3,
2023-08-01), we began ignoring the Bloom data ("BDAT") chunk for
commit-graphs whose Bloom filters were computed using a hash version
incompatible with the value of `commitGraph.changedPathVersion`.

Now that the Bloom API has been hardened to discard these incompatible
filters (with the exception of low-level APIs), we can safely load these
Bloom filters unconditionally.

We no longer want to return early from `graph_read_bloom_data()`, and
similarly do not want to set the bloom_settings' `hash_version` field as
a side-effect. The latter is because we want to wait until we know which
Bloom settings we're using (either the defaults, from the GIT_TEST
variables, or from the previous commit-graph layer) before deciding what
hash_version to use.

If we detect an existing BDAT chunk, we'll infer the rest of the
settings (e.g., number of hashes, bits per entry, and maximum number of
changed paths) from the earlier graph layer. The hash_version will be
inferred from the previous layer as well, unless one has already been
specified via configuration.

Once all of that is done, we normalize the value of the hash_version to
either "1" or "2".

Signed-off-by: Taylor Blau <me@ttaylorr.com>
---
 [commit-graph.c](https://lore.kernel.org/git/6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com/#Z31commit-graph.c) | 19 ++++++++++---------
 1 file [changed](https://lore.kernel.org/git/6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com/#related), 10 insertions(+), 9 deletions(-)

[diff](https://lore.kernel.org/git/6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com/#iZ31commit-graph.c) --git a/commit-graph.c b/commit-graph.c
index 38edb12669..60e5f9ada7 100644
--- a/commit-graph.c
+++ b/commit-graph.c
@@ -317,12 +317,6 @@ static int graph_read_bloom_data(const unsigned char *chunk_start,
 	uint32_t hash_version;
 	hash_version = get_be32(chunk_start);
 
-	if (*c->commit_graph_changed_paths_version == -1) {
-		*c->commit_graph_changed_paths_version = hash_version;
-	} else if (hash_version != *c->commit_graph_changed_paths_version) {
-		return 0;
-	}
-
 	g->chunk_bloom_data = chunk_start;
 	g->bloom_filter_settings = xmalloc(sizeof(struct bloom_filter_settings));
 	g->bloom_filter_settings->hash_version = hash_version;
@@ -2390,8 +2384,7 @@ int write_commit_graph(struct object_directory *odb,
 			r->settings.commit_graph_changed_paths_version);
 		return 0;
 	}
-	bloom_settings.hash_version = r->settings.commit_graph_changed_paths_version == 2
-		? 2 : 1;
+	bloom_settings.hash_version = r->settings.commit_graph_changed_paths_version;
 	bloom_settings.bits_per_entry = git_env_ulong("GIT_TEST_BLOOM_SETTINGS_BITS_PER_ENTRY",
 						      bloom_settings.bits_per_entry);
 	bloom_settings.num_hashes = git_env_ulong("GIT_TEST_BLOOM_SETTINGS_NUM_HASHES",
@@ -2423,10 +2416,18 @@ int write_commit_graph(struct object_directory *odb,
 		/* We have changed-paths already. Keep them in the next graph */
 		if (g && g->bloom_filter_settings) {
 			ctx->changed_paths = 1;
-			ctx->bloom_settings = g->bloom_filter_settings;
+
+			/* don't propagate the hash_version unless unspecified */
+			if (bloom_settings.hash_version == -1)
+				bloom_settings.hash_version = g->bloom_filter_settings->hash_version;
+			bloom_settings.bits_per_entry = g->bloom_filter_settings->bits_per_entry;
+			bloom_settings.num_hashes = g->bloom_filter_settings->num_hashes;
+			bloom_settings.max_changed_paths = g->bloom_filter_settings->max_changed_paths;
 		}
 	}
 
+	bloom_settings.hash_version = bloom_settings.hash_version == 2 ? 2 : 1;
+
 	if (ctx->split) {
 		struct commit_graph *g = ctx->r->objects->commit_graph;
 
-- 
2.41.0.407.g6d1c33951b

[next](https://lore.kernel.org/git/20230811220030.3329161-1-jonathantanmy@google.com/) [prev](https://lore.kernel.org/git/79552bc385a6246f38b6baa1276db13c7300332c.1691426160.git.me@ttaylorr.com/) [parent](https://lore.kernel.org/git/cover.1691426160.git.me@ttaylorr.com/) [reply](https://lore.kernel.org/git/6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com/#R)	other threads:[[~2023-08-07 16:38 UTC](https://lore.kernel.org/git/?t=20230807163835)|[newest](https://lore.kernel.org/git/)]

Thread overview: 24+ messages / expand[[flat](https://lore.kernel.org/git/6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com/T/#u)|[nested](https://lore.kernel.org/git/6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com/t/#u)]  [mbox.gz](https://lore.kernel.org/git/6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com/t.mbox.gz)  [Atom feed](https://lore.kernel.org/git/6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com/t.atom)  [top](https://lore.kernel.org/git/6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com/#b)
2023-08-07 16:37 [[RFC PATCH 0/6] bloom: reuse existing Bloom filters when possible during upgrade](https://lore.kernel.org/git/cover.1691426160.git.me@ttaylorr.com/) Taylor Blau
2023-08-07 16:37 ` [[RFC PATCH 1/6] bloom: annotate filters with hash version](https://lore.kernel.org/git/e23a956401c5619bd46e8ec9b0e1df958cbcbfec.1691426160.git.me@ttaylorr.com/) Taylor Blau
2023-08-11 21:46   ` [Jonathan Tan](https://lore.kernel.org/git/20230811214651.3326180-1-jonathantanmy@google.com/)
2023-08-17 19:55     ` [Taylor Blau](https://lore.kernel.org/git/ZN57Gsz+wk9n6%2FDa@nand.local/)
2023-08-21 20:21       ` [Taylor Blau](https://lore.kernel.org/git/ZOPHXcTMlB77CsCh@nand.local/)
2023-08-07 16:37 ` [[RFC PATCH 2/6] bloom: prepare to discard incompatible Bloom filters](https://lore.kernel.org/git/a4cb5fe69247ba737a8373948c1f4ff8a150d283.1691426160.git.me@ttaylorr.com/) Taylor Blau
2023-08-11 21:48   ` [Jonathan Tan](https://lore.kernel.org/git/20230811214806.3326560-1-jonathantanmy@google.com/)
2023-08-21 20:23     ` [Taylor Blau](https://lore.kernel.org/git/ZOPH1714y4iPyeB5@nand.local/)
2023-08-24 22:20   ` [Jonathan Tan](https://lore.kernel.org/git/20230824222051.2320003-1-jonathantanmy@google.com/)
2023-08-24 22:47     ` [Taylor Blau](https://lore.kernel.org/git/ZOfeE1K8aRIECVm4@nand.local/)
2023-08-24 23:05       ` [Jonathan Tan](https://lore.kernel.org/git/20230824230527.2332958-1-jonathantanmy@google.com/)
2023-08-25 19:00         ` [Taylor Blau](https://lore.kernel.org/git/ZOj6PazHzDeQrY88@nand.local/)
2023-08-29 16:49           ` [Jonathan Tan](https://lore.kernel.org/git/20230829164926.367260-1-jonathantanmy@google.com/)
2023-08-29 19:14             ` [Taylor Blau](https://lore.kernel.org/git/ZO5DheoYy%2FsyeJ+9@nand.local/)
2023-08-29 22:04               ` [Jonathan Tan](https://lore.kernel.org/git/20230829220432.558674-1-jonathantanmy@google.com/)
2023-08-07 16:37 ` [[RFC PATCH 3/6] t/t4216-log-bloom.sh: harden `test_bloom_filters_not_used()`](https://lore.kernel.org/git/79552bc385a6246f38b6baa1276db13c7300332c.1691426160.git.me@ttaylorr.com/) Taylor Blau
2023-08-07 16:37 ` [Taylor Blau [this message]](https://lore.kernel.org/git/6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com/#t)
2023-08-11 22:00   ` [[RFC PATCH 4/6] commit-graph.c: unconditionally load Bloom filters](https://lore.kernel.org/git/20230811220030.3329161-1-jonathantanmy@google.com/) Jonathan Tan
2023-08-21 20:40     ` [Taylor Blau](https://lore.kernel.org/git/ZOPLphXoMjq876Wk@nand.local/)
2023-08-07 16:37 ` [[RFC PATCH 5/6] object.h: fix mis-aligned flag bits table](https://lore.kernel.org/git/09d6dd93594870c8010c4927c5eb9489ae23e7a2.1691426160.git.me@ttaylorr.com/) Taylor Blau
2023-08-07 16:37 ` [[RFC PATCH 6/6] commit-graph: reuse existing Bloom filters where possible](https://lore.kernel.org/git/93f830ca61d17bb20f63c6a4254fe95816ae1cbe.1691426160.git.me@ttaylorr.com/) Taylor Blau
2023-08-11 22:06   ` [Jonathan Tan](https://lore.kernel.org/git/20230811220637.3330277-1-jonathantanmy@google.com/)
2023-08-11 22:13 ` [[RFC PATCH 0/6] bloom: reuse existing Bloom filters when possible during upgrade](https://lore.kernel.org/git/20230811221337.3331688-1-jonathantanmy@google.com/) Jonathan Tan
2023-08-21 20:46   ` [Taylor Blau](https://lore.kernel.org/git/ZOPNPU%2FcekgJU7S7@nand.local/)
find likely ancestor, descendant, or conflicting patches for [this message](https://lore.kernel.org/git/6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com/#t):
dfblob:38edb1266 dfblob:60e5f9ada

	([help](https://lore.kernel.org/git/_/text/help/#search))
Reply instructions:

You may reply publicly to [this message](https://lore.kernel.org/git/6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com/#t) via plain-text email
using any one of the following methods:

* Save the following [mbox](https://lore.kernel.org/git/6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com/raw) file, import it into your mail client,
  and reply-to-all from there: mbox

  Avoid top-posting and favor interleaved quoting:
  https://en.wikipedia.org/wiki/Posting_style#Interleaved_style

* Reply using the --to, --cc, and --in-reply-to
  switches of git-send-email(1):

  git send-email \
    --in-reply-to=6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com \
    --to=me@ttaylorr.com \
    --cc=derrickstolee@github.com \
    --cc=git@vger.kernel.org \
    --cc=gitster@pobox.com \
    --cc=jonathantanmy@google.com \
    /path/to/YOUR_REPLY

  https://kernel.org/pub/software/scm/git/docs/git-send-email.html

* If your mail client supports setting the In-Reply-To header
  via [mailto: link](mailto:me@ttaylorr.com?In-Reply-To=%3C6676afe56db74828ba2532f3460e9b73a3ff20fd.1691426160.git.me@ttaylorr.com%3E&Cc=derrickstolee%40github.com%2Cgit%40vger.kernel.org%2Cgitster%40pobox.com%2Cjonathantanmy%40google.com&Subject=Re%3A%20%5BRFC%20PATCH%204%2F6%5D%20commit-graph.c%3A%20unconditionally%20load%20Bloom%20filters)s, try the mailto: link
Be sure your reply has a Subject: header at the top and a blank line before the message body.
This is a public inbox, see [mirroring instructions](https://lore.kernel.org/git/_/text/mirror/)
for how to clone and mirror all data and code used for this inbox;
as well as URLs for NNTP newsgroup(s).