### PR TITLE
Add linux-arm64 builds to official releases

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -63,6 +63,12 @@ parameters:
         pool: GitClientPME-1ESHostedPool-intel-pc
         image: ubuntu-x86_64-ado1es
         os: linux
+      - id: linux_arm64
+        jobName: 'Linux (ARM64)'
+        runtime: linux-arm64
+        pool: GitClientPME-1ESHostedPool-arm64-pc
+        image: ubuntu-arm64-ado1es
+        os: linux
 
 variables:
   - name: 'esrpAppConnectionName'
@@ -778,6 +784,9 @@ extends:
                   artifactName: 'linux-x64'
                   targetPath: $(Pipeline.Workspace)/assets/linux-x64
                 - input: pipelineArtifact
+                  artifactName: 'linux-arm64'
+                  targetPath: $(Pipeline.Workspace)/assets/linux-arm64
+                - input: pipelineArtifact
                   artifactName: 'dotnet-tool'
                   targetPath: $(Pipeline.Workspace)/assets/dotnet-tool
             steps:
@@ -802,6 +811,8 @@ extends:
                     $(Pipeline.Workspace)/assets/osx-arm64/*.tar.gz
                     $(Pipeline.Workspace)/assets/linux-x64/*.deb
                     $(Pipeline.Workspace)/assets/linux-x64/*.tar.gz
+                    $(Pipeline.Workspace)/assets/linux-arm64/*.deb
+                    $(Pipeline.Workspace)/assets/linux-arm64/*.tar.gz
                     $(Pipeline.Workspace)/assets/dotnet-tool/*.nupkg
                     $(Pipeline.Workspace)/assets/dotnet-tool/*.snupkg
 


### PR DESCRIPTION
The build process already supports ARM64 for Linux, so let's extend the official build process to also produce these binaries.

Note that we have already been performing [CI builds on GitHub of `linux-arm64`](https://github.com/git-ecosystem/git-credential-manager/blob/1b3f77efe12efffaadac7c5a218822896e657a39/.github/workflows/continuous-integration.yml#L59), so this is just about extending the official build pipeline.