### PR TITLE
release: include payload only in osx-arm64 tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -606,7 +606,7 @@ jobs:
           tar -C macos-osx-x64-artifacts/payload -czf osx-payload-and-symbols/gcm-osx-x64-$version.tar.gz .
           tar -C macos-osx-x64-artifacts/symbols -czf osx-payload-and-symbols/gcm-osx-x64-$version-symbols.tar.gz .
 
-          tar -C macos-osx-arm64-artifacts -czf osx-payload-and-symbols/gcm-osx-arm64-$version.tar.gz .
+          tar -C macos-osx-arm64-artifacts/payload -czf osx-payload-and-symbols/gcm-osx-arm64-$version.tar.gz .
           tar -C macos-osx-arm64-artifacts/symbols -czf osx-payload-and-symbols/gcm-osx-arm64-$version-symbols.tar.gz .
 
       - name: Archive Windows payload and symbols


### PR DESCRIPTION
Only include the payload (binaries) in the tar.gz archive for osx-arm64. Previously this was including the parent directory that captured the payload, pkg, and symbol subdirectories and children.

The osx-x64 tar.gz archive is already correctly only containing the payload.

**Illustration of discrepancy**

```text
% tree -L 1 gcm-osx-arm64-2.4.0
gcm-osx-arm64-2.4.0
├── payload
├── pkg
└── symbols

4 directories, 0 files
% tree -L 1 gcm-osx-x64-2.4.0  
gcm-osx-x64-2.4.0
├── Atlassian.Bitbucket.dll
├── Avalonia.Base.dll
├── Avalonia.Controls.dll
├── Avalonia.DesignerSupport.dll
├── Avalonia.Desktop.dll
├── Avalonia.Dialogs.dll
├── Avalonia.FreeDesktop.dll
├── Avalonia.Markup.Xaml.dll
...
```