### PR TITLE
Use published sign.exe CLI and 3rd part certificate extractor tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,9 +358,7 @@ jobs:
         sign.exe code trusted-signing payload/* `
           -tse https://wus2.codesigning.azure.net/ `
           -tsa git-fundamentals-signing `
-          -tscp git-fundamentals-windows-signing `
-          -d "Git Fundamentals Windows Signing Certificate" `
-          -u "https://github.com/git-ecosystem/git-credential-manager"
+          -tscp git-fundamentals-windows-signing
 
     - name: Lay out signed payload, images, and symbols
       shell: bash
@@ -436,9 +434,7 @@ jobs:
         sign.exe code trusted-signing nupkg/* `
           -tse https://wus2.codesigning.azure.net/ `
           -tsa git-fundamentals-signing `
-          -tscp git-fundamentals-windows-signing `
-          -d "Git Fundamentals Windows Signing Certificate" `
-          -u "https://github.com/git-ecosystem/git-credential-manager"
+          -tscp git-fundamentals-windows-signing
 
         mv nupkg/* .
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,19 +349,13 @@ jobs:
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-    - name: Download/extract Sign CLI tool
-      env:
-        AST: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
-        ASC: ${{ secrets.AZURE_STORAGE_CONTAINER }}
-        SCT: 'Sign.Cli-alpha.zip'
+    - name: Install sign CLI tool
       run: |
-        az storage blob download --file sign-cli.zip --auth-mode login `
-          --account-name $env:AST --container-name $env:ASC --name $env:SCT
-        Expand-Archive -Path sign-cli.zip -DestinationPath .\sign-cli
+        dotnet tool install -g --version 0.9.1-beta.24325.5
 
     - name: Sign payload
       run: |
-        ./sign-cli/sign.exe code trusted-signing payload/* `
+        sign.exe code trusted-signing payload/* `
           -tse https://wus2.codesigning.azure.net/ `
           -tsa git-fundamentals-signing `
           -tscp git-fundamentals-windows-signing `
@@ -433,19 +427,13 @@ jobs:
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-    - name: Download/extract Sign CLI tool
-      env:
-        AST: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
-        ASC: ${{ secrets.AZURE_STORAGE_CONTAINER }}
-        SCT: 'Sign.Cli-alpha.zip'
+    - name: Install sign CLI tool
       run: |
-        az storage blob download --file sign-cli.zip --auth-mode login `
-          --account-name $env:AST --container-name $env:ASC --name $env:SCT
-        Expand-Archive -Path sign-cli.zip -DestinationPath .\sign-cli
+        dotnet tool install -g --version 0.9.1-beta.24325.5
 
     - name: Sign package
       run: |
-        ./sign-cli/sign.exe code trusted-signing nupkg/* `
+        sign.exe code trusted-signing nupkg/* `
           -tse https://wus2.codesigning.azure.net/ `
           -tsa git-fundamentals-signing `
           -tscp git-fundamentals-windows-signing `

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -450,10 +450,20 @@ jobs:
           -tsa git-fundamentals-signing `
           -tscp git-fundamentals-windows-signing `
           -d "Git Fundamentals Windows Signing Certificate" `
-          -u "https://github.com/git-ecosystem/git-credential-manager" `
-          -co nuget-signing-certificate.cer
+          -u "https://github.com/git-ecosystem/git-credential-manager"
 
         mv nupkg/* .
+
+    # Remove this once NuGet supports the subscriber identity validation EKU:
+    # https://github.com/NuGet/NuGetGallery/issues/10027
+    - name: Extract signing certificate from package
+      shell: pwsh
+      run: |
+        dotnet tool install --global Knapcode.CertificateExtractor
+        $nupkg = gci *.nupkg
+        nuget-cert-extractor --file $nupkg --output certs --code-signing --author --leaf
+        $cert = gci certs\*.cer
+        mv $cert .\nuget-signing.cer
 
     - name: Publish signed package and certificate
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Use a 3rd party tool to extract the NuGet signing certificate for upload rather than relying on an option added to the sign.exe tool in a private fork. At the same time let's use the `dotnet tool install` command to acquire the code signing tool, rather than rely on our Azure blob store.

Also let's drop the `-d` and `-u` options from the sign.exe CLI; they are no longer required ([source](https://github.com/dotnet/sign/pull/734#issuecomment-2196589982)).