### PR TITLE
docs: update Secret Service links

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1022,7 +1022,7 @@ Defaults to disabled.
 [devbox]: https://azure.microsoft.com/en-us/products/dev-box
 [enterprise-config]: enterprise-config.md
 [envars]: environment.md
-[freedesktop-ss]: https://specifications.freedesktop.org/secret-service/
+[freedesktop-ss]: https://specifications.freedesktop.org/secret-service-spec/
 [gcm-allow-windowsauth]: environment.md#GCM_ALLOW_WINDOWSAUTH
 [gcm-authority]: environment.md#GCM_AUTHORITY-deprecated
 [gcm-autodetect-timeout]: environment.md#GCM_AUTODETECT_TIMEOUT

--- a/docs/credstores.md
+++ b/docs/credstores.md
@@ -257,7 +257,7 @@ that you take with you and use full-disk encryption.
 [cmdkey]: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmdkey
 [credential-store]: configuration.md#credentialcredentialstore
 [credential-cache]: https://git-scm.com/docs/git-credential-cache
-[freedesktop-secret-service]: https://specifications.freedesktop.org/secret-service/
+[freedesktop-secret-service]: https://specifications.freedesktop.org/secret-service-spec/
 [gcm-credential-store]: environment.md#GCM_CREDENTIAL_STORE
 [git-credential-store]: https://git-scm.com/docs/git-credential-store
 [mac-keychain-management]: https://support.apple.com/en-gb/guide/mac-help/mchlf375f392/mac

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1182,7 +1182,7 @@ Defaults to disabled.
 [credential-trace-msauth]: configuration.md#credentialtracemsauth
 [default-values]: enterprise-config.md
 [devbox]: https://azure.microsoft.com/en-us/products/dev-box
-[freedesktop-ss]: https://specifications.freedesktop.org/secret-service/
+[freedesktop-ss]: https://specifications.freedesktop.org/secret-service-spec/
 [gcm]: usage.md
 [gcm-interactive]: #gcm_interactive
 [gcm-credential-store]: #gcm_credential_store


### PR DESCRIPTION
The links to FreeDesktop's Secret Service specifications has changed, it would seem.