### PR TITLE
fix(generic): save new refresh_token value

### DIFF
--- a/src/shared/Core/GenericHostProvider.cs
+++ b/src/shared/Core/GenericHostProvider.cs
@@ -161,7 +161,7 @@ namespace GitCredentialManager
                     // Store new refresh token if we have been given one
                     if (!string.IsNullOrWhiteSpace(refreshResult.RefreshToken))
                     {
-                        Context.CredentialStore.AddOrUpdate(refreshService, refreshToken.Account, refreshToken.Password);
+                        Context.CredentialStore.AddOrUpdate(refreshService, refreshToken.Account, refreshResult.RefreshToken);
                     }
 
                     // Return the new access token


### PR DESCRIPTION
Missing the update of single-use-tokens will lead to continuous re-registration requirement for GCM.

Check in statement is done correctly for new value.
The update request just used the wrong variable.