### PR TITLE
Remove misleading error message

### DIFF
--- a/src/shared/GitLab/GitLabHostProvider.cs
+++ b/src/shared/GitLab/GitLabHostProvider.cs
@@ -41,9 +41,6 @@ namespace GitLab
                 return false;
             }
 
-            // We do not support unencrypted HTTP communications to GitLab,
-            // but we report `true` here for HTTP so that we can show a helpful
-            // error message for the user in `CreateCredentialAsync`.
             if (!StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "http") &&
                 !StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "https"))
             {
@@ -93,13 +90,6 @@ namespace GitLab
         public override async Task<ICredential> GenerateCredentialAsync(InputArguments input)
         {
             ThrowIfDisposed();
-
-            // We should not allow unencrypted communication and should inform the user
-            if (StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "http"))
-            {
-                throw new Trace2Exception(Context.Trace2,
-                    "Unencrypted HTTP is not supported for GitHub. Ensure the repository remote URL is using HTTPS.");
-            }
 
             Uri remoteUri = input.GetRemoteUri();
 


### PR DESCRIPTION
GitLab is used for internal hosting, which may often use unencrpted http. This error message is misleading, as the process continues and works regardless, and also falsely mentions Github instead of GitLab.

Got a new PC at work. First clone of the GitLab repo I'm working on went like this:

 - run git clone on an http GitLab instance, in my case I ran `git clone http://gitlab.company-local-domain.de/group/project LocalRepo-Name`
   Note:
    - http, not https
    - GitLab
 - Get the following error message:
   fatal: Unencrypted HTTP is not supported for GitHub. Ensure the repository remote URL is using HTTPS.
 - Get prompted for and enter credentials
 - Get warning about redirecting to .git URL
 - Cloning commences and finishes successfully