### PR TITLE
install-from-source: update libssl for alpine

### DIFF
--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -186,10 +186,16 @@ case "$distribution" in
         ensure_dotnet_installed
     ;;
     alpine)
+        libssl_version=libssl3
+
+        if [[ $(echo "$version 3.15" | awk '{print ($1 < $2)}') -ne 0 ]]; then
+            libssl_version=libssl1.1
+        fi
+
         $sudo_cmd apk update
 
         # Install dotnet/GCM dependencies.
-        install_packages apk add "curl git icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib which bash coreutils gcompat"
+        install_packages apk add "curl git icu-libs krb5-libs libgcc libintl $libssl_version libstdc++ zlib which bash coreutils gcompat"
 
         ensure_dotnet_installed
     ;;


### PR DESCRIPTION
The `validate-install-from-source` workflow is currently failing [1]. According
to [2] and [3], the solution is to upgrade the libssl version from 1.1 to 3, as
version 1.1 is out of support. Since this version is only supported on Alpine
3.15 and later, we detect the version of Alpine the user is running on and set
this dependency version accordingly.
    
1: https://github.com/git-ecosystem/git-credential-manager/actions/runs/8604126129
2: https://stackoverflow.com/questions/77640298/dockerfile-unable-to-select-packages-linux-alpine
3: https://learn.microsoft.com/en-us/dotnet/core/install/linux-alpine