### PR TITLE
Allow installing on azurelinux

### DIFF
--- a/.github/workflows/validate-install-from-source.yml
+++ b/.github/workflows/validate-install-from-source.yml
@@ -29,6 +29,7 @@ jobs:
         - image: registry.suse.com/suse/sle15:15.4.27.11.31
         - image: archlinux
         - image: mcr.microsoft.com/cbl-mariner/base/core:2.0
+        - image: mcr.microsoft.com/azurelinux/base/core:3.0
     container: ${{matrix.vector.image}}
     steps:
       - run: |
@@ -36,7 +37,7 @@ jobs:
             zypper -n install tar gzip
           elif [[ ${{matrix.vector.image}} == *"centos"* ]]; then
             dnf install which -y
-          elif [[ ${{matrix.vector.image}} == *"mariner"* ]]; then
+          elif [[ ${{matrix.vector.image}} == *"mariner"* || ${{matrix.vector.image}} == *"azurelinux"* ]]; then
             GNUPGHOME=/root/.gnupg tdnf update -y &&
             GNUPGHOME=/root/.gnupg tdnf install tar -y # needed for `actions/checkout`
           fi

--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -231,7 +231,7 @@ case "$distribution" in
 
         ensure_dotnet_installed
     ;;
-    mariner)
+    mariner | azurelinux*)
         print_unsupported_distro "WARNING" "$distribution"
         $sudo_cmd tdnf update -y
 


### PR DESCRIPTION
[`install-from-source.sh`](https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.2/src/linux/Packaging.Linux/install-from-source.sh#L234) already allows you to install on `mariner`. But `mariner` is now `azurelinux`, so we ought to allow both.

The installer works fine without any other modifications. And I have had no issues using gcm on azurelinux3 so far.

I also add azurelinux3 to the test matrix.