### PR TITLE
Use Avalonia 11 generated view codes

### DIFF
--- a/src/shared/Atlassian.Bitbucket/UI/Views/CredentialsView.axaml
+++ b/src/shared/Atlassian.Bitbucket/UI/Views/CredentialsView.axaml
@@ -29,7 +29,7 @@
                        Margin="0,10,0,0"/>
         </StackPanel>
 
-        <TabControl x:Name="authModesTabControl"
+        <TabControl x:Name="_authModesTabControl"
                     VerticalContentAlignment="Center"
                     AutoScrollToSelectedItem="True"
                     Width="288"
@@ -48,7 +48,7 @@
                     <TextBlock Text="Browser" FontSize="12" />
                 </TabItem.Header>
                 <StackPanel Margin="0,15">
-                    <Button x:Name="oauthLoginButton" IsDefault="True"
+                    <Button x:Name="_oauthLoginButton" IsDefault="True"
                             HorizontalAlignment="Center" HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                             Command="{Binding OAuthCommand}"
                             Classes="accent" Height="40" Padding="15,5"
@@ -61,11 +61,11 @@
                     <TextBlock Text="Password/Token" FontSize="12" />
                 </TabItem.Header>
                 <StackPanel Margin="0,15">
-                    <TextBox x:Name="userNameTextBox" Margin="0,0,0,10"
+                    <TextBox x:Name="_userNameTextBox" Margin="0,0,0,10"
                              HorizontalAlignment="Stretch"
                              Watermark="Email or username"
                              Text="{Binding UserName}" />
-                    <TextBox x:Name="passwordTextBox" Margin="0,0,0,10"
+                    <TextBox x:Name="_passwordTextBox" Margin="0,0,0,10"
                              HorizontalAlignment="Stretch"
                              Watermark="Password or token" PasswordChar="●"
                              Text="{Binding Password}" />

--- a/src/shared/Atlassian.Bitbucket/UI/Views/CredentialsView.axaml.cs
+++ b/src/shared/Atlassian.Bitbucket/UI/Views/CredentialsView.axaml.cs
@@ -8,24 +8,9 @@ namespace Atlassian.Bitbucket.UI.Views
 {
     public partial class CredentialsView : UserControl, IFocusable
     {
-        private TabControl _tabControl;
-        private Button _oauthLoginButton;
-        private TextBox _userNameTextBox;
-        private TextBox _passwordTextBox;
-
         public CredentialsView()
         {
             InitializeComponent();
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-
-            _tabControl = this.FindControl<TabControl>("authModesTabControl");
-            _oauthLoginButton = this.FindControl<Button>("oauthLoginButton");
-            _userNameTextBox = this.FindControl<TextBox>("userNameTextBox");
-            _passwordTextBox = this.FindControl<TextBox>("passwordTextBox");
         }
 
         public void SetFocus()
@@ -37,12 +22,12 @@ namespace Atlassian.Bitbucket.UI.Views
 
             if (vm.ShowOAuth)
             {
-                _tabControl.SelectedIndex = 0;
+                _authModesTabControl.SelectedIndex = 0;
                 _oauthLoginButton.Focus();
             }
             else if (vm.ShowBasic)
             {
-                _tabControl.SelectedIndex = 1;
+                _authModesTabControl.SelectedIndex = 1;
                 if (string.IsNullOrWhiteSpace(vm.UserName))
                 {
                     // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293

--- a/src/shared/Core/UI/Controls/AboutWindow.axaml.cs
+++ b/src/shared/Core/UI/Controls/AboutWindow.axaml.cs
@@ -14,14 +14,6 @@ namespace GitCredentialManager.UI.Controls
         public AboutWindow()
         {
             InitializeComponent();
-#if DEBUG
-            this.AttachDevTools();
-#endif
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
         }
 
         private void ProjectButton_Click(object sender, RoutedEventArgs e)

--- a/src/shared/Core/UI/Controls/DialogWindow.axaml
+++ b/src/shared/Core/UI/Controls/DialogWindow.axaml
@@ -64,7 +64,7 @@
                           Content="Show Custom Chrome" Margin="5,0"/>
             </StackPanel>
 
-            <ContentControl x:Name="contentHolder" Margin="30,25,30,30"/>
+            <ContentControl x:Name="_contentHolder" Margin="30,25,30,30"/>
         </DockPanel>
     </Border>
 

--- a/src/shared/Core/UI/Controls/DialogWindow.axaml.cs
+++ b/src/shared/Core/UI/Controls/DialogWindow.axaml.cs
@@ -12,7 +12,6 @@ namespace GitCredentialManager.UI.Controls
     public partial class DialogWindow : Window
     {
         private readonly Control _view;
-        private ContentControl _contentHolder;
 
         public DialogWindow() : this(null)
         {
@@ -22,18 +21,8 @@ namespace GitCredentialManager.UI.Controls
         public DialogWindow(Control view)
         {
             InitializeComponent();
-#if DEBUG
-            this.AttachDevTools();
-#endif
             _view = view;
             _contentHolder.Content = _view;
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-
-            _contentHolder = this.FindControl<ContentControl>("contentHolder");
         }
 
         protected override void OnDataContextChanged(EventArgs e)

--- a/src/shared/Core/UI/Controls/ProgressWindow.axaml.cs
+++ b/src/shared/Core/UI/Controls/ProgressWindow.axaml.cs
@@ -14,11 +14,6 @@ public partial class ProgressWindow : Window
         InitializeComponent();
     }
 
-    private void InitializeComponent()
-    {
-        AvaloniaXamlLoader.Load(this);
-    }
-
     public static IntPtr ShowAndGetHandle(CancellationToken ct)
     {
         var tsc = new TaskCompletionSource<IntPtr>();

--- a/src/shared/Core/UI/Views/CredentialsView.axaml
+++ b/src/shared/Core/UI/Views/CredentialsView.axaml
@@ -33,10 +33,10 @@
         </StackPanel>
 
         <StackPanel Margin="20,0">
-            <TextBox x:Name="userNameTextBox"
+            <TextBox x:Name="_userNameTextBox"
                      Watermark="Username" Margin="0,0,0,10"
                      Text="{Binding UserName}"/>
-            <TextBox x:Name="passwordTextBox"
+            <TextBox x:Name="_passwordTextBox"
                      Watermark="Password" Margin="0,0,0,20"
                      PasswordChar="●"
                      Text="{Binding Password}"/>

--- a/src/shared/Core/UI/Views/CredentialsView.axaml.cs
+++ b/src/shared/Core/UI/Views/CredentialsView.axaml.cs
@@ -7,20 +7,9 @@ namespace GitCredentialManager.UI.Views
 {
     public partial class CredentialsView : UserControl, IFocusable
     {
-        private TextBox _userNameTextBox;
-        private TextBox _passwordTextBox;
-
         public CredentialsView()
         {
             InitializeComponent();
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-
-            _userNameTextBox = this.FindControl<TextBox>("userNameTextBox");
-            _passwordTextBox = this.FindControl<TextBox>("passwordTextBox");
         }
 
         public void SetFocus()

--- a/src/shared/Core/UI/Views/DefaultAccountView.axaml.cs
+++ b/src/shared/Core/UI/Views/DefaultAccountView.axaml.cs
@@ -9,10 +9,5 @@ namespace GitCredentialManager.UI.Views
         {
             InitializeComponent();
         }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
     }
 }

--- a/src/shared/Core/UI/Views/DeviceCodeView.axaml.cs
+++ b/src/shared/Core/UI/Views/DeviceCodeView.axaml.cs
@@ -9,10 +9,5 @@ namespace GitCredentialManager.UI.Views
         {
             InitializeComponent();
         }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
     }
 }

--- a/src/shared/Core/UI/Views/OAuthView.axaml.cs
+++ b/src/shared/Core/UI/Views/OAuthView.axaml.cs
@@ -9,10 +9,5 @@ namespace GitCredentialManager.UI.Views
         {
             InitializeComponent();
         }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
     }
 }

--- a/src/shared/GitHub/UI/Controls/HorizontalShadowDivider.axaml.cs
+++ b/src/shared/GitHub/UI/Controls/HorizontalShadowDivider.axaml.cs
@@ -9,10 +9,5 @@ namespace GitHub.UI.Controls
         {
             InitializeComponent();
         }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
     }
 }

--- a/src/shared/GitHub/UI/Controls/SixDigitInput.axaml
+++ b/src/shared/GitHub/UI/Controls/SixDigitInput.axaml
@@ -18,11 +18,11 @@
         </Style>
     </UserControl.Styles>
     <StackPanel Orientation="Horizontal">
-        <TextBox x:Name="one"/>
-        <TextBox x:Name="two"/>
-        <TextBox x:Name="three"/>
-        <TextBox x:Name="four"/>
-        <TextBox x:Name="five"/>
-        <TextBox x:Name="six" Margin="0"/>
+        <TextBox x:Name="_one"/>
+        <TextBox x:Name="_two"/>
+        <TextBox x:Name="_three"/>
+        <TextBox x:Name="_four"/>
+        <TextBox x:Name="_five"/>
+        <TextBox x:Name="_six" Margin="0"/>
     </StackPanel>
 </UserControl>

--- a/src/shared/GitHub/UI/Controls/SixDigitInput.axaml.cs
+++ b/src/shared/GitHub/UI/Controls/SixDigitInput.axaml.cs
@@ -28,20 +28,15 @@ namespace GitHub.UI.Controls
         public SixDigitInput()
         {
             InitializeComponent();
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
 
             _textBoxes = new[]
             {
-                this.FindControl<TextBox>("one"),
-                this.FindControl<TextBox>("two"),
-                this.FindControl<TextBox>("three"),
-                this.FindControl<TextBox>("four"),
-                this.FindControl<TextBox>("five"),
-                this.FindControl<TextBox>("six"),
+                _one,
+                _two,
+                _three,
+                _four,
+                _five,
+                _six,
             };
 
             foreach (TextBox textBox in _textBoxes)

--- a/src/shared/GitHub/UI/Views/CredentialsView.axaml
+++ b/src/shared/GitHub/UI/Views/CredentialsView.axaml
@@ -39,7 +39,7 @@
                     Classes="hyperlink"/>
         </WrapPanel>
 
-        <TabControl x:Name="authModesTabControl"
+        <TabControl x:Name="_authModesTabControl"
                     VerticalContentAlignment="Center"
                     AutoScrollToSelectedItem="True">
             <TabControl.Styles>
@@ -62,7 +62,7 @@
                     <TextBlock Text="{Binding OAuthModeTitle}" FontSize="12" />
                 </TabItem.Header>
                 <StackPanel Margin="0,10">
-                    <Button x:Name="signInBrowserButton"
+                    <Button x:Name="_signInBrowserButton"
                             Content="Sign in with your browser"
                             IsDefault="True"
                             Command="{Binding SignInBrowserCommand}"
@@ -70,7 +70,7 @@
                             HorizontalAlignment="Center"
                             Margin="0,0,0,10"
                             Classes="accent"/>
-                    <Button x:Name="signInDeviceButton"
+                    <Button x:Name="_signInDeviceButton"
                             Content="Sign in with a code"
                             Command="{Binding SignInDeviceCommand}"
                             IsVisible="{Binding ShowDeviceLogin}"
@@ -85,7 +85,7 @@
                     <TextBlock Text="Token" FontSize="12" />
                 </TabItem.Header>
                 <StackPanel Margin="0,10">
-                    <TextBox x:Name="tokenTextBox"
+                    <TextBox x:Name="_tokenTextBox"
                              Watermark="Personal access token" Margin="0,0,0,10"
                              PasswordChar="●"
                              Text="{Binding Token}"/>
@@ -103,10 +103,10 @@
                     <TextBlock Text="Password" FontSize="12" />
                 </TabItem.Header>
                 <StackPanel Margin="0,10">
-                    <TextBox x:Name="userNameTextBox"
+                    <TextBox x:Name="_userNameTextBox"
                              Watermark="Username or email" Margin="0,0,0,10"
                              Text="{Binding UserName}"/>
-                    <TextBox x:Name="passwordTextBox"
+                    <TextBox x:Name="_passwordTextBox"
                              Watermark="Password" Margin="0,0,0,10"
                              PasswordChar="●"
                              Text="{Binding Password}"/>

--- a/src/shared/GitHub/UI/Views/CredentialsView.axaml.cs
+++ b/src/shared/GitHub/UI/Views/CredentialsView.axaml.cs
@@ -8,28 +8,9 @@ namespace GitHub.UI.Views
 {
     public partial class CredentialsView : UserControl, IFocusable
     {
-        private TabControl _tabControl;
-        private Button _browserButton;
-        private Button _deviceButton;
-        private TextBox _tokenTextBox;
-        private TextBox _userNameTextBox;
-        private TextBox _passwordTextBox;
-
         public CredentialsView()
         {
             InitializeComponent();
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-
-            _tabControl = this.FindControl<TabControl>("authModesTabControl");
-            _browserButton = this.FindControl<Button>("signInBrowserButton");
-            _deviceButton = this.FindControl<Button>("signInDeviceButton");
-            _tokenTextBox = this.FindControl<TextBox>("tokenTextBox");
-            _userNameTextBox = this.FindControl<TextBox>("userNameTextBox");
-            _passwordTextBox = this.FindControl<TextBox>("passwordTextBox");
         }
 
         public void SetFocus()
@@ -43,17 +24,17 @@ namespace GitHub.UI.Views
             // and focus on the button/text box
             if (vm.ShowBrowserLogin)
             {
-                _tabControl.SelectedIndex = 0;
-                _browserButton.Focus();
+                _authModesTabControl.SelectedIndex = 0;
+                _signInBrowserButton.Focus();
             }
             else if (vm.ShowDeviceLogin)
             {
-                _tabControl.SelectedIndex = 0;
-                _deviceButton.Focus();
+                _authModesTabControl.SelectedIndex = 0;
+                _signInDeviceButton.Focus();
             }
             else if (vm.ShowTokenLogin)
             {
-                _tabControl.SelectedIndex = 1;
+                _authModesTabControl.SelectedIndex = 1;
                 // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293
                 if (!PlatformUtils.IsMacOS())
                     _tokenTextBox.Focus();
@@ -61,7 +42,7 @@ namespace GitHub.UI.Views
             }
             else if (vm.ShowBasicLogin)
             {
-                _tabControl.SelectedIndex = 2;
+                _authModesTabControl.SelectedIndex = 2;
                 if (string.IsNullOrWhiteSpace(vm.UserName))
                 {
                     // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293

--- a/src/shared/GitHub/UI/Views/DeviceCodeView.axaml.cs
+++ b/src/shared/GitHub/UI/Views/DeviceCodeView.axaml.cs
@@ -9,10 +9,5 @@ namespace GitHub.UI.Views
         {
             InitializeComponent();
         }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
     }
 }

--- a/src/shared/GitHub/UI/Views/SelectAccountView.axaml.cs
+++ b/src/shared/GitHub/UI/Views/SelectAccountView.axaml.cs
@@ -13,11 +13,6 @@ public partial class SelectAccountView : UserControl
         InitializeComponent();
     }
 
-    private void InitializeComponent()
-    {
-        AvaloniaXamlLoader.Load(this);
-    }
-
     private void ListBox_OnDoubleTapped(object sender, TappedEventArgs e)
     {
         if (DataContext is SelectAccountViewModel { SelectedAccount: not null } vm)

--- a/src/shared/GitHub/UI/Views/TwoFactorView.axaml
+++ b/src/shared/GitHub/UI/Views/TwoFactorView.axaml
@@ -27,7 +27,7 @@
         <StackPanel Orientation="Vertical" VerticalAlignment="Center">
             <TextBlock Text="{Binding Description}" Margin="0,0,0,20"
                        TextWrapping="Wrap" TextAlignment="Center"/>
-            <controls:SixDigitInput x:Name="codeInput"
+            <controls:SixDigitInput x:Name="_codeInput"
                                     Text="{Binding Code}"
                                     Margin="0,0,0,20"
                                     HorizontalAlignment="Center"/>

--- a/src/shared/GitHub/UI/Views/TwoFactorView.axaml.cs
+++ b/src/shared/GitHub/UI/Views/TwoFactorView.axaml.cs
@@ -8,18 +8,9 @@ namespace GitHub.UI.Views
 {
     public partial class TwoFactorView : UserControl, IFocusable
     {
-        private SixDigitInput _codeInput;
-
         public TwoFactorView()
         {
             InitializeComponent();
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-
-            _codeInput = this.FindControl<SixDigitInput>("codeInput");
         }
 
         public void SetFocus()

--- a/src/shared/GitLab/UI/Views/CredentialsView.axaml
+++ b/src/shared/GitLab/UI/Views/CredentialsView.axaml
@@ -52,7 +52,7 @@
                     Classes="hyperlink"/>
         </WrapPanel>
 
-        <TabControl x:Name="authModesTabControl"
+        <TabControl x:Name="_authModesTabControl"
                     VerticalContentAlignment="Center"
                     AutoScrollToSelectedItem="True">
             <TabControl.Styles>
@@ -70,7 +70,7 @@
                     <TextBlock Text="{Binding OAuthModeTitle}" FontSize="12" />
                 </TabItem.Header>
                 <StackPanel Margin="0,10">
-                    <Button x:Name="signInBrowserButton"
+                    <Button x:Name="_signInBrowserButton"
                             Content="Sign in with your browser"
                             IsDefault="True"
                             Command="{Binding SignInBrowserCommand}"
@@ -87,10 +87,10 @@
                     <TextBlock Text="Token" FontSize="12" />
                 </TabItem.Header>
                 <StackPanel Margin="0,10">
-                    <TextBox x:Name="patUserNameTextBox"
+                    <TextBox x:Name="_patUserNameTextBox"
                              Watermark="Username or email (optional)" Margin="0,0,0,10"
                              Text="{Binding TokenUserName}"/>
-                    <TextBox x:Name="tokenTextBox"
+                    <TextBox x:Name="_tokenTextBox"
                              Watermark="Personal access token" Margin="0,0,0,10"
                              PasswordChar="●"
                              Text="{Binding Token}"/>
@@ -108,10 +108,10 @@
                     <TextBlock Text="Password" FontSize="12" />
                 </TabItem.Header>
                 <StackPanel Margin="0,10">
-                    <TextBox x:Name="userNameTextBox"
+                    <TextBox x:Name="_userNameTextBox"
                              Watermark="Username or email" Margin="0,0,0,10"
                              Text="{Binding UserName}"/>
-                    <TextBox x:Name="passwordTextBox"
+                    <TextBox x:Name="_passwordTextBox"
                              Watermark="Password" Margin="0,0,0,10"
                              PasswordChar="●"
                              Text="{Binding Password}"/>

--- a/src/shared/GitLab/UI/Views/CredentialsView.axaml.cs
+++ b/src/shared/GitLab/UI/Views/CredentialsView.axaml.cs
@@ -8,28 +8,9 @@ namespace GitLab.UI.Views
 {
     public partial class CredentialsView : UserControl, IFocusable
     {
-        private TabControl _tabControl;
-        private Button _browserButton;
-        private TextBox _tokenTextBox;
-        private TextBox _patUserNameTextBox;
-        private TextBox _userNameTextBox;
-        private TextBox _passwordTextBox;
-
         public CredentialsView()
         {
             InitializeComponent();
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-
-            _tabControl = this.FindControl<TabControl>("authModesTabControl");
-            _browserButton = this.FindControl<Button>("signInBrowserButton");
-            _patUserNameTextBox = this.FindControl<TextBox>("patUserNameTextBox");
-            _tokenTextBox = this.FindControl<TextBox>("tokenTextBox");
-            _userNameTextBox = this.FindControl<TextBox>("userNameTextBox");
-            _passwordTextBox = this.FindControl<TextBox>("passwordTextBox");
         }
 
         public void SetFocus()
@@ -43,19 +24,19 @@ namespace GitLab.UI.Views
             // and focus on the button/text box
             if (vm.ShowBrowserLogin)
             {
-                _tabControl.SelectedIndex = 0;
-                _browserButton.Focus();
+                _authModesTabControl.SelectedIndex = 0;
+                _signInBrowserButton.Focus();
             }
             else if (vm.ShowTokenLogin)
             {
-                _tabControl.SelectedIndex = 1;
+                _authModesTabControl.SelectedIndex = 1;
                 // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293
                 if (!PlatformUtils.IsMacOS())
                     _tokenTextBox.Focus();
             }
             else if (vm.ShowBasicLogin)
             {
-                _tabControl.SelectedIndex = 2;
+                _authModesTabControl.SelectedIndex = 2;
                 if (string.IsNullOrWhiteSpace(vm.UserName))
                 {
                     // Workaround: https://github.com/git-ecosystem/git-credential-manager/issues/1293


### PR DESCRIPTION
Avalonia 11 automatically generates some view codes.

- Properties for controls with `x:Name` or `Name`.
- `InitializeComponent()` method to initialize such properties.
- DevTools for debug builds.

This change uses such generated codes in views and reduces manual efforts. The names of the controls are changed to start with underscore, so that the generated property names align with the naming style in this project.