### PR TITLE
diagnose: avoid poluting stderr stream in Git diagnostic

### DIFF
--- a/src/shared/Core/Diagnostics/GitDiagnostic.cs
+++ b/src/shared/Core/Diagnostics/GitDiagnostic.cs
@@ -19,9 +19,16 @@ namespace GitCredentialManager.Diagnostics
             log.AppendLine($"Git version is '{gitVersion.OriginalString}'");
 
             log.Append("Locating current repository...");
-            string thisRepo =CommandContext.Git.GetCurrentRepository();
+            if (!CommandContext.Git.IsInsideRepository())
+            {
+                log.AppendLine("Not inside a Git repository.");
+            }
+            else
+            {
+                string thisRepo = CommandContext.Git.GetCurrentRepository();
+                log.AppendLine($"Git repository at '{thisRepo}'");
+            }
             log.AppendLine(" OK");
-            log.AppendLine(thisRepo is null ? "Not inside a Git repository." : $"Git repository at '{thisRepo}'");
 
             log.Append("Listing all Git configuration...");
             ChildProcess configProc = CommandContext.Git.CreateProcess("config --list --show-origin");


### PR DESCRIPTION
Avoid poluting the standard error stream with a 'fatal' Git error message during the Git diagnostic run as part of the `diagnose` command.

When checking if we are inside of a Git repo we should be using an explicit check for `IGit::IsInsideRepository` rather than trying to get the current repo path and checking for null.