### PR TITLE
Detect Linux runtime from host architecture if not specified

### DIFF
--- a/src/linux/Packaging.Linux/pack.sh
+++ b/src/linux/Packaging.Linux/pack.sh
@@ -59,12 +59,28 @@ fi
 if [ -z "$SYMBOLS" ]; then
     die "--symbols was not set"
 fi
-if [ -z "$RUNTIME" ]; then
-    die "--runtime was not set"
-fi
-
 if [ -z "$OUTPUT_ROOT" ]; then
     OUTPUT_ROOT="$PROJ_OUT/$CONFIGURATION"
+fi
+
+# Fall back to host architecture if no explicit runtime is given.
+if test -z "$RUNTIME"; then
+    HOST_ARCH="`uname -m`"
+
+    case $HOST_ARCH in
+        x86_64|amd64)
+            RUNTIME="linux-x64"
+            ;;
+        aarch64|arm64)
+            RUNTIME="linux-arm64"
+            ;;
+        armhf)
+            RUNTIME="linux-arm"
+            ;;
+        *)
+            die "Could not determine host architecture! ($HOST_ARCH)"
+            ;;
+    esac
 fi
 
 TAROUT="$OUTPUT_ROOT/tar"
@@ -107,26 +123,6 @@ popd
 INSTALL_TO="$DEBROOT/usr/local/share/gcm-core/"
 LINK_TO="$DEBROOT/usr/local/bin/"
 mkdir -p "$DEBROOT/DEBIAN" "$INSTALL_TO" "$LINK_TO" || exit 1
-
-# Fall back to host architecture if no explicit runtime is given.
-if test -z "$RUNTIME"; then
-    HOST_ARCH="`dpkg-architecture -q DEB_HOST_ARCH`"
-
-    case $HOST_ARCH in
-        amd64)
-            RUNTIME="linux-x64"
-            ;;
-        arm64)
-            RUNTIME="linux-arm64"
-            ;;
-        armhf)
-            RUNTIME="linux-arm"
-            ;;
-        *)
-            die "Could not determine host architecture!"
-            ;;
-    esac
-fi
 
 # Determine architecture for debian control file from the runtime architecture
 case $RUNTIME in


### PR DESCRIPTION
Detect the runtime (linux-x64/linux-arm64/etc) from the current host architecture if not specified via the `--runtime` argument.

We had already been doing this in the script, but after we already `die`-d when `--runtime` was missing! Oops.

Let's move this auto-detection logic up-front, and also no longer rely on `dpkg-architecture` to determine the host arch; we can use `uname -m` instead.