### PR TITLE
release: sign .deb files with a stronger algorithm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,6 +270,15 @@ jobs:
         # Install debsigs
         sudo apt install debsigs
 
+        # Stop using SHA-1 for the signature. For details, see
+        # https://gitlab.com/debsigs/debsigs/-/commit/75c6c8f96e6cdc33bca9c5f32195b68ff35bc32f
+        # which seems to have made it to have made it into debsigs v0.2.1, but Ubuntu 24.04 is
+        # stuck with v1.19.
+        mkdir -p patched-debsigs &&
+        sed 's/, "--openpgp"//' </usr/bin/debsigs >patched-debsigs/debsigs &&
+        chmod a+x patched-debsigs/debsigs &&
+        echo "$PWD/patched-debsigs" >>$GITHUB_PATH
+
         # Download GPG key, passphrase, and keygrip from Azure Key Vault
         key=$(az keyvault secret show --name $GPG_KEY_SECRET_NAME --vault-name $AZURE_VAULT --query "value")
         passphrase=$(az keyvault secret show --name $GPG_PASSPHRASE_SECRET_NAME --vault-name $AZURE_VAULT --query "value")


### PR DESCRIPTION
It has been reported in https://github.com/git-ecosystem/git-credential-manager/issues/2028 that Git Credential Manager's `.deb` files cannot be validated with `debsig-verify`. A deeper investigation brought to light that the reason is a weak digest algorithm: `debsigs` calls `gpg --opengpg` which uses SHA-1, but `debsig-verify` rejects such weak signatures.

This was actually already fixed in `debsigs`, but current Ubuntu versions will not get those fixes, being stuck with older `debsigs` versions.

It's easy enough to work around, though, so just like https://github.com/microsoft/git/pull/815, let's let Git Credential Manager's `release` workflow work around that.

This closes https://github.com/git-ecosystem/git-credential-manager/issues/2028