### PR TITLE
Add support for Workload Identity Federation

### DIFF
--- a/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureDevOpsConstants.cs
@@ -46,6 +46,9 @@ namespace Microsoft.AzureRepos
             public const string ServicePrincipalCertificateThumbprint = "GCM_AZREPOS_SP_CERT_THUMBPRINT";
             public const string ServicePrincipalCertificateSendX5C = "GCM_AZREPOS_SP_CERT_SEND_X5C";
             public const string ManagedIdentity = "GCM_AZREPOS_MANAGEDIDENTITY";
+            public const string FederatedIdentity = "GCM_AZREPOS_FEDERATEDIDENTITY";
+            public const string FederatedIdentityTenantId = "GCM_AZREPOS_FEDERATEDIDENTITY_TENANTID";
+            public const string FederatedIdentityClientAppId = "GCM_AZREPOS_FEDERATEDIDENTITY_CLIENTAPPID";
         }
 
         public static class GitConfiguration
@@ -62,6 +65,9 @@ namespace Microsoft.AzureRepos
                 public const string ServicePrincipalCertificateThumbprint = "azreposServicePrincipalCertificateThumbprint";
                 public const string ServicePrincipalCertificateSendX5C = "azreposServicePrincipalCertificateSendX5C";
                 public const string ManagedIdentity = "azreposManagedIdentity";
+                public const string FederatedIdentity = "azreposFederatedIdentity";
+                public const string FederatedIdentityTenantId = "azreposFederatedIdentityTenantId";
+                public const string FederatedIdentityClientAppId = "azreposFederatedIdentityClientAppId";
             }
         }
     }


### PR DESCRIPTION
Add the ability to use Workload Identity Federation in GCM, accessing code in an Azure DevOps instance connected to Tenant A using a VM in Tenant B.

An image showing the successful checkout of a sample repo using the Federated Identity options

![image](https://github.com/user-attachments/assets/30c00a04-54f7-48a1-ac98-3de95ba664c9)


Addresses #1843