### PR TITLE
linux/pack.sh: use standard filename format

### DIFF
--- a/src/linux/Packaging.Linux/pack.sh
+++ b/src/linux/Packaging.Linux/pack.sh
@@ -84,12 +84,12 @@ if test -z "$RUNTIME"; then
 fi
 
 TAROUT="$OUTPUT_ROOT/tar"
-TARBALL="$TAROUT/gcm-$RUNTIME.$VERSION.tar.gz"
-SYMTARBALL="$TAROUT/gcm-$RUNTIME.$VERSION-symbols.tar.gz"
+TARBALL="$TAROUT/gcm-$RUNTIME-$VERSION.tar.gz"
+SYMTARBALL="$TAROUT/gcm-$RUNTIME-$VERSION-symbols.tar.gz"
 
 DEBOUT="$OUTPUT_ROOT/deb"
 DEBROOT="$DEBOUT/root"
-DEBPKG="$DEBOUT/gcm-$RUNTIME.$VERSION.deb"
+DEBPKG="$DEBOUT/gcm-$RUNTIME-$VERSION.deb"
 mkdir -p "$DEBROOT"
 
 # Set full read, write, execute permissions for owner and just read and execute permissions for group and other


### PR DESCRIPTION
All other platforms use the package filename format:

```
  gcm(user)-$RUNTIME-$VERSION.$EXT
```

But the Linux packages have been set to:

```
  gcm-$RUNTIME.$VERSION.$EXT
```

Let's standardise on the `.` separator between runtime and version.