### PR TITLE
Fixed a tiny grammar mistake in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ supported by dotnet][dotnet-distributions].
 ## Supported Git versions
 
 Git Credential Manager tries to be compatible with the broadest set of Git
-versions (within reason). However there are some know problematic releases of
+versions (within reason). However there are some known problematic releases of
 Git that are not compatible.
 
 - Git 1.x


### PR DESCRIPTION
# About
Under the "Supported Git Versions" section there was
> However there are some know problematic releases of Git that are not compatible.

Which is not quite right, "know" should instead be "known". So I fixed it. This is an incredibly minor thing, I just figured I would fix this since I noticed it.