### PR TITLE
Add global.json file to lock SDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "rollForward": "latestMajor",
+    "version": "8.0"
+  }
+}
+


### PR DESCRIPTION
Add a global.json file to the project to make it clearer that we should be using _at least_ version 8.x of the .NET SDK. This can help when building locally without a valid .NET Runtime version installed, to make it clear what the issue is.

We set the roll-forward policy to `latestMajor` meaning we will look for any SDK major version from the set version forward. In this case, since we set 8.0, this will match 8.x, 9.x, 10.x etc.

When we move to a newer runtime target (probably `net10.0`) we'll want to bump this minimum SDK version to 10.0.