### PR TITLE
azrepos: fix error message to stderr when not in repo

### DIFF
--- a/src/shared/TestInfrastructure/Objects/TestGit.cs
+++ b/src/shared/TestInfrastructure/Objects/TestGit.cs
@@ -33,6 +33,8 @@ namespace GitCredentialManager.Tests.Objects
             throw new NotImplementedException();
         }
 
+        bool IGit.IsInsideRepository() => !string.IsNullOrWhiteSpace(CurrentRepository);
+
         string IGit.GetCurrentRepository() => CurrentRepository;
 
         IEnumerable<GitRemote> IGit.GetRemotes() => Remotes;


### PR DESCRIPTION
Suppress the standard error stream from Git when checking if we're inside a repository or not, because the failure message is otherwise printed to the user's console when we are not (which is what we're trying to decide!).

Note that we normally don't suppress or redirect the standard error stream for Git commands as the user may have enabled Git tracing (v1 or v2) to the stderr file and we don't want to mute these for all calls.

Example before:

```shell
% pwd
/Users/mjcheetham
% gcm azure-repos list
fatal: not a git repository (or any of the parent directories): .git
devdiv:
  (global) -> USER@DOMAIN
```

Example now:
```shell
% pwd
/Users/mjcheetham
% gcm azure-repos list
devdiv:
  (global) -> USER@DOMAIN
```