### PR TITLE
Add no-op credential storage option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -585,6 +585,7 @@ _(unset)_|Windows: `wincredman`, macOS: `keychain`, Linux: _(none)_|-
 `gpg`|Use GPG to store encrypted files that are compatible with the [pass][pass] (requires GPG and `pass` to initialize the store).|macOS, Linux
 `cache`|Git's built-in [credential cache][credential-cache].|macOS, Linux
 `plaintext`|Store credentials in plaintext files (**UNSECURE**). Customize the plaintext store location with [`credential.plaintextStorePath`][credential-plaintextstorepath].|Windows, macOS, Linux
+`none`|Do not store credentials via GCM.|Windows, macOS, Linux
 
 #### Example
 

--- a/docs/credstores.md
+++ b/docs/credstores.md
@@ -9,6 +9,7 @@ There are several options for storing credentials that GCM supports:
 - GPG/[`pass`][passwordstore] compatible files
 - Git's built-in [credential cache][credential-cache]
 - Plaintext files
+- Passthrough/no-op (no credential store)
 
 The default credential stores on macOS and Windows are the macOS Keychain and
 the Windows Credential Manager, respectively.
@@ -250,6 +251,31 @@ If you chose to use this credential store, it is recommended you set the
 permissions on this directory such that no other users or applications can
 access files within. If possible, use a path that exists on an external volume
 that you take with you and use full-disk encryption.
+
+## Passthrough/no-op (no credential store)
+
+**Available on:** _Windows, macOS, Linux_
+
+**:warning: .**
+
+```batch
+SET GCM_CREDENTIAL_STORE="none"
+```
+
+or
+
+```shell
+git config --global credential.credentialStore none
+```
+
+This option disables the internal credential store. All operations to store or
+retrieve credentials will do nothing, and will return success. This is useful if
+you want to use a different credential store, chained in sequence via Git
+configuration, and don't want GCM to store credentials.
+
+Note that you'll want to ensure that another credential helper is placed before
+GCM in the `credential.helper` Git configuration or else you will be prompted to
+enter your credentials every time you interact with a remote repository.
 
 [access-windows-credential-manager]: https://support.microsoft.com/en-us/windows/accessing-credential-manager-1b5c916a-6a16-889f-8581-fc16e8165ac0
 [aws-cloudshell]: https://aws.amazon.com/cloudshell/

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -716,6 +716,7 @@ _(unset)_|Windows: `wincredman`, macOS: `keychain`, Linux: _(none)_|-
 `gpg`|Use GPG to store encrypted files that are compatible with the [`pass` utility][passwordstore] (requires GPG and `pass` to initialize the store).|macOS, Linux
 `cache`|Git's built-in [credential cache][git-credential-cache].|Windows, macOS, Linux
 `plaintext`|Store credentials in plaintext files (**UNSECURE**). Customize the plaintext store location with [`GCM_PLAINTEXT_STORE_PATH`][gcm-plaintext-store-path].|Windows, macOS, Linux
+`none`|Do not store credentials via GCM.|Windows, macOS, Linux
 
 #### Windows
 

--- a/src/shared/Core/Constants.cs
+++ b/src/shared/Core/Constants.cs
@@ -38,6 +38,7 @@ namespace GitCredentialManager
             public const string SecretService = "secretservice";
             public const string Plaintext = "plaintext";
             public const string Cache = "cache";
+            public const string None = "none";
         }
 
         public static class RegexPatterns

--- a/src/shared/Core/CredentialStore.cs
+++ b/src/shared/Core/CredentialStore.cs
@@ -100,6 +100,10 @@ namespace GitCredentialManager
                     _backingStore = new PlaintextCredentialStore(_context.FileSystem, plainStoreRoot, ns);
                     break;
 
+                case StoreNames.None:
+                    _backingStore = new NullCredentialStore();
+                    break;
+
                 default:
                     var sb = new StringBuilder();
                     sb.AppendLine(string.IsNullOrWhiteSpace(credStoreName)
@@ -168,6 +172,9 @@ namespace GitCredentialManager
 
             sb.AppendFormat("  {1,-13} : store credentials in plain-text files (UNSECURE){0}",
                 Environment.NewLine, StoreNames.Plaintext);
+
+            sb.AppendFormat("  {1, -13} : disable internal credential storage{0}",
+                Environment.NewLine, StoreNames.None);
         }
 
         private void ValidateWindowsCredentialManager()

--- a/src/shared/Core/NullCredentialStore.cs
+++ b/src/shared/Core/NullCredentialStore.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+namespace GitCredentialManager;
+
+/// <summary>
+/// Credential store that does nothing. This is useful when you want to disable internal credential storage
+/// and only use another helper configured in Git to store credentials.
+/// </summary>
+public class NullCredentialStore : ICredentialStore
+{
+    public IList<string> GetAccounts(string service) => Array.Empty<string>();
+
+    public ICredential Get(string service, string account) => null;
+
+    public void AddOrUpdate(string service, string account, string secret) { }
+
+    public bool Remove(string service, string account) => false;
+}


### PR DESCRIPTION
Add a null/no-op credential store option that, as the name suggests, does nothing. This can be useful if the user wants to use another credential helper, configured in-front of GCM via Git, to store credentials.

Example config:

```ini
[credential]
	credentialStore = none
	helper = /bin/my-awesome-helper
	helper = /usr/local/bin/git-credential-manager
```

In this example, the `my-awesome-helper` will be consulted first to retrieve existing credentials before GCM, and will be asked to store any credentials generated by GCM.

Fixes https://github.com/git-ecosystem/git-credential-manager/issues/1283