### PR TITLE
Enable assembly trimming and single-file publish on all platforms

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,6 +29,11 @@ jobs:
       with:
         dotnet-version: 8.0.x
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3.2.0
+      with:
+        dotnet-version: 8.0.x
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -37,9 +37,9 @@ jobs:
       shell: bash
       run: |
         mkdir -p artifacts/bin
-        mv out/windows/Installer.Windows/bin/Release/net472/win-x86 artifacts/bin/
-        cp out/windows/Installer.Windows/bin/Release/net472/win-x86.sym/* artifacts/bin/win-x86/
-        mv out/windows/Installer.Windows/bin/Release/net472/gcm*.exe artifacts/
+        mv out/windows/Installer.Windows/bin/Release/net8.0/win-x86 artifacts/bin/
+        cp out/windows/Installer.Windows/bin/Release/net8.0/win-x86.sym/* artifacts/bin/win-x86/
+        mv out/windows/Installer.Windows/bin/Release/net8.0/gcm*.exe artifacts/
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,7 +200,7 @@ jobs:
           /p:PayloadPath=$env:GITHUB_WORKSPACE\payload /p:NoLayout=true `
           --configuration=WindowsRelease
         mkdir installers
-        Move-Item -Path .\out\windows\Installer.Windows\bin\Release\net472\*.exe `
+        Move-Item -Path .\out\windows\Installer.Windows\bin\Release\net8.0\*.exe `
          -Destination $env:GITHUB_WORKSPACE\installers
 
     - name: Sign installers with Azure Code Signing

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,10 +26,4 @@
     <GenerateWindowsAppManifest Condition="'$(GenerateWindowsAppManifest)' == '' AND '$(OSPlatform)' == 'windows' AND '$(_IsExeProject)' == 'true'">true</GenerateWindowsAppManifest>
   </PropertyGroup>
 
-  <ItemGroup Condition = "'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="System.Text.Json">
-      <Version>8.0.5</Version>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -34,4 +34,9 @@
     </ItemGroup>
   </Target>
 
+  <PropertyGroup>
+    <!-- Ignore platform API compatibilty checks in test projects -->
+    <NoWarn Condition="'$(IsTestProject)'=='true'">$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+
 </Project>

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,9 +40,9 @@ To build from the command line, run:
 dotnet build -c WindowsDebug
 ```
 
-You can find a copy of the installer .exe file in `out\windows\Installer.Windows\bin\Debug\net472`.
+You can find a copy of the installer .exe file in `out\windows\Installer.Windows\bin\Debug\net8.0`.
 
-The flat binaries can also be found in `out\windows\Payload.Windows\bin\Debug\net472\win-x86`.
+The flat binaries can also be found in `out\windows\Payload.Windows\bin\Debug\net8.0\win-x86`.
 
 ### Linux
 

--- a/src/linux/Packaging.Linux/layout.sh
+++ b/src/linux/Packaging.Linux/layout.sh
@@ -77,7 +77,6 @@ if [ -z "$RUNTIME" ]; then
         --configuration="$CONFIGURATION" \
         --framework="$FRAMEWORK" \
         --self-contained \
-        -p:PublishSingleFile=true \
         --output="$(make_absolute "$PAYLOAD")" || exit 1
 else
     $DOTNET_ROOT/dotnet publish "$GCM_SRC" \
@@ -85,7 +84,6 @@ else
         --framework="$FRAMEWORK" \
         --runtime="$RUNTIME" \
         --self-contained \
-        -p:PublishSingleFile=true \
         --output="$(make_absolute "$PAYLOAD")" || exit 1
 fi
 

--- a/src/osx/Installer.Mac/layout.sh
+++ b/src/osx/Installer.Mac/layout.sh
@@ -21,7 +21,6 @@ SRC="$ROOT/src"
 OUT="$ROOT/out"
 INSTALLER_SRC="$SRC/osx/Installer.Mac"
 GCM_SRC="$SRC/shared/Git-Credential-Manager"
-GCM_UI_SRC="$SRC/shared/Git-Credential-Manager.UI.Avalonia"
 
 # Build parameters
 FRAMEWORK=net8.0

--- a/src/shared/Atlassian.Bitbucket/Atlassian.Bitbucket.csproj
+++ b/src/shared/Atlassian.Bitbucket/Atlassian.Bitbucket.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net8.0;net472</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Atlassian.Bitbucket</AssemblyName>
     <RootNamespace>Atlassian.Bitbucket</RootNamespace>
     <IsTestProject>false</IsTestProject>
@@ -11,10 +10,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/shared/Atlassian.Bitbucket/BitbucketJsonSerializerContext.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketJsonSerializerContext.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Atlassian.Bitbucket;
+
+[JsonSourceGenerationOptions(
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    PropertyNameCaseInsensitive = true
+)]
+[JsonSerializable(typeof(BitbucketTokenEndpointResponseJson))]
+[JsonSerializable(typeof(Cloud.UserInfo), TypeInfoPropertyName = "Cloud_UserInfo")]
+[JsonSerializable(typeof(DataCenter.UserInfo), TypeInfoPropertyName = "DataCenter_UserInfo")]
+[JsonSerializable(typeof(DataCenter.LoginOptions))]
+internal partial class BitbucketJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/shared/Atlassian.Bitbucket/BitbucketOAuth2Client.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketOAuth2Client.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using GitCredentialManager;
@@ -42,7 +43,7 @@ namespace Atlassian.Bitbucket
             // We override the token endpoint response parsing because the Bitbucket authority returns
             // the non-standard 'scopes' property for the list of scopes, rather than the (optional)
             // 'scope' (note the singular vs plural) property as outlined in the standard.
-            if (TryDeserializeJson(json, out BitbucketTokenEndpointResponseJson jsonObj))
+            if (TryDeserializeJson(json, BitbucketJsonSerializerContext.Default, out BitbucketTokenEndpointResponseJson jsonObj))
             {
                 result = jsonObj.ToResult();
                 return true;

--- a/src/shared/Atlassian.Bitbucket/Cloud/BitbucketRestApi.cs
+++ b/src/shared/Atlassian.Bitbucket/Cloud/BitbucketRestApi.cs
@@ -43,11 +43,7 @@ namespace Atlassian.Bitbucket.Cloud
 
                     if (response.IsSuccessStatusCode)
                     {
-                        var obj = JsonSerializer.Deserialize<UserInfo>(json,
-                            new JsonSerializerOptions
-                            {
-                                PropertyNameCaseInsensitive = true,
-                            });
+                        UserInfo obj = JsonSerializer.Deserialize(json, BitbucketJsonSerializerContext.Default.Cloud_UserInfo);
 
                         return new RestApiResult<IUserInfo>(response.StatusCode, obj);
                     }

--- a/src/shared/Atlassian.Bitbucket/DataCenter/BitbucketRestApi.cs
+++ b/src/shared/Atlassian.Bitbucket/DataCenter/BitbucketRestApi.cs
@@ -107,12 +107,7 @@ namespace Atlassian.Bitbucket.DataCenter
 
                     if (response.IsSuccessStatusCode)
                     {
-                        var loginOptions = JsonSerializer.Deserialize<LoginOptions>(json,
-                            new JsonSerializerOptions
-                            {
-                                PropertyNameCaseInsensitive = true,
-                                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-                            });
+                        LoginOptions loginOptions = JsonSerializer.Deserialize(json, BitbucketJsonSerializerContext.Default.LoginOptions);
 
                         if (loginOptions.Results.Any(r => "LOGIN_FORM".Equals(r.Type)))
                         {

--- a/src/shared/Atlassian.Bitbucket/UI/Views/CredentialsView.axaml
+++ b/src/shared/Atlassian.Bitbucket/UI/Views/CredentialsView.axaml
@@ -5,6 +5,8 @@
              xmlns:vm="clr-namespace:Atlassian.Bitbucket.UI.ViewModels;assembly=Atlassian.Bitbucket"
              xmlns:converters="clr-namespace:GitCredentialManager.UI.Converters;assembly=gcmcore"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:DataType="vm:CredentialsViewModel"
+             x:CompileBindings="True"
              x:Class="Atlassian.Bitbucket.UI.Views.CredentialsView">
     <Design.DataContext>
         <vm:CredentialsViewModel/>

--- a/src/shared/Core/Authentication/AuthenticationBase.cs
+++ b/src/shared/Core/Authentication/AuthenticationBase.cs
@@ -60,11 +60,7 @@ namespace GitCredentialManager.Authentication
             // Write the standard input to the process if we have any to write
             if (standardInput is not null)
             {
-#if NETFRAMEWORK
-                await standardInput.BaseStream.CopyToAsync(process.StandardInput.BaseStream);
-#else
                 await standardInput.BaseStream.CopyToAsync(process.StandardInput.BaseStream, ct);
-#endif
                 process.StandardInput.Close();
             }
 

--- a/src/shared/Core/Authentication/OAuth/Json/OAuthJsonSerializerContext.cs
+++ b/src/shared/Core/Authentication/OAuth/Json/OAuthJsonSerializerContext.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace GitCredentialManager.Authentication.OAuth.Json;
+
+[JsonSourceGenerationOptions(
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    PropertyNameCaseInsensitive = true
+)]
+[JsonSerializable(typeof(DeviceAuthorizationEndpointResponseJson))]
+[JsonSerializable(typeof(ErrorResponseJson))]
+[JsonSerializable(typeof(TokenEndpointResponseJson))]
+public partial class OAuthJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/shared/Core/Constants.cs
+++ b/src/shared/Core/Constants.cs
@@ -17,6 +17,11 @@ namespace GitCredentialManager
         public const string GcmDataDirectoryName = ".gcm";
 
         public const string MacOSBundleId = "git-credential-manager";
+
+        public const string WindowsPlatformName = "windows";
+        public const string LinuxPlatformName = "linux";
+        public const string MacOSPlatformName = "osx";
+
         public static readonly Guid DevBoxPartnerId = new("e3171dd9-9a5f-e5be-b36c-cc7c4f3f3bcf");
 
         /// <summary>

--- a/src/shared/Core/Core.csproj
+++ b/src/shared/Core/Core.csproj
@@ -14,13 +14,13 @@
     <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.65.0" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.65.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="Avalonia" Version="11.1.3" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.3" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.3" />
+    <PackageReference Include="Avalonia" Version="11.3.8" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.8" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.8" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.1.3" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.8" />
   </ItemGroup>
 
 </Project>

--- a/src/shared/Core/Core.csproj
+++ b/src/shared/Core/Core.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net8.0;net472</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>gcmcore</AssemblyName>
     <RootNamespace>GitCredentialManager</RootNamespace>
     <IsTestProject>false</IsTestProject>
@@ -10,23 +9,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Web" />
-    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.65.0" />
-    <PackageReference Include="Avalonia.Win32" Version="11.1.3" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.3" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.65.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.65.0" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.65.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Avalonia" Version="11.1.3" />
-    <PackageReference Include="Avalonia.Skia" Version="11.1.3" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.1.3" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.3" />
   </ItemGroup>
 

--- a/src/shared/Core/CurlCookie.cs
+++ b/src/shared/Core/CurlCookie.cs
@@ -66,18 +66,12 @@ namespace GitCredentialManager
 
         private static DateTime ParseExpires(string expires)
         {
-#if NETFRAMEWORK
-            DateTime epoch = new DateTime(1970, 01, 01, 0, 0, 0, DateTimeKind.Utc);
-#else
-            DateTime epoch = DateTime.UnixEpoch;
-#endif
-
             if (long.TryParse(expires, out long i))
             {
-                return epoch.AddSeconds(i);
+                return DateTime.UnixEpoch.AddSeconds(i);
             }
 
-            return epoch;
+            return DateTime.UnixEpoch;
         }
     }
 }

--- a/src/shared/Core/HttpClientFactory.cs
+++ b/src/shared/Core/HttpClientFactory.cs
@@ -99,11 +99,7 @@ namespace GitCredentialManager
                 _streams.Error.WriteLine("warning: ---------------------------------------------------");
                 _streams.Error.WriteLine($"warning: HTTPS connections may not be secure. See {Constants.HelpUrls.GcmTlsVerification} for more information.");
 
-#if NETFRAMEWORK
-                ServicePointManager.ServerCertificateValidationCallback = (req, cert, chain, errors) => true;
-#else
                 handler.ServerCertificateCustomValidationCallback = (req, cert, chain, errors) => true;
-#endif
             }
             // If schannel is the TLS backend, custom certificate usage must be explicitly enabled
             else if (!string.IsNullOrWhiteSpace(_settings.CustomCertificateBundlePath) &&
@@ -178,23 +174,7 @@ namespace GitCredentialManager
 
                 // Set the custom server certificate validation callback.
                 // NOTE: this is executed after the default platform server certificate validation is performed
-#if NETFRAMEWORK
-                ServicePointManager.ServerCertificateValidationCallback = (_, cert, chain, errors) =>
-                {
-                    // Fail immediately if the cert or chain isn't present
-                    if (cert is null || chain is null)
-                    {
-                        return false;
-                    }
-
-                    using (X509Certificate2 cert2 = new X509Certificate2(cert))
-                    {
-                        return validationCallback(cert2, chain, errors);
-                    }
-                };
-#else
                 handler.ServerCertificateCustomValidationCallback = (_, cert, chain, errors) => validationCallback(cert, chain, errors);
-#endif
             }
 
             // If CustomCookieFilePath is set, set Cookie header from cookie file, which is written by libcurl

--- a/src/shared/Core/Interop/Linux/LinuxFileSystem.cs
+++ b/src/shared/Core/Interop/Linux/LinuxFileSystem.cs
@@ -1,9 +1,11 @@
 using System;
 using System.IO;
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.Posix;
 
 namespace GitCredentialManager.Interop.Linux
 {
+    [SupportedOSPlatform(Constants.LinuxPlatformName)]
     public class LinuxFileSystem : PosixFileSystem
     {
         public override bool IsSamePath(string a, string b)

--- a/src/shared/Core/Interop/Linux/LinuxSessionManager.cs
+++ b/src/shared/Core/Interop/Linux/LinuxSessionManager.cs
@@ -1,7 +1,9 @@
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.Posix;
 
 namespace GitCredentialManager.Interop.Linux;
 
+[SupportedOSPlatform(Constants.LinuxPlatformName)]
 public class LinuxSessionManager : PosixSessionManager
 {
     private bool? _isWebBrowserAvailable;

--- a/src/shared/Core/Interop/Linux/LinuxTerminal.cs
+++ b/src/shared/Core/Interop/Linux/LinuxTerminal.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.Linux.Native;
 using GitCredentialManager.Interop.Posix;
 using GitCredentialManager.Interop.Posix.Native;
 
 namespace GitCredentialManager.Interop.Linux
 {
+    [SupportedOSPlatform(Constants.LinuxPlatformName)]
     public class LinuxTerminal : PosixTerminal
     {
         public LinuxTerminal(ITrace trace, ITrace2 trace2)

--- a/src/shared/Core/Interop/MacOS/MacOSEnvironment.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSEnvironment.cs
@@ -2,11 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.Versioning;
 using System.Threading;
 using GitCredentialManager.Interop.Posix;
 
 namespace GitCredentialManager.Interop.MacOS
 {
+    [SupportedOSPlatform(Constants.MacOSPlatformName)]
     public class MacOSEnvironment : PosixEnvironment
     {
         private ICollection<string> _pathsToIgnore;

--- a/src/shared/Core/Interop/MacOS/MacOSFileSystem.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSFileSystem.cs
@@ -1,9 +1,11 @@
 using System;
 using System.IO;
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.Posix;
 
 namespace GitCredentialManager.Interop.MacOS
 {
+    [SupportedOSPlatform(Constants.MacOSPlatformName)]
     public class MacOSFileSystem : PosixFileSystem
     {
         public override bool IsSamePath(string a, string b)

--- a/src/shared/Core/Interop/MacOS/MacOSSessionManager.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSSessionManager.cs
@@ -1,8 +1,10 @@
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.MacOS.Native;
 using GitCredentialManager.Interop.Posix;
 
 namespace GitCredentialManager.Interop.MacOS
 {
+    [SupportedOSPlatform(Constants.MacOSPlatformName)]
     public class MacOSSessionManager : PosixSessionManager
     {
         public MacOSSessionManager(IEnvironment env, IFileSystem fs) : base(env, fs)

--- a/src/shared/Core/Interop/MacOS/MacOSTerminal.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSTerminal.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.MacOS.Native;
 using GitCredentialManager.Interop.Posix;
 using GitCredentialManager.Interop.Posix.Native;
 
 namespace GitCredentialManager.Interop.MacOS
 {
+    [SupportedOSPlatform(Constants.MacOSPlatformName)]
     public class MacOSTerminal : PosixTerminal
     {
         public MacOSTerminal(ITrace trace, ITrace2 trace2)

--- a/src/shared/Core/Interop/Posix/PosixEnvironment.cs
+++ b/src/shared/Core/Interop/Posix/PosixEnvironment.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Versioning;
 
 namespace GitCredentialManager.Interop.Posix
 {
+    [SupportedOSPlatform(Constants.LinuxPlatformName)]
+    [SupportedOSPlatform(Constants.MacOSPlatformName)]
     public class PosixEnvironment : EnvironmentBase
     {
         public PosixEnvironment(IFileSystem fileSystem)

--- a/src/shared/Core/Interop/Posix/PosixFileSystem.cs
+++ b/src/shared/Core/Interop/Posix/PosixFileSystem.cs
@@ -13,13 +13,6 @@ namespace GitCredentialManager.Interop.Posix
         /// <exception cref="ArgumentException">Path is not absolute.</exception>
         protected internal static string ResolveSymbolicLinks(string path)
         {
-#if NETFRAMEWORK
-            // Support for symlinks only exists in .NET 6+.
-            // Since we're still targeting .NET Framework on Windows it
-            // doesn't matter if we don't resolve symlinks for POSIX here
-            // (unless we're running on Mono.. but why do that?)
-            return path;
-#else
             if (!Path.IsPathRooted(path))
             {
                 throw new ArgumentException("Path must be absolute", nameof(path));
@@ -54,10 +47,8 @@ namespace GitCredentialManager.Interop.Posix
             }
 
             return Path.Combine("/", partialPath);
-#endif
         }
 
-#if !NETFRAMEWORK
         private static bool TryResolveFileLink(string path, out string target)
         {
             FileSystemInfo fsi = File.ResolveLinkTarget(path, true);
@@ -71,6 +62,5 @@ namespace GitCredentialManager.Interop.Posix
             target = fsi?.FullName;
             return fsi != null;
         }
-#endif
     }
 }

--- a/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
+++ b/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Text;
 
 namespace GitCredentialManager.Interop.Windows
 {
+    [SupportedOSPlatform(Constants.WindowsPlatformName)]
     public class WindowsEnvironment : EnvironmentBase
     {
         public WindowsEnvironment(IFileSystem fileSystem)

--- a/src/shared/Core/Interop/Windows/WindowsFileSystem.cs
+++ b/src/shared/Core/Interop/Windows/WindowsFileSystem.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
+using System.Runtime.Versioning;
 
 namespace GitCredentialManager.Interop.Windows
 {
+    [SupportedOSPlatform(Constants.WindowsPlatformName)]
     public class WindowsFileSystem : FileSystem
     {
         public override bool IsSamePath(string a, string b)

--- a/src/shared/Core/Interop/Windows/WindowsProcessManager.cs
+++ b/src/shared/Core/Interop/Windows/WindowsProcessManager.cs
@@ -1,5 +1,8 @@
+using System.Runtime.Versioning;
+
 namespace GitCredentialManager.Interop.Windows;
 
+[SupportedOSPlatform(Constants.WindowsPlatformName)]
 public class WindowsProcessManager : ProcessManager
 {
     public WindowsProcessManager(ITrace2 trace2) : base(trace2)

--- a/src/shared/Core/Interop/Windows/WindowsSessionManager.cs
+++ b/src/shared/Core/Interop/Windows/WindowsSessionManager.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.Windows.Native;
 
 namespace GitCredentialManager.Interop.Windows
 {
+    [SupportedOSPlatform(Constants.WindowsPlatformName)]
     public class WindowsSessionManager : SessionManager
     {
         public WindowsSessionManager(IEnvironment env, IFileSystem fs) : base(env, fs)

--- a/src/shared/Core/Interop/Windows/WindowsSettings.cs
+++ b/src/shared/Core/Interop/Windows/WindowsSettings.cs
@@ -21,7 +21,6 @@ namespace GitCredentialManager.Interop.Windows
         {
             value = null;
 
-#if NETFRAMEWORK
             // Check for machine (HKLM) registry keys that match the Git configuration name.
             // These can be set by system administrators via Group Policy, so make useful defaults.
             using (Microsoft.Win32.RegistryKey configKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(Constants.WindowsRegistry.HKConfigurationPath))
@@ -48,9 +47,6 @@ namespace GitCredentialManager.Interop.Windows
 
                 return true;
             }
-#else
-            return base.TryGetExternalDefault(section, scope, property, out value);
-#endif
         }
     }
 }

--- a/src/shared/Core/Interop/Windows/WindowsSettings.cs
+++ b/src/shared/Core/Interop/Windows/WindowsSettings.cs
@@ -1,9 +1,12 @@
 
+using System.Runtime.Versioning;
+
 namespace GitCredentialManager.Interop.Windows
 {
     /// <summary>
     /// Reads settings from Git configuration, environment variables, and defaults from the Windows Registry.
     /// </summary>
+    [SupportedOSPlatform(Constants.WindowsPlatformName)]
     public class WindowsSettings : Settings
     {
         private readonly ITrace _trace;

--- a/src/shared/Core/Interop/Windows/WindowsTerminal.cs
+++ b/src/shared/Core/Interop/Windows/WindowsTerminal.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Text;
 using GitCredentialManager.Interop.Windows.Native;
 using Microsoft.Win32.SafeHandles;
@@ -9,6 +10,7 @@ namespace GitCredentialManager.Interop.Windows
     /// <summary>
     /// Represents a thin wrapper around the Windows console device.
     /// </summary>
+    [SupportedOSPlatform(Constants.WindowsPlatformName)]
     public class WindowsTerminal : ITerminal
     {
         // ReadConsole 32768 fail, 32767 OK @linquize [https://github.com/Microsoft/Git-Credential-Manager-for-Windows/commit/a62b9a19f430d038dcd85a610d97e5f763980f85]

--- a/src/shared/Core/PlatformUtils.cs
+++ b/src/shared/Core/PlatformUtils.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using GitCredentialManager.Interop.Posix.Native;
 
 namespace GitCredentialManager
@@ -24,6 +26,7 @@ namespace GitCredentialManager
             return new PlatformInformation(osType, osVersion, cpuArch, clrVersion);
         }
 
+        [SupportedOSPlatformGuard(Constants.WindowsPlatformName)]
         public static bool IsDevBox()
         {
             if (!IsWindows())
@@ -65,6 +68,7 @@ namespace GitCredentialManager
             }
         }
 
+        [SupportedOSPlatformGuard(Constants.WindowsPlatformName)]
         public static bool IsWindowsBrokerSupported()
         {
             if (!IsWindows())
@@ -109,33 +113,38 @@ namespace GitCredentialManager
         /// Check if the current Operating System is macOS.
         /// </summary>
         /// <returns>True if running on macOS, false otherwise.</returns>
+        [SupportedOSPlatformGuard(Constants.MacOSPlatformName)]
         public static bool IsMacOS()
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+            return OperatingSystem.IsMacOS();
         }
 
         /// <summary>
         /// Check if the current Operating System is Windows.
         /// </summary>
         /// <returns>True if running on Windows, false otherwise.</returns>
+        [SupportedOSPlatformGuard(Constants.WindowsPlatformName)]
         public static bool IsWindows()
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            return OperatingSystem.IsWindows();
         }
 
         /// <summary>
         /// Check if the current Operating System is Linux-based.
         /// </summary>
         /// <returns>True if running on a Linux distribution, false otherwise.</returns>
+        [SupportedOSPlatformGuard(Constants.LinuxPlatformName)]
         public static bool IsLinux()
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            return OperatingSystem.IsLinux();
         }
 
         /// <summary>
         /// Check if the current Operating System is POSIX-compliant.
         /// </summary>
         /// <returns>True if running on a POSIX-compliant Operating System, false otherwise.</returns>
+        [SupportedOSPlatformGuard(Constants.LinuxPlatformName)]
+        [SupportedOSPlatformGuard(Constants.MacOSPlatformName)]
         public static bool IsPosix()
         {
             return IsMacOS() || IsLinux();
@@ -145,6 +154,7 @@ namespace GitCredentialManager
         /// Ensure the current Operating System is macOS, fail otherwise.
         /// </summary>
         /// <exception cref="PlatformNotSupportedException">Thrown if the current OS is not macOS.</exception>
+        [SupportedOSPlatformGuard(Constants.MacOSPlatformName)]
         public static void EnsureMacOS()
         {
             if (!IsMacOS())
@@ -157,6 +167,7 @@ namespace GitCredentialManager
         /// Ensure the current Operating System is Windows, fail otherwise.
         /// </summary>
         /// <exception cref="PlatformNotSupportedException">Thrown if the current OS is not Windows.</exception>
+        [SupportedOSPlatformGuard(Constants.WindowsPlatformName)]
         public static void EnsureWindows()
         {
             if (!IsWindows())
@@ -169,6 +180,7 @@ namespace GitCredentialManager
         /// Ensure the current Operating System is Linux-based, fail otherwise.
         /// </summary>
         /// <exception cref="PlatformNotSupportedException">Thrown if the current OS is not Linux-based.</exception>
+        [SupportedOSPlatformGuard(Constants.LinuxPlatformName)]
         public static void EnsureLinux()
         {
             if (!IsLinux())
@@ -181,6 +193,8 @@ namespace GitCredentialManager
         /// Ensure the current Operating System is POSIX-compliant, fail otherwise.
         /// </summary>
         /// <exception cref="PlatformNotSupportedException">Thrown if the current OS is not POSIX-compliant.</exception>
+        [SupportedOSPlatformGuard(Constants.LinuxPlatformName)]
+        [SupportedOSPlatformGuard(Constants.MacOSPlatformName)]
         public static void EnsurePosix()
         {
             if (!IsPosix())

--- a/src/shared/Core/PlatformUtils.cs
+++ b/src/shared/Core/PlatformUtils.cs
@@ -31,7 +31,6 @@ namespace GitCredentialManager
                 return false;
             }
 
-#if NETFRAMEWORK
             // Check for machine (HKLM) registry keys for Cloud PC indicators
             // Note that the keys are only found in the 64-bit registry view
             using (Microsoft.Win32.RegistryKey hklm64 = Microsoft.Win32.RegistryKey.OpenBaseKey(Microsoft.Win32.RegistryHive.LocalMachine, Microsoft.Win32.RegistryView.Registry64))
@@ -48,9 +47,6 @@ namespace GitCredentialManager
 
                 return w365Value is not null && Guid.TryParse(partnerValue, out Guid partnerId) && partnerId == Constants.DevBoxPartnerId;
             }
-#else
-            return false;
-#endif
         }
 
         /// <summary>
@@ -197,11 +193,9 @@ namespace GitCredentialManager
         {
             if (IsWindows())
             {
-#if NETFRAMEWORK
                 var identity = System.Security.Principal.WindowsIdentity.GetCurrent();
                 var principal = new System.Security.Principal.WindowsPrincipal(identity);
                 return principal.IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator);
-#endif
             }
             else if (IsPosix())
             {
@@ -287,9 +281,6 @@ namespace GitCredentialManager
                 }
             }
 
-#if NETFRAMEWORK
-            return null;
-#else
             //
             // We cannot determine the absolute file path from argv[0]
             // (how we were launched), so let's now try to extract the
@@ -299,7 +290,6 @@ namespace GitCredentialManager
             //
             FileSystemInfo fsi = File.ResolveLinkTarget("/proc/self/exe", returnFinalTarget: false);
             return fsi?.FullName;
-#endif
         }
 
         private static string GetMacOSEntryPath()
@@ -368,12 +358,11 @@ namespace GitCredentialManager
             // However, we still need to use the old method for Windows on .NET Framework
             // and call into the Win32 API to get the correct version (regardless of app
             // compatibility settings).
-#if NETFRAMEWORK
             if (IsWindows() && RtlGetVersionEx(out RTL_OSVERSIONINFOEX osvi) == 0)
             {
                 return $"{osvi.dwMajorVersion}.{osvi.dwMinorVersion} (build {osvi.dwBuildNumber})";
             }
-#endif
+
             if (IsWindows() || IsMacOS())
             {
                 return Environment.OSVersion.Version.ToString();

--- a/src/shared/Core/Trace2Message.cs
+++ b/src/shared/Core/Trace2Message.cs
@@ -6,17 +6,46 @@ using System.Text.Json.Serialization;
 
 namespace GitCredentialManager;
 
+public class Trace2EventEnumConverter : JsonStringEnumConverter<Trace2Event>
+{
+    public Trace2EventEnumConverter()
+        : base(JsonNamingPolicy.SnakeCaseLower, false) { }
+}
+
+public class Trace2ProcessClassEnumConverter : JsonStringEnumConverter<Trace2ProcessClass>
+{
+    public Trace2ProcessClassEnumConverter()
+        : base(JsonNamingPolicy.SnakeCaseLower, false) { }
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    PropertyNameCaseInsensitive = true,
+    Converters = new[]
+    {
+        typeof(Trace2EventEnumConverter),
+        typeof(Trace2ProcessClassEnumConverter)
+    }
+)]
+[JsonSerializable(typeof(VersionMessage))]
+[JsonSerializable(typeof(StartMessage))]
+[JsonSerializable(typeof(ExitMessage))]
+[JsonSerializable(typeof(ExitMessage))]
+[JsonSerializable(typeof(ChildStartMessage))]
+[JsonSerializable(typeof(ChildExitMessage))]
+[JsonSerializable(typeof(ErrorMessage))]
+[JsonSerializable(typeof(RegionEnterMessage))]
+[JsonSerializable(typeof(RegionLeaveMessage))]
+internal partial class Trace2JsonSerializerContext : JsonSerializerContext
+{
+}
+
 public abstract class Trace2Message
 {
     private const int SourceColumnMaxWidth = 23;
     private const string NormalPerfTimeFormat = "HH:mm:ss.ffffff";
 
     protected const string EmptyPerformanceSpan =  "|     |           |           |             ";
-    protected static readonly JsonSerializerOptions JsonSerializerOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        Converters = { new JsonStringEnumConverter(new SnakeCaseNamingPolicy()) }
-    };
 
     [JsonPropertyName("event")]
     [JsonPropertyOrder(1)]
@@ -194,7 +223,7 @@ public class VersionMessage : Trace2Message
 
     public override string ToJson()
     {
-        return JsonSerializer.Serialize(this, JsonSerializerOptions);
+        return JsonSerializer.Serialize(this, Trace2JsonSerializerContext.Default.VersionMessage);
     }
 
     public override string ToNormalString()
@@ -230,7 +259,7 @@ public class StartMessage : Trace2Message
 
     public override string ToJson()
     {
-        return JsonSerializer.Serialize(this, JsonSerializerOptions);
+        return JsonSerializer.Serialize(this, Trace2JsonSerializerContext.Default.StartMessage);
     }
 
     public override string ToNormalString()
@@ -266,7 +295,7 @@ public class ExitMessage : Trace2Message
 
     public override string ToJson()
     {
-        return JsonSerializer.Serialize(this, JsonSerializerOptions);
+        return JsonSerializer.Serialize(this, Trace2JsonSerializerContext.Default.ExitMessage);
     }
 
     public override string ToNormalString()
@@ -314,7 +343,7 @@ public class ChildStartMessage : Trace2Message
 
     public override string ToJson()
     {
-        return JsonSerializer.Serialize(this, JsonSerializerOptions);
+        return JsonSerializer.Serialize(this, Trace2JsonSerializerContext.Default.ChildStartMessage);
     }
 
     public override string ToNormalString()
@@ -371,7 +400,7 @@ public class ChildExitMessage : Trace2Message
 
     public override string ToJson()
     {
-        return JsonSerializer.Serialize(this, JsonSerializerOptions);
+        return JsonSerializer.Serialize(this, Trace2JsonSerializerContext.Default.ChildExitMessage);
     }
 
     public override string ToNormalString()
@@ -415,7 +444,7 @@ public class ErrorMessage : Trace2Message
 
     public override string ToJson()
     {
-        return JsonSerializer.Serialize(this, JsonSerializerOptions);
+        return JsonSerializer.Serialize(this, Trace2JsonSerializerContext.Default.ErrorMessage);
     }
 
     public override string ToNormalString()
@@ -473,7 +502,7 @@ public class RegionEnterMessage : RegionMessage
 {
     public override string ToJson()
     {
-        return JsonSerializer.Serialize(this, JsonSerializerOptions);
+        return JsonSerializer.Serialize(this, Trace2JsonSerializerContext.Default.RegionEnterMessage);
     }
 
     public override string ToNormalString()
@@ -504,7 +533,7 @@ public class RegionLeaveMessage : RegionMessage
 
     public override string ToJson()
     {
-        return JsonSerializer.Serialize(this, JsonSerializerOptions);
+        return JsonSerializer.Serialize(this, Trace2JsonSerializerContext.Default.RegionLeaveMessage);
     }
 
     public override string ToNormalString()
@@ -526,10 +555,4 @@ public class RegionLeaveMessage : RegionMessage
     {
         return Message;
     }
-}
-
-public class SnakeCaseNamingPolicy : JsonNamingPolicy
-{
-    public override string ConvertName(string name) =>
-        name.ToSnakeCase();
 }

--- a/src/shared/Core/UI/AvaloniaUi.cs
+++ b/src/shared/Core/UI/AvaloniaUi.cs
@@ -65,22 +65,15 @@ namespace GitCredentialManager.UI
                 {
                     var appBuilder = AppBuilder.Configure<AvaloniaApp>();
 
-#if NETFRAMEWORK
                     // Set custom rendering options and modes if required
                     if (PlatformUtils.IsWindows() && _win32SoftwareRendering)
                     {
                         appBuilder.With(new Win32PlatformOptions
                             { RenderingMode = new[] { Win32RenderingMode.Software } });
                     }
-#endif
 
                     appBuilder
-#if NETFRAMEWORK
-                        .UseWin32()
-                        .UseSkia()
-#else
                         .UsePlatformDetect()
-#endif
                         .LogToTrace()
                         .SetupWithoutStarting();
 

--- a/src/shared/Core/UI/Controls/AboutWindow.axaml
+++ b/src/shared/Core/UI/Controls/AboutWindow.axaml
@@ -3,11 +3,14 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:gcm="clr-namespace:GitCredentialManager"
+        xmlns:controls="clr-namespace:GitCredentialManager.UI.Controls"
         mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="450"
         x:Class="GitCredentialManager.UI.Controls.AboutWindow"
         Title="About Git Credential Manager"
         CanResize="False" Width="300" SizeToContent="Height"
         x:Name="window"
+        x:DataType="controls:AboutWindow"
+        x:CompileBindings="True"
         Background="{DynamicResource WindowBackgroundBrush}">
     <StackPanel Margin="20">
         <Image HorizontalAlignment="Center"

--- a/src/shared/Core/UI/Controls/DialogWindow.axaml
+++ b/src/shared/Core/UI/Controls/DialogWindow.axaml
@@ -14,7 +14,9 @@
         WindowState="Normal" WindowStartupLocation="CenterScreen"
         ShowInTaskbar="True" ShowActivated="True"
         PointerPressed="Window_PointerPressed"
-        KeyUp="Window_KeyUp">
+        KeyUp="Window_KeyUp"
+        x:DataType="vm:WindowViewModel"
+        x:CompileBindings="True">
     <Design.DataContext>
         <vm:WindowViewModel/>
     </Design.DataContext>

--- a/src/shared/Core/UI/Controls/ProgressWindow.axaml
+++ b/src/shared/Core/UI/Controls/ProgressWindow.axaml
@@ -6,6 +6,7 @@
         SizeToContent="WidthAndHeight" CanResize="False" Topmost="True"
         ExtendClientAreaChromeHints="NoChrome" ExtendClientAreaToDecorationsHint="True"
         ShowInTaskbar="False" Title="Git Credential Manager" WindowStartupLocation="CenterScreen"
+        x:CompileBindings="True"
         x:Class="GitCredentialManager.UI.Controls.ProgressWindow">
     <ProgressBar Orientation="Horizontal"
                  IsIndeterminate="True"

--- a/src/shared/Core/UI/Views/CredentialsView.axaml
+++ b/src/shared/Core/UI/Views/CredentialsView.axaml
@@ -5,6 +5,8 @@
              xmlns:vm="clr-namespace:GitCredentialManager.UI.ViewModels;assembly=gcmcore"
              xmlns:converters="clr-namespace:GitCredentialManager.UI.Converters;assembly=gcmcore"
              mc:Ignorable="d" d:DesignWidth="420"
+             x:DataType="vm:CredentialsViewModel"
+             x:CompileBindings="True"
              x:Class="GitCredentialManager.UI.Views.CredentialsView">
     <Design.DataContext>
         <vm:CredentialsViewModel/>

--- a/src/shared/Core/UI/Views/DefaultAccountView.axaml
+++ b/src/shared/Core/UI/Views/DefaultAccountView.axaml
@@ -5,6 +5,8 @@
              xmlns:vm="clr-namespace:GitCredentialManager.UI.ViewModels;assembly=gcmcore"
              xmlns:converters="clr-namespace:GitCredentialManager.UI.Converters;assembly=gcmcore"
              mc:Ignorable="d" d:DesignWidth="420"
+             x:DataType="vm:DefaultAccountViewModel"
+             x:CompileBindings="True"
              x:Class="GitCredentialManager.UI.Views.DefaultAccountView">
     <Design.DataContext>
         <vm:DefaultAccountViewModel/>

--- a/src/shared/Core/UI/Views/DeviceCodeView.axaml
+++ b/src/shared/Core/UI/Views/DeviceCodeView.axaml
@@ -2,11 +2,13 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:sharedVms="clr-namespace:GitCredentialManager.UI.ViewModels;assembly=gcmcore"
+             xmlns:vm="clr-namespace:GitCredentialManager.UI.ViewModels;assembly=gcmcore"
              mc:Ignorable="d" d:DesignWidth="420"
+             x:DataType="vm:DeviceCodeViewModel"
+             x:CompileBindings="True"
              x:Class="GitCredentialManager.UI.Views.DeviceCodeView">
     <Design.DataContext>
-        <sharedVms:DeviceCodeViewModel/>
+        <vm:DeviceCodeViewModel/>
     </Design.DataContext>
     <DockPanel>
         <StackPanel DockPanel.Dock="Top" Margin="0,0,0,15">

--- a/src/shared/Core/UI/Views/OAuthView.axaml
+++ b/src/shared/Core/UI/Views/OAuthView.axaml
@@ -4,6 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:GitCredentialManager.UI.ViewModels;assembly=gcmcore"
              mc:Ignorable="d" d:DesignWidth="420"
+             x:DataType="vm:OAuthViewModel"
+             x:CompileBindings="True"
              x:Class="GitCredentialManager.UI.Views.OAuthView">
     <Design.DataContext>
         <vm:OAuthViewModel/>

--- a/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
+++ b/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
@@ -10,6 +10,9 @@
     <IsTestProject>false</IsTestProject>
     <LangVersion>latest</LangVersion>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>true</PublishTrimmed>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
+++ b/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
@@ -3,9 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net472;net8.0</TargetFrameworks>
     <RuntimeIdentifiers>win-x86;osx-x64;linux-x64;osx-arm64;linux-arm64;linux-arm</RuntimeIdentifiers>
-    <PlatformTarget Condition="'$(OSPlatform)'=='windows'">x86</PlatformTarget>
     <AssemblyName>git-credential-manager</AssemblyName>
     <RootNamespace>GitCredentialManager</RootNamespace>
     <ApplicationIcon>$(RepoAssetsPath)gcmicon.ico</ApplicationIcon>

--- a/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
+++ b/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
@@ -10,8 +10,7 @@
     <IsTestProject>false</IsTestProject>
     <LangVersion>latest</LangVersion>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
-    <PublishSingleFile>true</PublishSingleFile>
-    <PublishTrimmed>true</PublishTrimmed>
+    <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 

--- a/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
+++ b/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
@@ -14,6 +14,18 @@
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(RuntimeIdentifier.StartsWith('win-x86')' or '$(RuntimeIdentifier.StartsWith('linux-arm')'">
+    <!--
+      AOT compilation is not supported for these RIDs, so disable it and
+      instead rely on the trimming and single-file publishing options to
+      reduce file size, and ReadyToRun to improve startup performance.
+    -->
+    <PublishAot>false</PublishAot>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>true</PublishTrimmed>
+    <PublishReadyToRun>true</PublishReadyToRun>
+  </PropertyGroup>
+
   <PropertyGroup Condition="$(RuntimeIdentifier.StartsWith('win-'))">
     <!--
       Prefer to reduce the size of the single file by compressing the containing

--- a/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
+++ b/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
@@ -15,6 +15,16 @@
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(RuntimeIdentifier.StartsWith('win-'))">
+    <!--
+      Prefer to reduce the size of the single file by compressing the containing
+      assemblies. This will increase the startup time of the application a bit.
+      Keeping the on-disk size small is important because we are bundled inside
+      of Git for Windows and we don't want to bloat their distribution.
+    -->
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Atlassian.Bitbucket\Atlassian.Bitbucket.csproj" />
     <ProjectReference Include="..\GitHub\GitHub.csproj" />

--- a/src/shared/Git-Credential-Manager/Program.cs
+++ b/src/shared/Git-Credential-Manager/Program.cs
@@ -76,12 +76,7 @@ namespace GitCredentialManager
         // Required for Avalonia designer
         static AppBuilder BuildAvaloniaApp() =>
             AppBuilder.Configure<AvaloniaApp>()
-#if NETFRAMEWORK
-                .UseWin32()
-                .UseSkia()
-#else
                 .UsePlatformDetect()
-#endif
                 .LogToTrace();
     }
 }

--- a/src/shared/GitHub/GitHub.csproj
+++ b/src/shared/GitHub/GitHub.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net8.0;net472</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>GitHub</AssemblyName>
     <RootNamespace>GitHub</RootNamespace>
     <IsTestProject>false</IsTestProject>
@@ -11,10 +10,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/src/shared/GitHub/GitHubJsonSerializerContext.cs
+++ b/src/shared/GitHub/GitHubJsonSerializerContext.cs
@@ -1,0 +1,13 @@
+namespace GitHub;
+
+using System.Text.Json.Serialization;
+
+[JsonSourceGenerationOptions(
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    PropertyNameCaseInsensitive = true
+)]
+[JsonSerializable(typeof(GitHubUserInfo))]
+[JsonSerializable(typeof(GitHubMetaInfo))]
+internal partial class GitHubJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/shared/GitHub/GitHubRestApi.cs
+++ b/src/shared/GitHub/GitHubRestApi.cs
@@ -106,7 +106,7 @@ namespace GitHub
 
                     string json = await response.Content.ReadAsStringAsync();
 
-                    return JsonSerializer.Deserialize<GitHubUserInfo>(json);
+                    return JsonSerializer.Deserialize(json, GitHubJsonSerializerContext.Default.GitHubUserInfo);
                 }
             }
         }
@@ -125,7 +125,7 @@ namespace GitHub
 
                 string json = await response.Content.ReadAsStringAsync();
 
-                return JsonSerializer.Deserialize<GitHubMetaInfo>(json);
+                return JsonSerializer.Deserialize(json, GitHubJsonSerializerContext.Default.GitHubMetaInfo);
             }
         }
 

--- a/src/shared/GitHub/UI/Controls/SixDigitInput.axaml.cs
+++ b/src/shared/GitHub/UI/Controls/SixDigitInput.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using GitCredentialManager;
@@ -156,7 +157,7 @@ namespace GitHub.UI.Controls
 
         private void OnPaste()
         {
-            Text = TopLevel.GetTopLevel(this)?.Clipboard?.GetTextAsync().GetAwaiter().GetResult();
+            Text = TopLevel.GetTopLevel(this)?.Clipboard?.TryGetTextAsync().GetAwaiter().GetResult();
         }
 
         private bool MoveNext() => MoveFocus(true);

--- a/src/shared/GitHub/UI/Views/CredentialsView.axaml
+++ b/src/shared/GitHub/UI/Views/CredentialsView.axaml
@@ -6,6 +6,8 @@
              xmlns:vm="clr-namespace:GitHub.UI.ViewModels"
              xmlns:converters="clr-namespace:GitCredentialManager.UI.Converters;assembly=gcmcore"
              mc:Ignorable="d" d:DesignWidth="420"
+             x:DataType="vm:CredentialsViewModel"
+             x:CompileBindings="True"
              x:Class="GitHub.UI.Views.CredentialsView">
     <Design.DataContext>
         <vm:CredentialsViewModel/>

--- a/src/shared/GitHub/UI/Views/DeviceCodeView.axaml
+++ b/src/shared/GitHub/UI/Views/DeviceCodeView.axaml
@@ -5,6 +5,8 @@
              xmlns:controls="clr-namespace:GitHub.UI.Controls"
              xmlns:vm="clr-namespace:GitHub.UI.ViewModels"
              mc:Ignorable="d" d:DesignWidth="420"
+             x:DataType="vm:DeviceCodeViewModel"
+             x:CompileBindings="True"
              x:Class="GitHub.UI.Views.DeviceCodeView">
     <Design.DataContext>
         <vm:DeviceCodeViewModel/>

--- a/src/shared/GitHub/UI/Views/SelectAccountView.axaml
+++ b/src/shared/GitHub/UI/Views/SelectAccountView.axaml
@@ -5,6 +5,8 @@
              xmlns:controls="clr-namespace:GitHub.UI.Controls"
              xmlns:vm="clr-namespace:GitHub.UI.ViewModels"
              mc:Ignorable="d" d:DesignWidth="420"
+             x:DataType="vm:SelectAccountViewModel"
+             x:CompileBindings="True"
              x:Class="GitHub.UI.Views.SelectAccountView">
     <Design.DataContext>
         <vm:SelectAccountViewModel/>

--- a/src/shared/GitHub/UI/Views/TwoFactorView.axaml
+++ b/src/shared/GitHub/UI/Views/TwoFactorView.axaml
@@ -5,6 +5,8 @@
              xmlns:controls="clr-namespace:GitHub.UI.Controls"
              xmlns:vm="clr-namespace:GitHub.UI.ViewModels"
              mc:Ignorable="d" d:DesignWidth="420"
+             x:DataType="vm:TwoFactorViewModel"
+             x:CompileBindings="True"
              x:Class="GitHub.UI.Views.TwoFactorView">
     <Design.DataContext>
         <vm:TwoFactorViewModel/>

--- a/src/shared/GitLab/GitLab.csproj
+++ b/src/shared/GitLab/GitLab.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net8.0;net472</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>GitLab</AssemblyName>
     <RootNamespace>GitLab</RootNamespace>
     <IsTestProject>false</IsTestProject>
@@ -11,10 +10,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/src/shared/GitLab/UI/Views/CredentialsView.axaml
+++ b/src/shared/GitLab/UI/Views/CredentialsView.axaml
@@ -6,6 +6,8 @@
              xmlns:converters="clr-namespace:GitCredentialManager.UI.Converters;assembly=gcmcore"
              mc:Ignorable="d" d:DesignWidth="420"
              x:Class="GitLab.UI.Views.CredentialsView"
+             x:DataType="vm:CredentialsViewModel"
+             x:CompileBindings="True"
              x:Name="view">
     <UserControl.Resources>
         <ResourceDictionary>

--- a/src/shared/Microsoft.AzureRepos/Microsoft.AzureRepos.csproj
+++ b/src/shared/Microsoft.AzureRepos/Microsoft.AzureRepos.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net8.0;net472</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Microsoft.AzureRepos</AssemblyName>
     <RootNamespace>Microsoft.AzureRepos</RootNamespace>
     <IsTestProject>false</IsTestProject>
@@ -11,10 +10,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/src/windows/Installer.Windows/Installer.Windows.csproj
+++ b/src/windows/Installer.Windows/Installer.Windows.csproj
@@ -3,10 +3,10 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <PayloadPath>$(PlatformOutPath)Installer.Windows\bin\$(Configuration)\net472\win-x86</PayloadPath>
+    <PayloadPath>$(PlatformOutPath)Installer.Windows\bin\$(Configuration)\net8.0\win-x86</PayloadPath>
     <InnoSetupVersion>6.3.1</InnoSetupVersion>
   </PropertyGroup>
 

--- a/src/windows/Installer.Windows/layout.ps1
+++ b/src/windows/Installer.Windows/layout.ps1
@@ -39,29 +39,15 @@ mkdir -p "$PAYLOAD","$SYMBOLS" | Out-Null
 # Publish core application executables
 Write-Output "Publishing core application..."
 dotnet publish "$GCM_SRC" `
-	--framework net472 `
-	--configuration "$Configuration" `
+	--framework net8.0 `
+	--self-contained `
+	--configuration "$CONFIGURATION" `
 	--runtime win-x86 `
 	--output "$PAYLOAD"
 
 # Delete libraries that are not needed for Windows but find their way
 # into the publish output.
 Remove-Item -Path "$PAYLOAD/*.dylib" -Force -ErrorAction Ignore
-
-# Delete extraneous files that get included for other architectures
-# We only care about x86 as the core GCM executable is only targeting x86
-Remove-Item -Path "$PAYLOAD/arm/" -Recurse -Force -ErrorAction Ignore
-Remove-Item -Path "$PAYLOAD/arm64/" -Recurse -Force -ErrorAction Ignore
-Remove-Item -Path "$PAYLOAD/x64/" -Recurse -Force -ErrorAction Ignore
-Remove-Item -Path "$PAYLOAD/musl-x64/" -Recurse -Force -ErrorAction Ignore
-Remove-Item -Path "$PAYLOAD/runtimes/win-arm64/" -Recurse -Force -ErrorAction Ignore
-Remove-Item -Path "$PAYLOAD/runtimes/win-x64/" -Recurse -Force -ErrorAction Ignore
-
-# The Avalonia and MSAL binaries in these directories are already included in
-# the $PAYLOAD directory directly, so we can delete these extra copies.
-Remove-Item -Path "$PAYLOAD/x86/libSkiaSharp.dll" -Recurse -Force -ErrorAction Ignore
-Remove-Item -Path "$PAYLOAD/x86/libHarfBuzzSharp.dll" -Recurse -Force -ErrorAction Ignore
-Remove-Item -Path "$PAYLOAD/runtimes/win-x86/native/msalruntime_x86.dll" -Recurse -Force -ErrorAction Ignore
 
 # Delete localized resource assemblies - we don't localize the core GCM assembly anyway
 Get-ChildItem "$PAYLOAD" -Recurse -Include "*.resources.dll" | Remove-Item -Force -ErrorAction Ignore


### PR DESCRIPTION
*Depends on: https://github.com/git-ecosystem/git-credential-manager/pull/1417 and https://github.com/git-ecosystem/git-credential-manager/pull/1418*

Now that we no longer have to target .NET Framework on Windows, and we are using the latest .NET (.NET 8) and CoreCLR, we can take advantage of the mature and stable assembly trimming logic in the SDK.

This will allow us to reduce the number and sizes of binaries that we produce and ship. In addition we enable single-file publishing on all platforms that links all CIL code in to the same entry executable. Native dependencies remain separate files, such as the MSAL runtime, and Avalonia graphics library dependencies.

In order to enable trimming we had to:
- Use source generation in System.Text.Json
- Enable compiled bindings in Avalonia components

** TODO: size comparisons **


Fixes: https://github.com/git-ecosystem/git-credential-manager/issues/113