### PR TITLE
Make install script compliant

### DIFF
--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -26,7 +26,7 @@ if [ -z "$installPrefix" ]; then
 fi
 
 # Ensure install directory exists
-if [! -d "$installPrefix" ]; then
+if [ ! -d "$installPrefix" ]; then
     echo "The folder $installPrefix does not exist"
     exit
 fi


### PR DESCRIPTION
This lack of space breaks the script on some less featured shells. This commit fixes it