### PR TITLE
exit 0 instead of 1 when interaction disabled

### DIFF
--- a/src/shared/Core/Authentication/AuthenticationBase.cs
+++ b/src/shared/Core/Authentication/AuthenticationBase.cs
@@ -90,6 +90,11 @@ namespace GitCredentialManager.Authentication
         {
             if (!Context.Settings.IsInteractionAllowed)
             {
+                if (Context is CommandContext)
+                {
+                    Environment.Exit(0);
+                }
+
                 string envName = Constants.EnvironmentVariables.GcmInteractive;
                 string cfgName = string.Format("{0}.{1}",
                     Constants.GitConfiguration.Credential.SectionName,


### PR DESCRIPTION
https://git-scm.com/docs/gitcredentials

> If a helper outputs a quit attribute with a value of true or 1, no further helpers will be consulted, nor will the user be prompted (if no credential has been provided, the operation will then fail).

Some users may prefer to consult later helpers

This is also handy for running Git's own test suite which assumes this behaviour https://github.com/git/git/blob/master/t/t0303-credential-external.sh

    GIT_TEST_CREDENTIAL_HELPER=manager GCM_CREDENTIAL_STORE=cache GCM_GUI_PROMPT=0 GCM_INTERACTIVE=never GCM_AUTODETECT_TIMEOUT=0 ./t0303-credential-external.sh