### PR TITLE
Alpine Linux: avoid requiring unsupported OpenSSL version

### DIFF
--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -189,7 +189,7 @@ case "$distribution" in
         $sudo_cmd apk update
 
         # Install dotnet/GCM dependencies.
-        install_packages apk add "curl git icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib which bash coreutils gcompat"
+        install_packages apk add "curl git icu-libs krb5-libs libgcc libintl libssl3 libstdc++ zlib which bash coreutils gcompat"
 
         ensure_dotnet_installed
     ;;


### PR DESCRIPTION
OpenSSL v1.1.* is no longer provided by Alpine Linux v3.19 according to https://pkgs.alpinelinux.org/packages?name=libssl1.1&branch=v3.19&repo=&arch=&maintainer=

However, OpenSSL v3.* is, so let's use that instead.

[EDIT] This fixes [the currently-broken `validate-install-from-source` build](https://github.com/git-ecosystem/git-credential-manager/actions/runs/7862395316/job/21451819126#step:5:46) (see [here](https://github.com/dscho/Git-Credential-Manager-Core/actions/runs/7864697417/job/21456763533) for a successful build of that workflow at the tip of this PR's branch).