### PR TITLE
Support generic OAuth for non-HTTP hosts

### DIFF
--- a/src/shared/Core/GenericHostProvider.cs
+++ b/src/shared/Core/GenericHostProvider.cs
@@ -67,14 +67,8 @@ namespace GitCredentialManager
 
             Uri uri = input.GetRemoteUri();
 
-            // Determine the if the host supports Windows Integration Authentication (WIA) or OAuth
-            if (!StringComparer.OrdinalIgnoreCase.Equals(uri.Scheme, "http") &&
-                !StringComparer.OrdinalIgnoreCase.Equals(uri.Scheme, "https"))
-            {
-                // Cannot check WIA or OAuth support for non-HTTP based protocols
-            }
             // Check for an OAuth configuration for this remote
-            else if (GenericOAuthConfig.TryGet(Context.Trace, Context.Settings, input, out GenericOAuthConfig oauthConfig))
+            if (GenericOAuthConfig.TryGet(Context.Trace, Context.Settings, input, out GenericOAuthConfig oauthConfig))
             {
                 Context.Trace.WriteLine($"Found generic OAuth configuration for '{uri}':");
                 Context.Trace.WriteLine($"\tAuthzEndpoint   = {oauthConfig.Endpoints.AuthorizationEndpoint}");


### PR DESCRIPTION
Non-HTTP hosts can support OAuth using absolute `authorize` and `token` endpoints, like EXO/Outlook.com SMTP. Example:

```
[sendemail]
smtpServer = smtp-mail.outlook.com
smtpUser = example@outlook.com
smtpEncryption = tls
smtpServerPort = 587
smtpAuth = XOAUTH2

[credential "smtp://smtp-mail.outlook.com:587"]
oauthClientId = a95fbac5-cbbb-4032-b10d-fb756c457ba1
oauthAuthorizeEndpoint = https://login.microsoftonline.com/common/oauth2/v2.0/authorize
oauthTokenEndpoint = https://login.microsoftonline.com/common/oauth2/v2.0/token
oauthScopes = offline_access https://outlook.office.com/SMTP.Send
```