### PR TITLE
Update code signing with latest Azure Trusted Signing tools/tasks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,27 +353,20 @@ jobs:
       env:
         AST: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
         ASC: ${{ secrets.AZURE_STORAGE_CONTAINER }}
-        SCT: ${{ secrets.SIGN_CLI_TOOL }}
+        SCT: 'Sign.Cli-alpha.zip'
       run: |
         az storage blob download --file sign-cli.zip --auth-mode login `
           --account-name $env:AST --container-name $env:ASC --name $env:SCT
         Expand-Archive -Path sign-cli.zip -DestinationPath .\sign-cli
 
     - name: Sign payload
-      env:
-        ACST: ${{ secrets.AZURE_TENANT_ID }}
-        ACSI: ${{ secrets.AZURE_CLIENT_ID }}
-        ACSS: ${{ secrets.AZURE_CLIENT_SECRET }}
       run: |
-        ./sign-cli/sign.exe code azcodesign payload/* `
-          -acsu https://wus2.codesigning.azure.net/ `
-          -acsa git-fundamentals-signing `
-          -acscp git-fundamentals-windows-signing `
+        ./sign-cli/sign.exe code trusted-signing payload/* `
+          -tse https://wus2.codesigning.azure.net/ `
+          -tsa git-fundamentals-signing `
+          -tscp git-fundamentals-windows-signing `
           -d "Git Fundamentals Windows Signing Certificate" `
-          -u "https://github.com/git-ecosystem/git-credential-manager" `
-          -acst $env:ACST `
-          -acsi $env:ACSI `
-          -acss $env:ACSS
+          -u "https://github.com/git-ecosystem/git-credential-manager"
 
     - name: Lay out signed payload, images, and symbols
       shell: bash
@@ -444,28 +437,21 @@ jobs:
       env:
         AST: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
         ASC: ${{ secrets.AZURE_STORAGE_CONTAINER }}
-        SCT: ${{ secrets.SIGN_CLI_TOOL }}
+        SCT: 'Sign.Cli-alpha.zip'
       run: |
         az storage blob download --file sign-cli.zip --auth-mode login `
           --account-name $env:AST --container-name $env:ASC --name $env:SCT
         Expand-Archive -Path sign-cli.zip -DestinationPath .\sign-cli
 
     - name: Sign package
-      env:
-        ACST: ${{ secrets.AZURE_TENANT_ID }}
-        ACSI: ${{ secrets.AZURE_CLIENT_ID }}
-        ACSS: ${{ secrets.AZURE_CLIENT_SECRET }}
       run: |
-        ./sign-cli/sign.exe code azcodesign nupkg/* `
-          -acsu https://wus2.codesigning.azure.net/ `
-          -acsa git-fundamentals-signing `
-          -acscp git-fundamentals-windows-signing `
+        ./sign-cli/sign.exe code trusted-signing nupkg/* `
+          -tse https://wus2.codesigning.azure.net/ `
+          -tsa git-fundamentals-signing `
+          -tscp git-fundamentals-windows-signing `
           -d "Git Fundamentals Windows Signing Certificate" `
           -u "https://github.com/git-ecosystem/git-credential-manager" `
-          -acst $env:ACST `
-          -acsi $env:ACSI `
-          -acss $env:ACSS `
-          -acsc nuget-signing-certificate.cer
+          -co nuget-signing-certificate.cer
 
         mv nupkg/* .
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,10 +177,10 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     - name: Sign payload files with Azure Code Signing
-      uses: azure/azure-code-signing-action@v0.3.1
+      uses: azure/trusted-signing-action@v0.3.20
       with:
         endpoint: https://wus2.codesigning.azure.net/
-        code-signing-account-name: git-fundamentals-signing
+        trusted-signing-account-name: git-fundamentals-signing
         certificate-profile-name: git-fundamentals-windows-signing
         files-folder: ${{ github.workspace }}\payload
         files-folder-filter: exe,dll
@@ -204,10 +204,10 @@ jobs:
          -Destination $env:GITHUB_WORKSPACE\installers
 
     - name: Sign installers with Azure Code Signing
-      uses: azure/azure-code-signing-action@v0.3.1
+      uses: azure/trusted-signing-action@v0.3.20
       with:
         endpoint: https://wus2.codesigning.azure.net/
-        code-signing-account-name: git-fundamentals-signing
+        trusted-signing-account-name: git-fundamentals-signing
         certificate-profile-name: git-fundamentals-windows-signing
         files-folder: ${{ github.workspace }}\installers
         files-folder-filter: exe


### PR DESCRIPTION
- Update to the latest version of the GitHub Action (the `azure/azure-code-signing-action` action has been replaced by the `azure/trusted-signing-action` one).

- Deploy a forked version of the `Sign.Cli` tool for Trusted Signing, which includes the ability to export the certificate. The fork can be found here https://github.com/mjcheetham/sign/tree/export-opt, and the PR to submit this change upstream here https://github.com/dotnet/sign/pull/734.

With these changes we are now completely secret/credential free, and rely on federation only.