### PR TITLE
Support linux install path from src

### DIFF
--- a/src/linux/Packaging.Linux/Packaging.Linux.csproj
+++ b/src/linux/Packaging.Linux/Packaging.Linux.csproj
@@ -23,8 +23,8 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
   <Target Name="CoreCompile" Condition="'$(OSPlatform)'=='linux'">
-    <Message Text="$(MSBuildProjectDirectory)\build.sh --install-from-source=$(InstallFromSource) --configuration='$(Configuration)' --version='$(Version)'" Importance="High" />
-    <Exec Command="$(MSBuildProjectDirectory)\build.sh --install-from-source=$(InstallFromSource) --configuration='$(Configuration)' --version='$(Version)'" />
+    <Message Text="$(MSBuildProjectDirectory)\build.sh --install-from-source=$(InstallFromSource) --configuration='$(Configuration)' --version='$(Version)' --install-location='$(InstallLocation)'" Importance="High" />
+    <Exec Command="$(MSBuildProjectDirectory)\build.sh --install-from-source=$(InstallFromSource) --configuration='$(Configuration)' --version='$(Version)' --install-location='$(InstallLocation)'" />
   </Target>
 
   <Target Name="CoreClean">

--- a/src/linux/Packaging.Linux/build.sh
+++ b/src/linux/Packaging.Linux/build.sh
@@ -30,6 +30,10 @@ case "$i" in
     INSTALL_FROM_SOURCE="${i#*=}"
     shift # past argument=value
     ;;
+    --install-location=*)
+    INSTALL_LOCATION="${i#*=}"
+    shift # past argument=value
+    ;;
     *)
           # unknown option
     ;;
@@ -50,10 +54,11 @@ SYMBOLS="$OUTDIR/payload.sym"
 "$INSTALLER_SRC/layout.sh" --configuration="$CONFIGURATION" || exit 1
 
 if [ $INSTALL_FROM_SOURCE = true ]; then
-    INSTALL_LOCATION="/usr/local"
+    #INSTALL_LOCATION="/usr/local"
+
     mkdir -p "$INSTALL_LOCATION"
 
-    echo "Installing..."
+    echo "Installing to $INSTALL_LOCATION"
 
     # Install directories
     INSTALL_TO="$INSTALL_LOCATION/share/gcm-core/"

--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -6,6 +6,7 @@
 # for additional details.
 set -e
 
+installLocation=/usr/local
 is_ci=
 for i in "$@"; do
     case "$i" in
@@ -13,15 +14,26 @@ for i in "$@"; do
         is_ci=true
         shift # Past argument=value
         ;;
+        --install-location=*)
+        installLocation="${i#*=}"
+        shift # past argument=value
+        ;;
     esac
 done
+
+
+# If pass the install-location check if it exists
+if [! -d "$installLocation" ]; then
+    echo "The folder $installLocation do not exists"
+    exit
+fi
 
 # In non-ci scenarios, advertise what we will be doing and
 # give user the option to exit.
 if [ -z $is_ci ]; then
     echo "This script will download, compile, and install Git Credential Manager to:
 
-    /usr/local/bin
+    $installLocation/bin
 
 Git Credential Manager is licensed under the MIT License: https://aka.ms/gcm/license"
 
@@ -225,5 +237,5 @@ if [ -z "$DOTNET_ROOT" ]; then
 fi
 
 cd "$toplevel_path"
-$sudo_cmd env "PATH=$PATH" $DOTNET_ROOT/dotnet build ./src/linux/Packaging.Linux/Packaging.Linux.csproj -c Release -p:InstallFromSource=true
-add_to_PATH "/usr/local/bin"
+$sudo_cmd env "PATH=$PATH" $DOTNET_ROOT/dotnet build ./src/linux/Packaging.Linux/Packaging.Linux.csproj -c Release -p:InstallFromSource=true -p:InstallLocation=$installLocation
+add_to_PATH $installLocation


### PR DESCRIPTION
This PR fix #1304.

I found that the add func [add_to_PATH](https://github.com/git-ecosystem/git-credential-manager/blob/afcb6b87302b34d1809a0a057f24c7ba7a3ff5db/src/linux/Packaging.Linux/install-from-source.sh#L94) doesn't persist the path to the $PATH env variable. 

To persist in the current shell is necessary to use a dot or `source` [see doc](https://ss64.com/bash/source.html)

_When a script is run using source it runs within the existing shell, any variables created or modified by the script will remain available after the script completes. In contrast if the script is run just as filename, then a separate subshell (with a completely separate set of variables) would be spawned to run the script._

To persist the PATH among the reboot/new shell, it is necessary to update the _.profile_ with `echo 'PATH="$PATH:$installPath' >>~/.profile`.

I don't know if this is the correct behavior, Prior to this commit, it was working because the `/usr/local/bin` is already in the PATH.