### PR TITLE
Fix bug when reading linux defaults

### DIFF
--- a/src/shared/Core/Interop/Linux/LinuxSettings.cs
+++ b/src/shared/Core/Interop/Linux/LinuxSettings.cs
@@ -35,14 +35,17 @@ public class LinuxSettings : Settings
 
         _extConfigCache ??= ReadExternalConfiguration();
 
+        if (_extConfigCache is null)
+            return false; // No external config found (or failed to read)
+
         string name = string.IsNullOrWhiteSpace(scope)
             ? $"{section}.{property}"
             : $"{section}.{scope}.{property}";
 
         // Check if the setting exists in the configuration
-        if (!_extConfigCache?.TryGetValue(name, out value) ?? false)
+        if (!_extConfigCache.TryGetValue(name, out value))
         {
-            // No property exists (or failed to read config)
+            // No property exists
             return false;
         }
 


### PR DESCRIPTION
If there is no GCM configuration defaults directory on Linux, we had been inadvertently returning `null` for the setting value!

Fix the issue by explictly returning `false` (no setting found) to `TryGetExternalDefault` rather than `true` (setting found).