### PR TITLE
Check for xdg-open availability on Linux for browser auth

### DIFF
--- a/src/shared/Core/Interop/Linux/LinuxSessionManager.cs
+++ b/src/shared/Core/Interop/Linux/LinuxSessionManager.cs
@@ -21,53 +21,34 @@ public class LinuxSessionManager : PosixSessionManager
     
     private bool GetWebBrowserAvailable()
     {
-        // Check if we have a way to launch the user's browser via a shell execute handler
-        // (xdg-open, gnome-open, kfmclient, wslview)
+        // Determine system properties
         bool hasHandler = BrowserUtils.TryGetLinuxShellExecuteHandler(Environment, out _);
+        bool isWsl = WslUtils.IsWslDistribution(Environment, FileSystem, out _);
+        bool isWslSession0 = isWsl && WslUtils.GetWindowsSessionId(FileSystem) == 0;
+        bool isDesktopSession = IsDesktopSession;
 
-        if (hasHandler)
-        {
-            // If this is a Windows Subsystem for Linux distribution, we need
-            // additional checks even though we have a handler (e.g., wslview)
-            if (WslUtils.IsWslDistribution(Environment, FileSystem, out _))
-            {
-                //
-                // If we are in Windows logon session 0 then the user can never interact,
-                // even in the WinSta0 window station. This is typical when SSH-ing into a
-                // Windows 10+ machine using the default OpenSSH Server configuration,
-                // which runs in the 'services' session 0.
-                //
-                // If we're in any other session, and in the WinSta0 window station then
-                // the user can possibly interact. However, since it's hard to determine
-                // the window station from PowerShell cmdlets (we'd need to write P/Invoke
-                // code and that's just messy and too many levels of indirection quite
-                // frankly!) we just assume any non session 0 is interactive.
-                //
-                // This assumption doesn't hold true if the user has changed the user that
-                // the OpenSSH Server service runs as (not a built-in NT service) *AND*
-                // they've SSH-ed into the Windows host (and then started a WSL shell).
-                // This feels like a very small subset of users...
-                //
-                if (WslUtils.GetWindowsSessionId(FileSystem) == 0)
-                {
-                    return false;
-                }
-            }
+        //
+        // WSL session 0 note:
+        // If we are in Windows logon session 0 then the user can never interact,
+        // even in the WinSta0 window station. This is typical when SSH-ing into a
+        // Windows 10+ machine using the default OpenSSH Server configuration,
+        // which runs in the 'services' session 0.
+        //
+        // If we're in any other session, and in the WinSta0 window station then
+        // the user can possibly interact. However, since it's hard to determine
+        // the window station from PowerShell cmdlets (we'd need to write P/Invoke
+        // code and that's just messy and too many levels of indirection quite
+        // frankly!) we just assume any non session 0 is interactive.
+        //
+        // This assumption doesn't hold true if the user has changed the user that
+        // the OpenSSH Server service runs as (not a built-in NT service) *AND*
+        // they've SSH-ed into the Windows host (and then started a WSL shell).
+        // This feels like a very small subset of users...
+        //
 
-            // We have a handler and either not WSL or not in session 0
-            return true;
-        }
-
-        // No explicit handler found
-        // If this is WSL without a handler, we cannot launch the browser
-        if (WslUtils.IsWslDistribution(Environment, FileSystem, out _))
-        {
-            return false;
-        }
-
-        // For non-WSL Linux without an explicit handler, fall back to checking for
-        // a desktop session (X11/Wayland). Desktop environments typically have handlers
-        // installed, so this maintains backward compatibility.
-        return IsDesktopSession;
+        // We can launch a browser if:
+        // 1. We have a shell execute handler (xdg-open, wslview, etc.) and not blocked by WSL session 0, OR
+        // 2. We have a desktop session on non-WSL Linux (backward compatibility - assumes handler exists)
+        return (hasHandler && !isWslSession0) || (isDesktopSession && !isWsl && !hasHandler);
     }
 }


### PR DESCRIPTION
## Summary

Check for browser launcher availability (xdg-open, gnome-open, etc.) in addition to checking for desktop session presence to gate web auth flow.

## Problem

GCM currently only checks for `DISPLAY` or `WAYLAND_DISPLAY` environment variables to determine if browser-based authentication is available on Linux. However, MSAL checks for `xdg-open` availability in addition to display environment variables. This creates a mismatch where GCM reports "browser not available" even though MSAL can successfully launch a browser using `xdg-open`.

## Real-World BLocker: WaveSpace VMs

This fix isimportant for **WaveSpace VMs** and similar environments where:
- Users connect via SSH without X11 forwarding (no `DISPLAY` environment variable)
- `xdg-open` is available and can launch the host system's browser (this is setup by VSCode remote tunnels)
- Browser-based authentication needs to work for conditional access policies, satisifed by the host's browser (Microsoft Edge in this case).

## Solution

Modified `LinuxSessionManager.GetWebBrowserAvailable()` to return `true` if:
- An interactive desktop session is detected (existing behavior via `DISPLAY`/`WAYLAND_DISPLAY`), **OR**
- A shell execute handler like `xdg-open` is available (new behavior)

This matches [MSAL's browser detection logic](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/8faea30d3e43ea88c10603312f65ac0633907775/src/client/Microsoft.Identity.Client/Platforms/netstandard/NetCorePlatformProxy.cs#L202-L210) and ensures GCM, AzureAuth and MSAL behave consistently.

## Behavior Changes

| Scenario | Before | After |
|----------|--------|-------|
| Linux with DISPLAY set | ✅ Browser available | ✅ Browser available |
| Linux with WAYLAND_DISPLAY set | ✅ Browser available | ✅ Browser available |
| Linux with xdg-open but no DISPLAY | ❌ Browser NOT available | ✅ Browser available (FIXED) |
| Linux without display vars or browser launchers | ❌ Browser NOT available | ❌ Browser NOT available |

## Testing

- ✅ Solution builds successfully with no warnings
- Manual testing recommended on Linux system without DISPLAY but with xdg-open available
- Verify OAuth authentication works in SSH sessions with xdg-open present

🤖 Generated with [Claude Code](https://claude.com/claude-code)