### PR TITLE
validate-install-from-source: bump Alpine LTS to latest non-EOL one

### DIFF
--- a/.github/workflows/validate-install-from-source.yml
+++ b/.github/workflows/validate-install-from-source.yml
@@ -23,7 +23,7 @@ jobs:
         - image: tgagor/centos
         - image: redhat/ubi8
         - image: alpine
-        - image: alpine:3.14.10
+        - image: alpine:3.19.8
         - image: opensuse/leap
         - image: opensuse/tumbleweed
         - image: registry.suse.com/suse/sle15:15.4.27.11.31


### PR DESCRIPTION
The Alpine container we use still is at version v3.14 (which, from a numerophile's point of view is a quite pleasing number). However, this Alpine version is past its support, as pointed out in https://github.com/actions/checkout/issues/2246#issuecomment-3182183831

One fallout is that since I upgraded Git Credential Manager's GitHub workflows to require Node.JS 24, we are now greeted with this error:

  ```
  Run actions/checkout@v5
  /usr/bin/docker exec  7d1dbaed0040c61df8247f411d8220c2fb587aa0a7536d22ed12caff60b592da sh -c "cat /etc/*release | grep ^ID"
  Error relocating /__e/node24_alpine/bin/node: pthread_getname_np: symbol not found
  ```

For details about this run, see
https://github.com/git-ecosystem/git-credential-manager/actions/runs/17937675613/job/51006830230

Let's switch to the oldest, just _barely_ supported Alpine version (https://alpinelinux.org/releases/ says that v3.19 will be out of support this November).