### PR TITLE
ci: move to "more official" tgagor/centos

### DIFF
--- a/.github/workflows/validate-install-from-source.yml
+++ b/.github/workflows/validate-install-from-source.yml
@@ -21,7 +21,6 @@ jobs:
         # tgagor is a contributor who pushes updated images weekly, which should
         # be sufficient for our validation needs.
         - image: tgagor/centos
-        - image: tgagor/centos-stream
         - image: redhat/ubi8
         - image: alpine
         - image: alpine:3.14.10


### PR DESCRIPTION
There used to be two separate images, `tgagor/centos` and `tgagor/centos-stream`, relating to the CentOS and the CentOS Stream distribution, respectively.

However, CentOS ceased to exist, and CentOS Stream is the only remaining actively-maintained project of the two.

As per https://hub.docker.com/r/tgagor/centos-stream:

	Moved to new repo

	I created new repo for both stream and non stream, variants. I
	push some images here, but it's better to switch to:
	https://hub.docker.com/r/tgagor/centos

Essentially, the CentOS Stream images are now available as `tgagor/centos`. So let's drop the `tgagor/centos-stream` one.