### PR TITLE
fix(bitbucket): detect expired OAuth credentials

### DIFF
--- a/src/shared/Atlassian.Bitbucket/BitbucketHostProvider.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketHostProvider.cs
@@ -443,11 +443,11 @@ namespace Atlassian.Bitbucket
                     _context.Trace.WriteLine(message);
                     _context.Trace.WriteException(ex);
                     _context.Trace2.WriteError(message);
-                    return false;
                 }
             }
 
-            return true;
+            // auth refresh will handle expired token (or invalid authModes configuration)
+            return false;
         }
 
         private static string GetServiceName(Uri remoteUri)


### PR DESCRIPTION
The code flow for **OAuth-only** authMode must report back credential expiry correctly.

If neither of the supported modes is selected, this constitutes an invalid configuration anyway.
Better let more sophisticated existing parts of the code (token refresh/create) deal with this inconsistency.

Resolves #1775