### PR TITLE
Fix: Add flag to search query for SecretService to retrieve all accounts

### DIFF
--- a/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
+++ b/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
@@ -66,7 +66,7 @@ namespace GitCredentialManager.Interop.Linux
                     secService,
                     ref schema,
                     queryAttrs,
-                    SecretSearchFlags.SECRET_SEARCH_UNLOCK,
+                    SecretSearchFlags.SECRET_SEARCH_UNLOCK | SecretSearchFlags.SECRET_SEARCH_ALL,
                     IntPtr.Zero,
                     out error);
 


### PR DESCRIPTION
Currently, this searchQuery only returns one account even when there are multiple of them. Adding this flag will result in retrieving all the accounts and does not interrupt the previous flow.