### PR TITLE
Do not query local bindings if outside repo in Azure Repos

### DIFF
--- a/src/shared/Microsoft.AzureRepos/AzureReposBindingManager.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposBindingManager.cs
@@ -93,11 +93,15 @@ namespace Microsoft.AzureRepos
 
             _trace.WriteLine($"Looking up organization binding for '{orgName}'...");
 
-            // NOT using the short-circuiting OR operator here on purpose - we need both branches to be evaluated
-            if (config.TryGet(GitConfigurationLevel.Local, GitConfigurationType.Raw,
-                    orgKey, out string localUser) |
-                config.TryGet(GitConfigurationLevel.Global, GitConfigurationType.Raw,
-                    orgKey, out string globalUser))
+            string localUser = null;
+            bool hasLocal = _git.IsInsideRepository() && // Can only check local config if we are inside a repository
+                            config.TryGet(GitConfigurationLevel.Local, GitConfigurationType.Raw,
+                                orgKey, out localUser);
+
+            bool hasGlobal = config.TryGet(GitConfigurationLevel.Global, GitConfigurationType.Raw,
+                orgKey, out string globalUser);
+
+            if (hasLocal || hasGlobal)
             {
                 return new AzureReposBinding(orgName, globalUser, localUser);
             }


### PR DESCRIPTION
Do not attempt to query for an organisation/user binding in the local repository configuration if we're not currently inside of a repository!

This will prevent the warning message from Git's standard error stream from flowing to our caller's stderr stream when GCM tries to use the `--local` option in a `git config` call.

cc @markphip 