### PR TITLE
adds httpPath variable for Bitbucket DC

### DIFF
--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketHelperTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketHelperTest.cs
@@ -1,7 +1,6 @@
 using Atlassian.Bitbucket.DataCenter;
 using GitCredentialManager;
 using Moq;
-using Newtonsoft.Json.Linq;
 using System;
 using Xunit;
 

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketHelperTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketHelperTest.cs
@@ -1,3 +1,7 @@
+using Atlassian.Bitbucket.DataCenter;
+using GitCredentialManager;
+using Moq;
+using Newtonsoft.Json.Linq;
 using System;
 using Xunit;
 
@@ -5,6 +9,10 @@ namespace Atlassian.Bitbucket.Tests
 {
     public class BitbucketHelperTest
     {
+
+
+        private Mock<ISettings> settings = new Mock<ISettings>(MockBehavior.Loose);
+
         [Theory]
         [InlineData(null, false)]
         [InlineData("", false)]
@@ -55,6 +63,37 @@ namespace Atlassian.Bitbucket.Tests
         {
             bool actual = BitbucketHelper.IsBitbucketOrg(new Uri(str));
             Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        // old behavior
+        [InlineData("http://bitbucket.org", null, "http://bitbucket.org:80")]
+        [InlineData("https://bitbucket.org", null, "https://bitbucket.org:443")]
+        [InlineData("https://bitbucket.org/project/repo.git", null, "https://bitbucket.org:443/project")]
+        // with http path
+        [InlineData("http://bitbucket.org", "/bitbucket", "http://bitbucket.org:80/bitbucket")]
+        [InlineData("https://bitbucket.org", "/bitbucket", "https://bitbucket.org:443/bitbucket")]
+        // usehttppath takes preference over httpPath
+        [InlineData("https://bitbucket.org/project/repo.git", "/bitbucket", "https://bitbucket.org:443/project")]
+        public void BitbucketHelper_GetBaseUri(string uri, string httpPath, string expected)
+        {
+
+            settings.Setup(s => s.RemoteUri).Returns(new Uri(uri));
+            if(httpPath != null)
+            {
+                MockHttpPath(httpPath);
+            }
+            var actual = BitbucketHelper.GetBaseUri(settings.Object);
+            Assert.Equal(expected, actual);
+        }
+
+        private string MockHttpPath(string value)
+        {
+            settings.Setup(s => s.TryGetSetting(
+                DataCenterConstants.EnvironmentVariables.HttpPath,
+                Constants.GitConfiguration.Credential.SectionName, DataCenterConstants.GitConfiguration.Credential.HttpPath,
+                out value)).Returns(true);
+            return value;
         }
     }
 }

--- a/src/shared/Atlassian.Bitbucket/BitbucketHelper.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketHelper.cs
@@ -1,17 +1,39 @@
 ﻿using System;
+using System.Net.NetworkInformation;
 using Atlassian.Bitbucket.Cloud;
+using Atlassian.Bitbucket.DataCenter;
 using GitCredentialManager;
 
 namespace Atlassian.Bitbucket
 {
     public static class BitbucketHelper
     {
-        public static string GetBaseUri(Uri remoteUri)
+
+        private static bool TryGetHttpPath(ISettings settings, out string httpPath)
         {
+            return settings.TryGetSetting(
+                DataCenterConstants.EnvironmentVariables.HttpPath,
+                Constants.GitConfiguration.Credential.SectionName, DataCenterConstants.GitConfiguration.Credential.HttpPath,
+                out httpPath);
+        }
+
+        public static string GetBaseUri(ISettings settings)
+        {
+            var remoteUri = settings?.RemoteUri;
+            if (remoteUri == null)
+            {
+                throw new ArgumentException("RemoteUri must be defined to generate Bitbucket DC Rest/OAuth endpoints");
+            }
+
             var pathParts = remoteUri.PathAndQuery.Split('/');
             var pathPart = remoteUri.PathAndQuery.StartsWith("/") ? pathParts[1] : pathParts[0];
             var path = !string.IsNullOrWhiteSpace(pathPart) ? "/" + pathPart : null;
+            if(path == null && TryGetHttpPath(settings, out string httpPath) && !string.IsNullOrEmpty(httpPath))
+            {
+                path = httpPath;
+            }
             return $"{remoteUri.Scheme}://{remoteUri.Host}:{remoteUri.Port}{path}";
+
         }
 
         public static bool IsBitbucketOrg(InputArguments input)     

--- a/src/shared/Atlassian.Bitbucket/BitbucketHelper.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net.NetworkInformation;
 using Atlassian.Bitbucket.Cloud;
 using Atlassian.Bitbucket.DataCenter;
 using GitCredentialManager;

--- a/src/shared/Atlassian.Bitbucket/DataCenter/BitbucketOAuth2Client.cs
+++ b/src/shared/Atlassian.Bitbucket/DataCenter/BitbucketOAuth2Client.cs
@@ -68,15 +68,9 @@ namespace Atlassian.Bitbucket.DataCenter
 
         private static OAuth2ServerEndpoints GetEndpoints(ISettings settings)
         {
-            var remoteUri = settings.RemoteUri;
-            if (remoteUri == null)
-            {
-                throw new ArgumentException("RemoteUri must be defined to generate Bitbucket DC OAuth2 endpoint Urls");
-            }
-
             return new OAuth2ServerEndpoints(
-                new Uri(BitbucketHelper.GetBaseUri(remoteUri) + "/rest/oauth2/latest/authorize"),
-                new Uri(BitbucketHelper.GetBaseUri(remoteUri) + "/rest/oauth2/latest/token")
+                new Uri(BitbucketHelper.GetBaseUri(settings) + "/rest/oauth2/latest/authorize"),
+                new Uri(BitbucketHelper.GetBaseUri(settings) + "/rest/oauth2/latest/token")
                 );
         }
     }

--- a/src/shared/Atlassian.Bitbucket/DataCenter/BitbucketOAuth2Client.cs
+++ b/src/shared/Atlassian.Bitbucket/DataCenter/BitbucketOAuth2Client.cs
@@ -3,8 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using GitCredentialManager;
 using GitCredentialManager.Authentication.OAuth;
 

--- a/src/shared/Atlassian.Bitbucket/DataCenter/BitbucketRestApi.cs
+++ b/src/shared/Atlassian.Bitbucket/DataCenter/BitbucketRestApi.cs
@@ -141,13 +141,7 @@ namespace Atlassian.Bitbucket.DataCenter
         {
             get
             {
-                var remoteUri = _context.Settings?.RemoteUri;
-                if (remoteUri == null)
-                {
-                    throw new ArgumentException("RemoteUri must be defined to generate Bitbucket DC OAuth2 endpoint Urls");
-                }
-
-                return new Uri(BitbucketHelper.GetBaseUri(remoteUri) + "/rest/");
+                return new Uri(BitbucketHelper.GetBaseUri(_context.Settings) + "/rest/");
             }
         }
     }

--- a/src/shared/Atlassian.Bitbucket/DataCenter/DataCenterConstants.cs
+++ b/src/shared/Atlassian.Bitbucket/DataCenter/DataCenterConstants.cs
@@ -30,6 +30,7 @@ namespace Atlassian.Bitbucket.DataCenter
             public const string OAuthClientId = "GCM_BITBUCKET_DATACENTER_CLIENTID";
             public const string OAuthClientSecret = "GCM_BITBUCKET_DATACENTER_CLIENTSECRET";
             public const string OAuthRedirectUri = "GCM_BITBUCKET_DATACENTER_OAUTH_REDIRECTURI";
+            public const string HttpPath = "GCM_BITBUCKET_DATACENTER_HTTP_PATH";
         }
 
         public static class GitConfiguration
@@ -39,6 +40,7 @@ namespace Atlassian.Bitbucket.DataCenter
                 public const string OAuthClientId = "bitbucketDataCenterOAuthClientId";
                 public const string OAuthClientSecret = "bitbucketDataCenterOAuthClientSecret";
                 public const string OAuthRedirectUri = "bitbucketDataCenterOauthRedirectUri";
+                public const string HttpPath = "bitbucketDataCenterHttpPath";
             }
         }
     }


### PR DESCRIPTION
A workaround for #1460. Allows setting a path for Bitbucket DC so Rest and OAuth endpoints can be relative to the host.

Adds a benefit that Bitbucket DC OAuth can be fully configured via registry settings. Previously we needed useHttpPath which, as far as i know, cannot be set via registry. 

