### PR TITLE
Fix/Docs: frdsktop secret service 404

### DIFF
--- a/docs/credstores.md
+++ b/docs/credstores.md
@@ -257,7 +257,7 @@ that you take with you and use full-disk encryption.
 [cmdkey]: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmdkey
 [credential-store]: configuration.md#credentialcredentialstore
 [credential-cache]: https://git-scm.com/docs/git-credential-cache
-[freedesktop-secret-service]: https://specifications.freedesktop.org/secret-service/
+[freedesktop-secret-service]: https://specifications.freedesktop.org/secret-service-spec/0.2/description.html
 [gcm-credential-store]: environment.md#GCM_CREDENTIAL_STORE
 [git-credential-store]: https://git-scm.com/docs/git-credential-store
 [mac-keychain-management]: https://support.apple.com/en-gb/guide/mac-help/mchlf375f392/mac


### PR DESCRIPTION
The current link for the header about `freedesktop-secret-service` results in a 404
https://specifications.freedesktop.org/secret-service/

The best replacement I found was
New 'good' link: https://specifications.freedesktop.org/secret-service-spec/0.2/description.html

the official freedesktop page has SSL issues resulting in a unreadable layout
Alt 'bad' link: https://freedesktop.org/wiki/Specifications/secret-storage-spec/secrets-api-0.1.html


