### PR TITLE
Add Oracle Linux to the install-from-source.sh script.

### DIFF
--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -181,7 +181,7 @@ case "$distribution" in
             fi
         fi
     ;;
-    fedora | centos | rhel)
+    fedora | centos | rhel | ol)
         $sudo_cmd dnf upgrade -y
 
         # Install dotnet/GCM dependencies.


### PR DESCRIPTION
Oracle Linux's distro ID in /etc/os-release is "ol". Added this ID to the list of RHEL compatible distributions in the distribution case.

Resolves issue #1856 