### PR TITLE
avalonia: actually setup Avalonia before starting

### DIFF
--- a/src/shared/Core/UI/AvaloniaUi.cs
+++ b/src/shared/Core/UI/AvaloniaUi.cs
@@ -81,7 +81,8 @@ namespace GitCredentialManager.UI
 #else
                         .UsePlatformDetect()
 #endif
-                        .LogToTrace();
+                        .LogToTrace()
+                        .SetupWithoutStarting();
 
                     appInitialized.Set();
 


### PR DESCRIPTION
In removing the Avalonia setup workaround in #1445 we forget to replace the SetupWithLifetime call with just SetupWithoutStarting!