### PR TITLE
don't require runtime to be set to install from source

### DIFF
--- a/src/linux/Packaging.Linux/build.sh
+++ b/src/linux/Packaging.Linux/build.sh
@@ -49,27 +49,9 @@ if [ ! -d "$INSTALL_PREFIX" ]; then
     mkdir -p "$INSTALL_PREFIX"
 fi
 
-# Fall back to host architecture if no explicit runtime is given.
-if test -z "$RUNTIME"; then
-    HOST_ARCH="`dpkg-architecture -q DEB_HOST_ARCH`"
-
-    case $HOST_ARCH in
-        amd64)
-            RUNTIME="linux-x64"
-            ;;
-        arm64)
-            RUNTIME="linux-arm64"
-            ;;
-        armhf)
-            RUNTIME="linux-arm"
-            ;;
-        *)
-            die "Could not determine host architecture!"
-            ;;
-    esac
+if [ ! -z "$RUNTIME" ]; then
+    echo "Building for runtime ${RUNTIME}"
 fi
-
-echo "Building for runtime ${RUNTIME}"
 
 # Perform pre-execution checks
 CONFIGURATION="${CONFIGURATION:=Debug}"

--- a/src/linux/Packaging.Linux/layout.sh
+++ b/src/linux/Packaging.Linux/layout.sh
@@ -44,10 +44,6 @@ PROJ_OUT="$OUT/linux/Packaging.Linux"
 # Build parameters
 FRAMEWORK=net8.0
 
-if [ -z "$RUNTIME" ]; then
-    die "--runtime was not set"
-fi
-
 # Perform pre-execution checks
 CONFIGURATION="${CONFIGURATION:=Debug}"
 
@@ -76,13 +72,22 @@ fi
 
 # Publish core application executables
 echo "Publishing core application..."
-$DOTNET_ROOT/dotnet publish "$GCM_SRC" \
-	--configuration="$CONFIGURATION" \
-	--framework="$FRAMEWORK" \
-	--runtime="$RUNTIME" \
-	--self-contained \
-	-p:PublishSingleFile=true \
-	--output="$(make_absolute "$PAYLOAD")" || exit 1
+if [ -z "$RUNTIME" ]; then
+    $DOTNET_ROOT/dotnet publish "$GCM_SRC" \
+        --configuration="$CONFIGURATION" \
+        --framework="$FRAMEWORK" \
+        --self-contained \
+        -p:PublishSingleFile=true \
+        --output="$(make_absolute "$PAYLOAD")" || exit 1
+else
+    $DOTNET_ROOT/dotnet publish "$GCM_SRC" \
+        --configuration="$CONFIGURATION" \
+        --framework="$FRAMEWORK" \
+        --runtime="$RUNTIME" \
+        --self-contained \
+        -p:PublishSingleFile=true \
+        --output="$(make_absolute "$PAYLOAD")" || exit 1
+fi
 
 # Collect symbols
 echo "Collecting managed symbols..."

--- a/src/linux/Packaging.Linux/pack.sh
+++ b/src/linux/Packaging.Linux/pack.sh
@@ -100,6 +100,26 @@ INSTALL_TO="$DEBROOT/usr/local/share/gcm-core/"
 LINK_TO="$DEBROOT/usr/local/bin/"
 mkdir -p "$DEBROOT/DEBIAN" "$INSTALL_TO" "$LINK_TO" || exit 1
 
+# Fall back to host architecture if no explicit runtime is given.
+if test -z "$RUNTIME"; then
+    HOST_ARCH="`dpkg-architecture -q DEB_HOST_ARCH`"
+
+    case $HOST_ARCH in
+        amd64)
+            RUNTIME="linux-x64"
+            ;;
+        arm64)
+            RUNTIME="linux-arm64"
+            ;;
+        armhf)
+            RUNTIME="linux-arm"
+            ;;
+        *)
+            die "Could not determine host architecture!"
+            ;;
+    esac
+fi
+
 # Determine architecture for debian control file from the runtime architecture
 case $RUNTIME in
     linux-x64)


### PR DESCRIPTION
@mjcheetham this should fix this https://github.com/git-ecosystem/git-credential-manager/pull/1633#issuecomment-2459973610

it also fixes as a side effect the alpine linux build from source being built against the wrong [glibc linux (linux-x64)](https://github.com/git-ecosystem/git-credential-manager/actions/runs/11573830139/job/32216761503#step:5:142) runtime instead of the correct [musl linux (linux-musl-x64)](https://github.com/theofficialgman/git-credential-manager/actions/runs/11706600286/job/32604070640#step:5:142) runtime

full test run: https://github.com/theofficialgman/git-credential-manager/actions/runs/11706600286