### PR TITLE
linuxsettings: Fix CS0121 string.Split call ambiguity with .NET 8.0

### DIFF
--- a/src/shared/Core/Interop/Linux/LinuxConfigParser.cs
+++ b/src/shared/Core/Interop/Linux/LinuxConfigParser.cs
@@ -31,7 +31,7 @@ public class LinuxConfigParser
     {
         var result = new Dictionary<string, string>(GitConfigurationKeyComparer.Instance);
 
-        IEnumerable<string> lines = content.Split(['\n'], StringSplitOptions.RemoveEmptyEntries);
+        IEnumerable<string> lines = content.Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
 
         foreach (string line in lines)
         {


### PR DESCRIPTION
The error in full:

    error CS0121: The call is ambiguous between the following methods or properties: 'string.Split(char[]?, StringSplitOptions)' and 'string.Split(string?, StringSplitOptions)' [src/shared/Core/Core.csproj::TargetFramework=net8.0]