### PR TITLE
Fix a few issues with TRACE2 output

### DIFF
--- a/src/shared/Core.Tests/Trace2MessageTests.cs
+++ b/src/shared/Core.Tests/Trace2MessageTests.cs
@@ -54,7 +54,7 @@ public class Trace2MessageTests
             ParameterizedMessage = "baz"
         };
 
-        var expected = "{\"event\":\"error\",\"sid\":\"123\",\"thread\":\"main\",\"time\":\"0001-01-01T00:00:00+00:00\",\"file\":\"foo.cs\",\"line\":1,\"depth\":1,\"msg\":\"bar\",\"format\":\"baz\"}";
+        var expected = "{\"event\":\"error\",\"sid\":\"123\",\"thread\":\"main\",\"time\":\"0001-01-01T00:00:00+00:00\",\"file\":\"foo.cs\",\"line\":1,\"depth\":1,\"msg\":\"bar\",\"fmt\":\"baz\"}";
         var actual = errorMessage.ToJson();
 
         Assert.Equal(expected, actual);

--- a/src/shared/Core.Tests/Trace2Tests.cs
+++ b/src/shared/Core.Tests/Trace2Tests.cs
@@ -6,25 +6,26 @@ public class Trace2Tests
 {
     [PosixTheory]
     [InlineData("af_unix:foo", "foo")]
-    [InlineData("af_unix:stream:foo-bar", "foo-bar")]
-    [InlineData("af_unix:dgram:foo-bar-baz", "foo-bar-baz")]
+    [InlineData("af_unix:foo/bar", "foo/bar")]
+    [InlineData("af_unix:stream:foo/bar", "foo/bar")]
+    [InlineData("af_unix:dgram:foo/bar/baz", "foo/bar/baz")]
     public void TryGetPipeName_Posix_Returns_Expected_Value(string input, string expected)
     {
         var isSuccessful = Trace2.TryGetPipeName(input, out var actual);
 
         Assert.True(isSuccessful);
-        Assert.Matches(actual, expected);
+        Assert.Equal(actual, expected);
     }
 
     [WindowsTheory]
     [InlineData("\\\\.\\pipe\\git-foo", "git-foo")]
     [InlineData("\\\\.\\pipe\\git-foo-bar", "git-foo-bar")]
-    [InlineData("\\\\.\\pipe\\foo\\git-bar", "git-bar")]
+    [InlineData("\\\\.\\pipe\\foo\\git-bar", "foo\\git-bar")]
     public void TryGetPipeName_Windows_Returns_Expected_Value(string input, string expected)
     {
         var isSuccessful = Trace2.TryGetPipeName(input, out var actual);
 
         Assert.True(isSuccessful);
-        Assert.Matches(actual, expected);
+        Assert.Equal(expected, actual);
     }
 }

--- a/src/shared/Core/Trace2.cs
+++ b/src/shared/Core/Trace2.cs
@@ -480,13 +480,16 @@ public class Trace2 : DisposableObject, ITrace2
     internal static bool TryGetPipeName(string eventTarget, out string name)
     {
         // Use prefixes to determine whether target is a named pipe/socket
-        if (eventTarget.Contains("af_unix:", StringComparison.OrdinalIgnoreCase) ||
-            eventTarget.Contains("\\\\.\\pipe\\", StringComparison.OrdinalIgnoreCase) ||
-            eventTarget.Contains("/./pipe/", StringComparison.OrdinalIgnoreCase))
+        if (eventTarget.StartsWith("af_unix:", StringComparison.OrdinalIgnoreCase) ||
+            eventTarget.StartsWith(@"\\.\pipe\", StringComparison.OrdinalIgnoreCase) ||
+            eventTarget.StartsWith("//./pipe/", StringComparison.OrdinalIgnoreCase))
         {
             name = PlatformUtils.IsWindows()
-                ? eventTarget.TrimUntilLastIndexOf("\\")
-                : eventTarget.TrimUntilLastIndexOf(":");
+                ? eventTarget.Replace('/', '\\')
+                    .TrimUntilIndexOf(@"\\.\pipe\")
+                : eventTarget.Replace("af_unix:dgram:", "")
+                    .Replace("af_unix:stream:", "")
+                    .Replace("af_unix:", "");
             return true;
         }
 

--- a/src/shared/Core/Trace2Message.cs
+++ b/src/shared/Core/Trace2Message.cs
@@ -409,7 +409,7 @@ public class ErrorMessage : Trace2Message
     [JsonPropertyOrder(8)]
     public string Message { get; set; }
 
-    [JsonPropertyName("format")]
+    [JsonPropertyName("fmt")]
     [JsonPropertyOrder(9)]
     public string ParameterizedMessage { get; set; }
 


### PR DESCRIPTION
I noticed a few problems with the TRACE2 support when writing to a pipe/socket. The handling of the `trace2.eventTarget` setting to get the correct pipe name/socket file path was incorrect resulting in names like "pipe\foobar" when given "//./pipe/foobar" on Windows, when it should be "foobar".

Also the event field name 'format' is incorrect; it should be 'fmt'.