### PR TITLE
Update dev.azure.com product page URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ We're [MIT][gcm-license] licensed.
 When using GitHub logos, please be sure to follow the
 [GitHub logo guidelines][github-logos].
 
-[azure-devops]: https://dev.azure.com/
+[azure-devops]: https://azure.microsoft.com/en-us/products/devops
 [azure-devops-ssh]: https://docs.microsoft.com/en-us/azure/devops/repos/git/use-ssh-keys-to-authenticate?view=azure-devops
 [bitbucket]: https://bitbucket.org
 [bitbucket-ssh]: https://confluence.atlassian.com/bitbucket/ssh-keys-935365775.html

--- a/docs/windows-broker.md
+++ b/docs/windows-broker.md
@@ -216,7 +216,7 @@ In order to fix the problem, there are a few options:
 
 [azure-refresh-token-terms]: https://docs.microsoft.com/azure/active-directory/devices/concept-primary-refresh-token#key-terminology-and-components
 [azure-conditional-access]: https://docs.microsoft.com/azure/active-directory/conditional-access/overview
-[azure-devops]: https://dev.azure.com
+[azure-devops]: https://azure.microsoft.com/en-us/products/devops
 [GCM_MSAUTH_USEBROKER]: environment.md#GCM_MSAUTH_USEBROKER-experimental
 [GCM_MSAUTH_USEDEFAULTACCOUNT]: environment.md#GCM_MSAUTH_USEDEFAULTACCOUNT-experimental
 [credential.msauthUseBroker]: configuration.md#credentialmsauthusebroker-experimental


### PR DESCRIPTION
Update the URL for the Azure DevOps product page. This used to be just https://dev.azure.com, but this now redirects you to https://azure.microsoft.com/en-us/products/devops instead.

The markdown link linter times out following the redirect, so let's just update the original link.