### PR TITLE
Consider domain matched when no domain hint is provided in GitHub account filtering

### DIFF
--- a/src/shared/GitHub.Tests/GitHubAuthChallengeTests.cs
+++ b/src/shared/GitHub.Tests/GitHubAuthChallengeTests.cs
@@ -86,9 +86,9 @@ public class GitHubAuthChallengeTests
     [InlineData("", false)]
     [InlineData(" ", false)]
     [InlineData("alice", true)]
-    [InlineData("alice_contoso", false)]
-    [InlineData("alice_CONTOSO", false)]
-    [InlineData("alice_contoso_alt", false)]
+    [InlineData("alice_contoso", true)]
+    [InlineData("alice_CONTOSO", true)]
+    [InlineData("alice_contoso_alt", true)]
     [InlineData("pj_nitin", true)]
     [InlineData("up_the_irons", true)]
     public void GitHubAuthChallenge_IsDomainMember_NoHint(string userName, bool expected)

--- a/src/shared/GitHub/GitHubAuthChallenge.cs
+++ b/src/shared/GitHub/GitHubAuthChallenge.cs
@@ -73,10 +73,15 @@ public class GitHubAuthChallenge : IEquatable<GitHubAuthChallenge>
             return false;
         }
 
+        if (string.IsNullOrWhiteSpace(Domain))
+        {
+            return true;
+        }
+
         int delim = userName.LastIndexOf('_');
         if (delim < 0)
         {
-            return string.IsNullOrWhiteSpace(Domain);
+            return false;
         }
 
         // Check for users that contain underscores but are not EMU logins


### PR DESCRIPTION
Several users mentioned that GitHub account filtering is not working. It turns out domain hint is not provided in their user cases. This change considers domain is matched in that case.