### PR TITLE
Linux - Fix interactive prompt handling during installation with curl

### DIFF
--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -40,18 +40,26 @@ if [ -z $is_ci ]; then
 
 Git Credential Manager is licensed under the MIT License: https://aka.ms/gcm/license"
 
-    while true; do
-        read -p "Do you want to continue? [Y/n] " yn
-        case $yn in
-            [Yy]*|"")
-                break
-            ;;
-            [Nn]*)
-                exit
-            ;;
-            *)
-                echo "Please answer yes or no."
-            ;;
+	while true; do
+        # Display prompt once before reading input
+        printf "Do you want to continue? [Y/n] "
+
+        # Prefer reading from the controlling terminal (TTY) when available,
+        # so that input works even if the script is piped (e.g. curl URL | sh)
+        if [ -r /dev/tty ]; then
+            read yn < /dev/tty
+        # If no TTY is available, attempt to read from standard input (stdin)
+        elif ! read yn; then
+            # If input is not possible via TTY or stdin, assume a non-interactive environment
+            # and abort with guidance for automated usage
+            echo "Interactive prompt unavailable in this environment. Use 'sh -s -- -y' for automated install."
+            exit 1
+        fi
+
+        case "$yn" in
+            [Yy]*|"") break ;;
+            [Nn]*) exit ;;
+            *) echo "Please answer yes or no." ;;
         esac
     done
 fi


### PR DESCRIPTION
### What changed?

- Fixed the interactive prompt not working when installing via piped execution (`curl -L <url> | sh`)
- Added proper `/dev/tty` fallback to always allow user input where available
- Removed duplicate prompt calls
- Improved handling of non-interactive environments with a clear fallback message

### Works in these cases

```sh
# ✔ Interactive (TTY prompt works even when piped)
curl -L https://example.com/install.sh | sh

# ✔ Non-interactive (automation, CI, scripts)
curl -L https://example.com/install.sh | sh -s -- -y
```

<img width="1411" height="1505" alt="image" src="https://github.com/user-attachments/assets/2d7b6734-ec3e-4be5-994f-6fb0b7e138f0" />

