### PR TITLE
install-from-source.sh: fix libssl Alpine pkgs

### DIFF
--- a/.github/workflows/validate-install-from-source.yml
+++ b/.github/workflows/validate-install-from-source.yml
@@ -24,6 +24,7 @@ jobs:
         - image: tgagor/centos-stream
         - image: redhat/ubi8
         - image: alpine
+        - image: alpine:3.14.10
         - image: opensuse/leap
         - image: opensuse/tumbleweed
         - image: registry.suse.com/suse/sle15:15.4.27.11.31

--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -137,6 +137,10 @@ print_unsupported_distro() {
     echo "See https://gh.io/gcm/linux for details."
 }
 
+version_at_least() {
+	[ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$1" ]
+}
+
 sudo_cmd=
 
 # If the user isn't root, we need to use `sudo` for certain commands
@@ -189,7 +193,14 @@ case "$distribution" in
         $sudo_cmd apk update
 
         # Install dotnet/GCM dependencies.
-        install_packages apk add "curl git icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib which bash coreutils gcompat"
+        # Alpine 3.14 and earlier need libssl1.1, while later versions need libssl3.
+        if ( version_at_least "3.15" $version ) then
+            libssl_pkg="libssl3"
+        else
+            libssl_pkg="libssl1.1"
+        fi
+
+        install_packages apk add "curl git icu-libs krb5-libs libgcc libintl $libssl_pkg libstdc++ zlib which bash coreutils gcompat"
 
         ensure_dotnet_installed
     ;;


### PR DESCRIPTION
The version of libssl available in the Alpine package feeds changed with version 3.15. The latest libssl package is 1.1 in 3.14.x and earlier, but newer versions only have libssl3.

Add a check for the Alpine version in the install from source script and switch between installing libssl3 and libssl1.1 depending on the distro version.

Also add another entry to the test matrix of distributions to include a 3.14.x Alpine version.

This replaces the two other PRs that aimed to address this issue:
- https://github.com/git-ecosystem/git-credential-manager/pull/1535
- https://github.com/git-ecosystem/git-credential-manager/pull/1574

Tested the updated workflow here: https://github.com/git-ecosystem/git-credential-manager/actions/runs/8698286553/job/23855027830