### PR TITLE
Support Oracle Linux in install-from-source.sh

### DIFF
--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -189,7 +189,7 @@ case "$distribution" in
             fi
         fi
     ;;
-    fedora | centos | rhel)
+    fedora | centos | rhel | ol)
         $sudo_cmd dnf upgrade -y
 
         # Install dotnet/GCM dependencies.


### PR DESCRIPTION
Added 'ol' to the list of supported distributions for installation.

Oracle Linux /etc/os-release output:
```sh
$ docker run -it oraclelinux:9 cat /etc/os-release NAME="Oracle Linux Server"
VERSION="9.7"
ID="ol"
ID_LIKE="fedora"
VERSION_ID="9.7"
PLATFORM_ID="platform:el9"
This confirms:
```
ID="ol"

ID_LIKE="fedora"

Since Oracle Linux is RHEL-compatible and part of the Fedora/RHEL family, handling it under the same case block (fedora | centos | rhel | ol) is appropriate and consistent with existing logic.