### PR TITLE
Update MSAL and Avalonia dependencies

### DIFF
--- a/src/shared/Core/Core.csproj
+++ b/src/shared/Core/Core.csproj
@@ -14,24 +14,24 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
     <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.60.3" />
-    <PackageReference Include="Avalonia.Win32" Version="11.0.4" />
+    <PackageReference Include="Avalonia.Win32" Version="11.0.10" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.4" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.10" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.60.3" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.60.3" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="Avalonia" Version="11.0.4" />
-    <PackageReference Include="Avalonia.Skia" Version="11.0.4" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.4" />
+    <PackageReference Include="Avalonia" Version="11.0.10" />
+    <PackageReference Include="Avalonia.Skia" Version="11.0.10" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.10" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.4" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.10" />
   </ItemGroup>
 
 </Project>

--- a/src/shared/Core/Core.csproj
+++ b/src/shared/Core/Core.csproj
@@ -13,7 +13,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
-    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.54.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.60.3" />
     <PackageReference Include="Avalonia.Win32" Version="11.0.4" />
   </ItemGroup>
 
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.54.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.28.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.60.3" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.60.3" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Avalonia" Version="11.0.4" />
     <PackageReference Include="Avalonia.Skia" Version="11.0.4" />


### PR DESCRIPTION
Update the various MSAL.NET packages to the latest version of 4.60.3.
Update the various AvaloniaUI packages to the latest stable version of 11.0.10.

Replaces #1588