### PR TITLE
option to exit 0 instead of 1 when interaction disabled

### DIFF
--- a/src/shared/Core/Authentication/AuthenticationBase.cs
+++ b/src/shared/Core/Authentication/AuthenticationBase.cs
@@ -90,6 +90,11 @@ namespace GitCredentialManager.Authentication
         {
             if (!Context.Settings.IsInteractionAllowed)
             {
+                if (Context.Settings.SilentExit)
+                {
+                    Environment.Exit(0);
+                }
+
                 string envName = Constants.EnvironmentVariables.GcmInteractive;
                 string cfgName = string.Format("{0}.{1}",
                     Constants.GitConfiguration.Credential.SectionName,
@@ -104,6 +109,11 @@ namespace GitCredentialManager.Authentication
         {
             if (!Context.Settings.IsGuiPromptsEnabled)
             {
+                if (Context.Settings.SilentExit)
+                {
+                    Environment.Exit(0);
+                }
+
                 Context.Trace.WriteLine($"{Constants.EnvironmentVariables.GitTerminalPrompts} is 0; GUI prompts have been disabled.");
                 throw new Trace2InvalidOperationException(Context.Trace2, "Cannot show prompt because GUI prompts have been disabled.");
             }
@@ -113,6 +123,11 @@ namespace GitCredentialManager.Authentication
         {
             if (!Context.Settings.IsTerminalPromptsEnabled)
             {
+                if (Context.Settings.SilentExit)
+                {
+                    Environment.Exit(0);
+                }
+
                 Context.Trace.WriteLine($"{Constants.EnvironmentVariables.GitTerminalPrompts} is 0; terminal prompts have been disabled.");
                 throw new Trace2InvalidOperationException(Context.Trace2, "Cannot prompt because terminal prompts have been disabled.");
             }
@@ -122,6 +137,11 @@ namespace GitCredentialManager.Authentication
         {
             if (!viewModel.WindowResult)
             {
+                if (Context.Settings.SilentExit)
+                {
+                    Environment.Exit(0);
+                }
+
                 throw new Exception("User cancelled dialog.");
             }
         }

--- a/src/shared/Core/Settings.cs
+++ b/src/shared/Core/Settings.cs
@@ -83,6 +83,11 @@ namespace GitCredentialManager
         bool IsInteractionAllowed { get; }
 
         /// <summary>
+        /// Whether to exit silently with status 0 in cases such interaction not allowed and terminal prompts disabled.
+        /// </summary>
+        bool SilentExit { get; }
+
+        /// <summary>
         /// Get if tracing has been enabled, returning trace setting value in the out parameter.
         /// </summary>
         /// <param name="value">Trace setting value.</param>
@@ -557,6 +562,9 @@ namespace GitCredentialManager
                 return defaultValue;
             }
         }
+
+        public bool SilentExit =>
+            !TryGetSetting("GCM_SILENT_EXIT", GitCredCfg.SectionName, "silentExit", out string value) || value.ToBooleanyOrDefault(false);
 
         public bool GetTracingEnabled(out string value) =>
             TryGetSetting(KnownEnvars.GcmTrace,

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -17,6 +17,8 @@ namespace GitCredentialManager.Tests.Objects
 
         public bool IsInteractionAllowed { get; set; } = true;
 
+        public bool SilentExit {get; } = false;
+
         public string Trace { get; set; }
 
         public bool IsSecretTracingEnabled { get; set; }


### PR DESCRIPTION
New option and environment variable GCM_SILENT_EXIT

Useful to run Git's credential helper test suite:

     GIT_TEST_CREDENTIAL_HELPER=manager GCM_CREDENTIAL_STORE=cache GCM_GUI_PROMPT=0 GCM_INTERACTIVE=never GCM_AUTODETECT_TIMEOUT=0 GCM_SILENT_EXIT=1  ./t0303-credential-external.sh 

Fixes #1451 

It remains to fix tests

```
not ok 11 - helper (manager) does not erase a password distinct from input
not ok 14 - helper (manager) can store empty username
not ok 18 - helper (manager) gets password_expiry_utc
not ok 19 - helper (manager) overwrites when password_expiry_utc changes
not ok 21 - helper (manager) gets oauth_refresh_token
```