### PR TITLE
ci: add Mariner and Arch Linux

### DIFF
--- a/.github/workflows/validate-install-from-source.yml
+++ b/.github/workflows/validate-install-from-source.yml
@@ -27,6 +27,8 @@ jobs:
         - image: opensuse/leap
         - image: opensuse/tumbleweed
         - image: registry.suse.com/suse/sle15:15.4.27.11.31
+        - image: archlinux
+        - image: mcr.microsoft.com/cbl-mariner/base/core:2.0
     container: ${{matrix.vector.image}}
     steps:
       - run: |
@@ -34,6 +36,9 @@ jobs:
             zypper -n install tar gzip
           elif [[ ${{matrix.vector.image}} == *"centos"* ]]; then
             dnf install which -y
+          elif [[ ${{matrix.vector.image}} == *"mariner"* ]]; then
+            GNUPGHOME=/root/.gnupg tdnf update -y &&
+            GNUPGHOME=/root/.gnupg tdnf install tar -y # needed for `actions/checkout`
           fi
 
       - uses: actions/checkout@v4

--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -228,7 +228,7 @@ case "$distribution" in
         $sudo_cmd tdnf update -y
 
         # Install dotnet/GCM dependencies.
-        install_packages tdnf install "curl git krb5-libs libicu openssl-libs zlib findutils which bash"
+        install_packages tdnf install "curl git krb5-libs libicu openssl-libs zlib findutils which bash awk"
 
         ensure_dotnet_installed
     ;;

--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -63,7 +63,7 @@ install_packages() {
 
     for package in $packages; do
         # Ensure we don't stomp on existing installations.
-        if [ ! -z $(which $package) ]; then
+        if type $package >/dev/null 2>&1; then
             continue
         fi
 

--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -228,7 +228,7 @@ case "$distribution" in
         $sudo_cmd tdnf update -y
 
         # Install dotnet/GCM dependencies.
-        install_packages tdnf install "curl git krb5-libs libicu openssl-libs zlib findutils which bash awk"
+        install_packages tdnf install "curl ca-certificates git krb5-libs libicu openssl-libs zlib findutils which bash awk"
 
         ensure_dotnet_installed
     ;;


### PR DESCRIPTION
After dropping the now-obsolete `tgagor/centos-stream` value from the matrix in #1746, let's now instead add the "somewhat" supported Mariner Linux and Arch Linux to the testing matrix.