### PR TITLE
release: capture nuget signing cert

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -464,13 +464,18 @@ jobs:
           -u "https://github.com/git-ecosystem/git-credential-manager" `
           -acst $env:ACST `
           -acsi $env:ACSI `
-          -acss $env:ACSS
+          -acss $env:ACSS `
+          -acsc nuget-signing-certificate.cer
 
-    - name: Publish signed package
+        mv nupkg/* .
+
+    - name: Publish signed package and certificate
       uses: actions/upload-artifact@v4
       with:
         name: dotnet-tool-sign
-        path: nupkg/*.nupkg
+        path: |
+          *.nupkg
+          *.cer
 
 # ================================
 #           Validate


### PR DESCRIPTION
NuGet requires that signed packages have a matching [registered signing certificate](https://learn.microsoft.com/en-us/nuget/create-packages/sign-a-package#register-the-certificate-on-nugetorg). Update release workflow to capture this certificate from the Sign CLI tool and upload it as a release artifact. Note that this means we will need to manually update this certificate to the [`git-credential-manager` organization](https://www.nuget.org/profiles/git-credential-manager) in nuget.org prior to publishing the .NET tool version for each release.

Tested the end-to-end flow in [my fork](https://github.com/ldennington/git-credential-manager) which resulted in publication of [this package](https://int.nugettest.org/packages/git-credential-manager) to the NuGet QA Gallery.