### PR TITLE
Show login URI in the terminal so that user could open it elsewhere

### DIFF
--- a/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
+++ b/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
@@ -99,6 +99,8 @@ namespace GitCredentialManager.Authentication.OAuth
             set => _codeGenerator = value;
         }
 
+        public Uri RedirectUri => _redirectUri;
+
         #region IOAuth2Client
 
         public async Task<OAuth2AuthorizationCodeResult> GetAuthorizationCodeAsync(IEnumerable<string> scopes,

--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -437,6 +437,7 @@ namespace GitHub
 
             // Write message to the terminal (if any is attached) for some feedback that we're waiting for a web response
             Context.Terminal.WriteLine("info: please complete authentication in your browser...");
+            Context.Terminal.WriteLine($"uri: {oauthClient.RedirectUri}");
 
             OAuth2AuthorizationCodeResult authCodeResult =
                 await oauthClient.GetAuthorizationCodeAsync(scopes, browser, queryParams, CancellationToken.None);

--- a/src/shared/GitLab/GitLabAuthentication.cs
+++ b/src/shared/GitLab/GitLabAuthentication.cs
@@ -278,6 +278,7 @@ namespace GitLab
 
             // Write message to the terminal (if any is attached) for some feedback that we're waiting for a web response
             Context.Terminal.WriteLine("info: please complete authentication in your browser...");
+            Context.Terminal.WriteLine($"uri: {oauthClient.RedirectUri}");
 
             OAuth2AuthorizationCodeResult authCodeResult =
                 await oauthClient.GetAuthorizationCodeAsync(scopes, browser, CancellationToken.None);


### PR DESCRIPTION
fixes https://github.com/git-ecosystem/git-credential-manager/issues/1825