### PR TITLE
platformutils: drop unnecessary netfx #ifdefs

### DIFF
--- a/src/shared/Core/PlatformUtils.cs
+++ b/src/shared/Core/PlatformUtils.cs
@@ -19,7 +19,7 @@ namespace GitCredentialManager
             string osType = GetOSType();
             string osVersion = GetOSVersion(trace2);
             string cpuArch = GetCpuArchitecture();
-            string clrVersion = GetClrVersion();
+            string clrVersion = RuntimeInformation.FrameworkDescription;
 
             return new PlatformInformation(osType, osVersion, cpuArch, clrVersion);
         }
@@ -99,11 +99,7 @@ namespace GitCredentialManager
         /// <returns>True if running on macOS, false otherwise.</returns>
         public static bool IsMacOS()
         {
-#if NETFRAMEWORK
-            return Environment.OSVersion.Platform == PlatformID.MacOSX;
-#else
             return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-#endif
         }
 
         /// <summary>
@@ -112,11 +108,7 @@ namespace GitCredentialManager
         /// <returns>True if running on Windows, false otherwise.</returns>
         public static bool IsWindows()
         {
-#if NETFRAMEWORK
-            return Environment.OSVersion.Platform == PlatformID.Win32NT;
-#else
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-#endif
         }
 
         /// <summary>
@@ -125,11 +117,7 @@ namespace GitCredentialManager
         /// <returns>True if running on a Linux distribution, false otherwise.</returns>
         public static bool IsLinux()
         {
-#if NETFRAMEWORK
-            return Environment.OSVersion.Platform == PlatformID.Unix;
-#else
             return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-#endif
         }
 
         /// <summary>
@@ -459,9 +447,6 @@ namespace GitCredentialManager
 
         private static string GetCpuArchitecture()
         {
-#if NETFRAMEWORK
-            return Environment.Is64BitOperatingSystem ? "x86-64" : "x86";
-#else
             switch (RuntimeInformation.OSArchitecture)
             {
                 case Architecture.Arm:
@@ -475,16 +460,6 @@ namespace GitCredentialManager
                 default:
                     return RuntimeInformation.OSArchitecture.ToString();
             }
-#endif
-        }
-
-        private static string GetClrVersion()
-        {
-#if NETFRAMEWORK
-            return $".NET Framework {Environment.Version}";
-#else
-            return RuntimeInformation.FrameworkDescription;
-#endif
         }
 
         #endregion


### PR DESCRIPTION
Since we're targetting .NET Framework 4.7.2 there are some unnecessary conditional compliation `#if NETFRAMEWORK` blocks. Namely around CLR and runtime/OS detection.