### PR TITLE
Update freedesktop secret service link

### DIFF
--- a/docs/credstores.md
+++ b/docs/credstores.md
@@ -257,7 +257,7 @@ that you take with you and use full-disk encryption.
 [cmdkey]: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmdkey
 [credential-store]: configuration.md#credentialcredentialstore
 [credential-cache]: https://git-scm.com/docs/git-credential-cache
-[freedesktop-secret-service]: https://specifications.freedesktop.org/secret-service/
+[freedesktop-secret-service]: https://specifications.freedesktop.org/secret-service-spec/latest/
 [gcm-credential-store]: environment.md#GCM_CREDENTIAL_STORE
 [git-credential-store]: https://git-scm.com/docs/git-credential-store
 [mac-keychain-management]: https://support.apple.com/en-gb/guide/mac-help/mchlf375f392/mac


### PR DESCRIPTION
Update the broken link for freedesktop secret service to point to the latest specification page.

The previous link is now dead/broken and results in a 404 error.

- Old link: https://specifications.freedesktop.org/secret-service/
- New link: https://specifications.freedesktop.org/secret-service-spec/latest/