### PR TITLE
release: fix signing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,7 +351,7 @@ jobs:
 
     - name: Install sign CLI tool
       run: |
-        dotnet tool install -g --version 0.9.1-beta.24325.5
+        dotnet tool install -g sign --version 0.9.1-beta.24325.5
 
     - name: Sign payload
       run: |
@@ -427,7 +427,7 @@ jobs:
 
     - name: Install sign CLI tool
       run: |
-        dotnet tool install -g --version 0.9.1-beta.24325.5
+        dotnet tool install -g sign --version 0.9.1-beta.24325.5
 
     - name: Sign package
       run: |


### PR DESCRIPTION
Fix the `dotnet tool install` command for code signing in the release workflow.

D'oh!