### PR TITLE
Add Windows Group Policy ADMX/ADML files and generator script

### DIFF
--- a/docs/enterprise-config.md
+++ b/docs/enterprise-config.md
@@ -43,6 +43,34 @@ those of the [Git configuration][config] settings.
 The type of each registry key can be either `REG_SZ` (string) or `REG_DWORD`
 (integer).
 
+### Group Policy templates
+
+Windows Group Policy Administrative Templates (ADMX/ADML) for GCM are available
+in the [`src/windows/policy-templates`][policy-templates] directory. Copy the
+files to the local or domain policy definitions folder:
+
+**Local machine:**
+
+```text
+GitCredentialManager.admx        → %SystemRoot%\PolicyDefinitions\
+en-US\GitCredentialManager.adml  → %SystemRoot%\PolicyDefinitions\en-US\
+```
+
+**Domain (Active Directory):**
+
+```text
+GitCredentialManager.admx        → \\<domain>\SYSVOL\<domain>\Policies\PolicyDefinitions\
+en-US\GitCredentialManager.adml  → \\<domain>\SYSVOL\<domain>\Policies\PolicyDefinitions\en-US\
+```
+
+After installing the templates, GCM settings appear under
+**Computer Configuration > Administrative Templates > Git Credential Manager**
+in the Group Policy Management Editor.
+
+The templates are generated from the [Git configuration][config] reference using
+the `generate-admx.ps1` script in the same directory. Re-run the script whenever
+the documentation changes to keep the templates up to date.
+
 ### 32-bit / x86
 
 When running the 32-bit (x86) version of GCM on a 64-bit (x64 or ARM64)
@@ -119,3 +147,4 @@ they will not be reflected in an already running process.
 
 [environment]: environment.md
 [config]: configuration.md
+[policy-templates]: ../src/windows/policy-templates

--- a/src/windows/policy-templates/GitCredentialManager.admx
+++ b/src/windows/policy-templates/GitCredentialManager.admx
@@ -1,0 +1,538 @@
+<?xml version="1.0" encoding="utf-8"?>
+<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+  <policyNamespaces>
+    <target prefix="GCM" namespace="Git.Policies.GitCredentialManager" />
+    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+  </policyNamespaces>
+  <supersededAdm fileName="" />
+  <resources minRequiredRevision="1.0" />
+  <supportedOn>
+    <definitions>
+      <definition name="SUPPORTED_GCM" displayName="$(string.SUPPORTED_GCM)" />
+    </definitions>
+  </supportedOn>
+  <categories>
+    <category name="GitCredentialManager" displayName="$(string.Cat_GitCredentialManager)" />
+    <category name="GCM_Trace2" displayName="$(string.Cat_GCM_Trace2)">
+      <parentCategory ref="GitCredentialManager" />
+    </category>
+    <category name="GCM_Tracing" displayName="$(string.Cat_GCM_Tracing)">
+      <parentCategory ref="GitCredentialManager" />
+    </category>
+    <category name="GCM_Credentials" displayName="$(string.Cat_GCM_Credentials)">
+      <parentCategory ref="GitCredentialManager" />
+    </category>
+    <category name="GCM_Authentication" displayName="$(string.Cat_GCM_Authentication)">
+      <parentCategory ref="GitCredentialManager" />
+    </category>
+    <category name="GCM_AzureRepos" displayName="$(string.Cat_GCM_AzureRepos)">
+      <parentCategory ref="GitCredentialManager" />
+    </category>
+    <category name="GCM_GitHub" displayName="$(string.Cat_GCM_GitHub)">
+      <parentCategory ref="GitCredentialManager" />
+    </category>
+    <category name="GCM_Bitbucket" displayName="$(string.Cat_GCM_Bitbucket)">
+      <parentCategory ref="GitCredentialManager" />
+    </category>
+    <category name="GCM_GitLab" displayName="$(string.Cat_GCM_GitLab)">
+      <parentCategory ref="GitCredentialManager" />
+    </category>
+    <category name="GCM_General" displayName="$(string.Cat_GCM_General)">
+      <parentCategory ref="GitCredentialManager" />
+    </category>
+  </categories>
+  <policies>
+    <policy name="GCM_interactive" class="Machine" displayName="$(string.GCM_interactive)" explainText="$(string.GCM_interactive_Explain)" presentation="$(presentation.GCM_interactive)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.interactive">
+      <parentCategory ref="GCM_General" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_interactive_Text" valueName="credential.interactive" />
+      </elements>
+    </policy>
+    <policy name="GCM_trace" class="Machine" displayName="$(string.GCM_trace)" explainText="$(string.GCM_trace_Explain)" presentation="$(presentation.GCM_trace)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.trace">
+      <parentCategory ref="GCM_Tracing" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_trace_Text" valueName="credential.trace" />
+      </elements>
+    </policy>
+    <policy name="GCM_traceSecrets" class="Machine" displayName="$(string.GCM_traceSecrets)" explainText="$(string.GCM_traceSecrets_Explain)" presentation="$(presentation.GCM_traceSecrets)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.traceSecrets">
+      <parentCategory ref="GCM_Tracing" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_traceSecrets_Text" valueName="credential.traceSecrets" />
+      </elements>
+    </policy>
+    <policy name="GCM_traceMsAuth" class="Machine" displayName="$(string.GCM_traceMsAuth)" explainText="$(string.GCM_traceMsAuth_Explain)" presentation="$(presentation.GCM_traceMsAuth)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.traceMsAuth">
+      <parentCategory ref="GCM_Tracing" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_traceMsAuth_Text" valueName="credential.traceMsAuth" />
+      </elements>
+    </policy>
+    <policy name="GCM_debug" class="Machine" displayName="$(string.GCM_debug)" explainText="$(string.GCM_debug_Explain)" presentation="$(presentation.GCM_debug)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.debug">
+      <parentCategory ref="GCM_General" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_debug_Text" valueName="credential.debug" />
+      </elements>
+    </policy>
+    <policy name="GCM_provider" class="Machine" displayName="$(string.GCM_provider)" explainText="$(string.GCM_provider_Explain)" presentation="$(presentation.GCM_provider)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.provider">
+      <parentCategory ref="GCM_General" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <enum id="GCM_provider_Enum" valueName="credential.provider">
+          <item displayName="$(string.GCM_provider_Enum_auto)">
+            <value>
+              <string>auto</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_provider_Enum_azure_repos)">
+            <value>
+              <string>azure-repos</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_provider_Enum_github)">
+            <value>
+              <string>github</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_provider_Enum_bitbucket)">
+            <value>
+              <string>bitbucket</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_provider_Enum_gitlab)">
+            <value>
+              <string>gitlab</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_provider_Enum_generic)">
+            <value>
+              <string>generic</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy name="GCM_authority" class="Machine" displayName="$(string.GCM_authority)" explainText="$(string.GCM_authority_Explain)" presentation="$(presentation.GCM_authority)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.authority">
+      <parentCategory ref="GCM_General" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <enum id="GCM_authority_Enum" valueName="credential.authority">
+          <item displayName="$(string.GCM_authority_Enum_auto)">
+            <value>
+              <string>auto</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_authority_Enum_msa)">
+            <value>
+              <string>msa</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_authority_Enum_github)">
+            <value>
+              <string>github</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_authority_Enum_bitbucket)">
+            <value>
+              <string>bitbucket</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_authority_Enum_gitlab)">
+            <value>
+              <string>gitlab</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_authority_Enum_basic)">
+            <value>
+              <string>basic</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy name="GCM_guiPrompt" class="Machine" displayName="$(string.GCM_guiPrompt)" explainText="$(string.GCM_guiPrompt_Explain)" presentation="$(presentation.GCM_guiPrompt)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.guiPrompt">
+      <parentCategory ref="GCM_General" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_guiPrompt_Text" valueName="credential.guiPrompt" />
+      </elements>
+    </policy>
+    <policy name="GCM_guiSoftwareRendering" class="Machine" displayName="$(string.GCM_guiSoftwareRendering)" explainText="$(string.GCM_guiSoftwareRendering_Explain)" presentation="$(presentation.GCM_guiSoftwareRendering)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.guiSoftwareRendering">
+      <parentCategory ref="GCM_General" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_guiSoftwareRendering_Text" valueName="credential.guiSoftwareRendering" />
+      </elements>
+    </policy>
+    <policy name="GCM_allowUnsafeRemotes" class="Machine" displayName="$(string.GCM_allowUnsafeRemotes)" explainText="$(string.GCM_allowUnsafeRemotes_Explain)" presentation="$(presentation.GCM_allowUnsafeRemotes)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.allowUnsafeRemotes">
+      <parentCategory ref="GCM_General" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_allowUnsafeRemotes_Text" valueName="credential.allowUnsafeRemotes" />
+      </elements>
+    </policy>
+    <policy name="GCM_autoDetectTimeout" class="Machine" displayName="$(string.GCM_autoDetectTimeout)" explainText="$(string.GCM_autoDetectTimeout_Explain)" presentation="$(presentation.GCM_autoDetectTimeout)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.autoDetectTimeout">
+      <parentCategory ref="GCM_General" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_autoDetectTimeout_Text" valueName="credential.autoDetectTimeout" />
+      </elements>
+    </policy>
+    <policy name="GCM_allowWindowsAuth" class="Machine" displayName="$(string.GCM_allowWindowsAuth)" explainText="$(string.GCM_allowWindowsAuth_Explain)" presentation="$(presentation.GCM_allowWindowsAuth)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.allowWindowsAuth">
+      <parentCategory ref="GCM_General" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <enum id="GCM_allowWindowsAuth_Enum" valueName="credential.allowWindowsAuth">
+          <item displayName="$(string.GCM_allowWindowsAuth_Enum_true)">
+            <value>
+              <string>true</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_allowWindowsAuth_Enum_false)">
+            <value>
+              <string>false</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy name="GCM_httpProxy" class="Machine" displayName="$(string.GCM_httpProxy)" explainText="$(string.GCM_httpProxy_Explain)" presentation="$(presentation.GCM_httpProxy)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.httpProxy">
+      <parentCategory ref="GCM_General" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_httpProxy_Text" valueName="credential.httpProxy" />
+      </elements>
+    </policy>
+    <policy name="GCM_bitbucketAuthModes" class="Machine" displayName="$(string.GCM_bitbucketAuthModes)" explainText="$(string.GCM_bitbucketAuthModes_Explain)" presentation="$(presentation.GCM_bitbucketAuthModes)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.bitbucketAuthModes">
+      <parentCategory ref="GCM_Bitbucket" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_bitbucketAuthModes_Text" valueName="credential.bitbucketAuthModes" />
+      </elements>
+    </policy>
+    <policy name="GCM_bitbucketAlwaysRefreshCredentials" class="Machine" displayName="$(string.GCM_bitbucketAlwaysRefreshCredentials)" explainText="$(string.GCM_bitbucketAlwaysRefreshCredentials_Explain)" presentation="$(presentation.GCM_bitbucketAlwaysRefreshCredentials)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.bitbucketAlwaysRefreshCredentials">
+      <parentCategory ref="GCM_Bitbucket" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <enum id="GCM_bitbucketAlwaysRefreshCredentials_Enum" valueName="credential.bitbucketAlwaysRefreshCredentials">
+          <item displayName="$(string.GCM_bitbucketAlwaysRefreshCredentials_Enum_true)">
+            <value>
+              <string>true</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_bitbucketAlwaysRefreshCredentials_Enum_false)">
+            <value>
+              <string>false</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy name="GCM_bitbucketValidateStoredCredentials" class="Machine" displayName="$(string.GCM_bitbucketValidateStoredCredentials)" explainText="$(string.GCM_bitbucketValidateStoredCredentials_Explain)" presentation="$(presentation.GCM_bitbucketValidateStoredCredentials)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.bitbucketValidateStoredCredentials">
+      <parentCategory ref="GCM_Bitbucket" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <enum id="GCM_bitbucketValidateStoredCredentials_Enum" valueName="credential.bitbucketValidateStoredCredentials">
+          <item displayName="$(string.GCM_bitbucketValidateStoredCredentials_Enum_true)">
+            <value>
+              <string>true</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_bitbucketValidateStoredCredentials_Enum_false)">
+            <value>
+              <string>false</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy name="GCM_bitbucketDataCenterOAuthClientId" class="Machine" displayName="$(string.GCM_bitbucketDataCenterOAuthClientId)" explainText="$(string.GCM_bitbucketDataCenterOAuthClientId_Explain)" presentation="$(presentation.GCM_bitbucketDataCenterOAuthClientId)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.bitbucketDataCenterOAuthClientId">
+      <parentCategory ref="GCM_Bitbucket" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_bitbucketDataCenterOAuthClientId_Text" valueName="credential.bitbucketDataCenterOAuthClientId" />
+      </elements>
+    </policy>
+    <policy name="GCM_bitbucketDataCenterOAuthClientSecret" class="Machine" displayName="$(string.GCM_bitbucketDataCenterOAuthClientSecret)" explainText="$(string.GCM_bitbucketDataCenterOAuthClientSecret_Explain)" presentation="$(presentation.GCM_bitbucketDataCenterOAuthClientSecret)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.bitbucketDataCenterOAuthClientSecret">
+      <parentCategory ref="GCM_Bitbucket" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_bitbucketDataCenterOAuthClientSecret_Text" valueName="credential.bitbucketDataCenterOAuthClientSecret" />
+      </elements>
+    </policy>
+    <policy name="GCM_gitHubAccountFiltering" class="Machine" displayName="$(string.GCM_gitHubAccountFiltering)" explainText="$(string.GCM_gitHubAccountFiltering_Explain)" presentation="$(presentation.GCM_gitHubAccountFiltering)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.gitHubAccountFiltering">
+      <parentCategory ref="GCM_GitHub" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <enum id="GCM_gitHubAccountFiltering_Enum" valueName="credential.gitHubAccountFiltering">
+          <item displayName="$(string.GCM_gitHubAccountFiltering_Enum_true)">
+            <value>
+              <string>true</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_gitHubAccountFiltering_Enum_false)">
+            <value>
+              <string>false</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy name="GCM_gitHubAuthModes" class="Machine" displayName="$(string.GCM_gitHubAuthModes)" explainText="$(string.GCM_gitHubAuthModes_Explain)" presentation="$(presentation.GCM_gitHubAuthModes)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.gitHubAuthModes">
+      <parentCategory ref="GCM_GitHub" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_gitHubAuthModes_Text" valueName="credential.gitHubAuthModes" />
+      </elements>
+    </policy>
+    <policy name="GCM_gitLabAuthModes" class="Machine" displayName="$(string.GCM_gitLabAuthModes)" explainText="$(string.GCM_gitLabAuthModes_Explain)" presentation="$(presentation.GCM_gitLabAuthModes)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.gitLabAuthModes">
+      <parentCategory ref="GCM_GitLab" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_gitLabAuthModes_Text" valueName="credential.gitLabAuthModes" />
+      </elements>
+    </policy>
+    <policy name="GCM_namespace" class="Machine" displayName="$(string.GCM_namespace)" explainText="$(string.GCM_namespace_Explain)" presentation="$(presentation.GCM_namespace)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.namespace">
+      <parentCategory ref="GCM_General" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_namespace_Text" valueName="credential.namespace" />
+      </elements>
+    </policy>
+    <policy name="GCM_credentialStore" class="Machine" displayName="$(string.GCM_credentialStore)" explainText="$(string.GCM_credentialStore_Explain)" presentation="$(presentation.GCM_credentialStore)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.credentialStore">
+      <parentCategory ref="GCM_Credentials" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <enum id="GCM_credentialStore_Enum" valueName="credential.credentialStore">
+          <item displayName="$(string.GCM_credentialStore_Enum_wincredman)">
+            <value>
+              <string>wincredman</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_credentialStore_Enum_dpapi)">
+            <value>
+              <string>dpapi</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_credentialStore_Enum_keychain)">
+            <value>
+              <string>keychain</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_credentialStore_Enum_secretservice)">
+            <value>
+              <string>secretservice</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_credentialStore_Enum_gpg)">
+            <value>
+              <string>gpg</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_credentialStore_Enum_cache)">
+            <value>
+              <string>cache</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_credentialStore_Enum_plaintext)">
+            <value>
+              <string>plaintext</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_credentialStore_Enum_none)">
+            <value>
+              <string>none</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy name="GCM_cacheOptions" class="Machine" displayName="$(string.GCM_cacheOptions)" explainText="$(string.GCM_cacheOptions_Explain)" presentation="$(presentation.GCM_cacheOptions)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.cacheOptions">
+      <parentCategory ref="GCM_Credentials" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_cacheOptions_Text" valueName="credential.cacheOptions" />
+      </elements>
+    </policy>
+    <policy name="GCM_plaintextStorePath" class="Machine" displayName="$(string.GCM_plaintextStorePath)" explainText="$(string.GCM_plaintextStorePath_Explain)" presentation="$(presentation.GCM_plaintextStorePath)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.plaintextStorePath">
+      <parentCategory ref="GCM_Credentials" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_plaintextStorePath_Text" valueName="credential.plaintextStorePath" />
+      </elements>
+    </policy>
+    <policy name="GCM_dpapiStorePath" class="Machine" displayName="$(string.GCM_dpapiStorePath)" explainText="$(string.GCM_dpapiStorePath_Explain)" presentation="$(presentation.GCM_dpapiStorePath)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.dpapiStorePath">
+      <parentCategory ref="GCM_Credentials" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_dpapiStorePath_Text" valueName="credential.dpapiStorePath" />
+      </elements>
+    </policy>
+    <policy name="GCM_gpgPassStorePath" class="Machine" displayName="$(string.GCM_gpgPassStorePath)" explainText="$(string.GCM_gpgPassStorePath_Explain)" presentation="$(presentation.GCM_gpgPassStorePath)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.gpgPassStorePath">
+      <parentCategory ref="GCM_Credentials" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_gpgPassStorePath_Text" valueName="credential.gpgPassStorePath" />
+      </elements>
+    </policy>
+    <policy name="GCM_msauthFlow" class="Machine" displayName="$(string.GCM_msauthFlow)" explainText="$(string.GCM_msauthFlow_Explain)" presentation="$(presentation.GCM_msauthFlow)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.msauthFlow">
+      <parentCategory ref="GCM_Authentication" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <enum id="GCM_msauthFlow_Enum" valueName="credential.msauthFlow">
+          <item displayName="$(string.GCM_msauthFlow_Enum_auto)">
+            <value>
+              <string>auto</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_msauthFlow_Enum_embedded)">
+            <value>
+              <string>embedded</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_msauthFlow_Enum_system)">
+            <value>
+              <string>system</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_msauthFlow_Enum_devicecode)">
+            <value>
+              <string>devicecode</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy name="GCM_msauthUseBroker" class="Machine" displayName="$(string.GCM_msauthUseBroker)" explainText="$(string.GCM_msauthUseBroker_Explain)" presentation="$(presentation.GCM_msauthUseBroker)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.msauthUseBroker">
+      <parentCategory ref="GCM_Authentication" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <enum id="GCM_msauthUseBroker_Enum" valueName="credential.msauthUseBroker">
+          <item displayName="$(string.GCM_msauthUseBroker_Enum_true)">
+            <value>
+              <string>true</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_msauthUseBroker_Enum_false)">
+            <value>
+              <string>false</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy name="GCM_msauthUseDefaultAccount" class="Machine" displayName="$(string.GCM_msauthUseDefaultAccount)" explainText="$(string.GCM_msauthUseDefaultAccount_Explain)" presentation="$(presentation.GCM_msauthUseDefaultAccount)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.msauthUseDefaultAccount">
+      <parentCategory ref="GCM_Authentication" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <enum id="GCM_msauthUseDefaultAccount_Enum" valueName="credential.msauthUseDefaultAccount">
+          <item displayName="$(string.GCM_msauthUseDefaultAccount_Enum_true)">
+            <value>
+              <string>true</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_msauthUseDefaultAccount_Enum_false)">
+            <value>
+              <string>false</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy name="GCM_useHttpPath" class="Machine" displayName="$(string.GCM_useHttpPath)" explainText="$(string.GCM_useHttpPath_Explain)" presentation="$(presentation.GCM_useHttpPath)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.useHttpPath">
+      <parentCategory ref="GCM_General" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <enum id="GCM_useHttpPath_Enum" valueName="credential.useHttpPath">
+          <item displayName="$(string.GCM_useHttpPath_Enum_false)">
+            <value>
+              <string>false</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_useHttpPath_Enum_true)">
+            <value>
+              <string>true</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy name="GCM_azreposCredentialType" class="Machine" displayName="$(string.GCM_azreposCredentialType)" explainText="$(string.GCM_azreposCredentialType_Explain)" presentation="$(presentation.GCM_azreposCredentialType)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.azreposCredentialType">
+      <parentCategory ref="GCM_AzureRepos" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <enum id="GCM_azreposCredentialType_Enum" valueName="credential.azreposCredentialType">
+          <item displayName="$(string.GCM_azreposCredentialType_Enum_pat)">
+            <value>
+              <string>pat</string>
+            </value>
+          </item>
+          <item displayName="$(string.GCM_azreposCredentialType_Enum_oauth)">
+            <value>
+              <string>oauth</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy name="GCM_azreposManagedIdentity" class="Machine" displayName="$(string.GCM_azreposManagedIdentity)" explainText="$(string.GCM_azreposManagedIdentity_Explain)" presentation="$(presentation.GCM_azreposManagedIdentity)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.azreposManagedIdentity">
+      <parentCategory ref="GCM_AzureRepos" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_azreposManagedIdentity_Text" valueName="credential.azreposManagedIdentity" />
+      </elements>
+    </policy>
+    <policy name="GCM_azreposServicePrincipal" class="Machine" displayName="$(string.GCM_azreposServicePrincipal)" explainText="$(string.GCM_azreposServicePrincipal_Explain)" presentation="$(presentation.GCM_azreposServicePrincipal)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.azreposServicePrincipal">
+      <parentCategory ref="GCM_AzureRepos" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_azreposServicePrincipal_Text" valueName="credential.azreposServicePrincipal" />
+      </elements>
+    </policy>
+    <policy name="GCM_azreposServicePrincipalSecret" class="Machine" displayName="$(string.GCM_azreposServicePrincipalSecret)" explainText="$(string.GCM_azreposServicePrincipalSecret_Explain)" presentation="$(presentation.GCM_azreposServicePrincipalSecret)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.azreposServicePrincipalSecret">
+      <parentCategory ref="GCM_AzureRepos" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_azreposServicePrincipalSecret_Text" valueName="credential.azreposServicePrincipalSecret" />
+      </elements>
+    </policy>
+    <policy name="GCM_azreposServicePrincipalCertificateThumbprint" class="Machine" displayName="$(string.GCM_azreposServicePrincipalCertificateThumbprint)" explainText="$(string.GCM_azreposServicePrincipalCertificateThumbprint_Explain)" presentation="$(presentation.GCM_azreposServicePrincipalCertificateThumbprint)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.azreposServicePrincipalCertificateThumbprint">
+      <parentCategory ref="GCM_AzureRepos" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_azreposServicePrincipalCertificateThumbprint_Text" valueName="credential.azreposServicePrincipalCertificateThumbprint" />
+      </elements>
+    </policy>
+    <policy name="GCM_azreposServicePrincipalCertificateSendX5C" class="Machine" displayName="$(string.GCM_azreposServicePrincipalCertificateSendX5C)" explainText="$(string.GCM_azreposServicePrincipalCertificateSendX5C_Explain)" presentation="$(presentation.GCM_azreposServicePrincipalCertificateSendX5C)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="credential.azreposServicePrincipalCertificateSendX5C">
+      <parentCategory ref="GCM_AzureRepos" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_azreposServicePrincipalCertificateSendX5C_Text" valueName="credential.azreposServicePrincipalCertificateSendX5C" />
+      </elements>
+    </policy>
+    <policy name="GCM_trace2_normalTarget" class="Machine" displayName="$(string.GCM_trace2_normalTarget)" explainText="$(string.GCM_trace2_normalTarget_Explain)" presentation="$(presentation.GCM_trace2_normalTarget)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="trace2.normalTarget">
+      <parentCategory ref="GCM_Trace2" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_trace2_normalTarget_Text" valueName="trace2.normalTarget" />
+      </elements>
+    </policy>
+    <policy name="GCM_trace2_eventTarget" class="Machine" displayName="$(string.GCM_trace2_eventTarget)" explainText="$(string.GCM_trace2_eventTarget_Explain)" presentation="$(presentation.GCM_trace2_eventTarget)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="trace2.eventTarget">
+      <parentCategory ref="GCM_Trace2" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_trace2_eventTarget_Text" valueName="trace2.eventTarget" />
+      </elements>
+    </policy>
+    <policy name="GCM_trace2_perfTarget" class="Machine" displayName="$(string.GCM_trace2_perfTarget)" explainText="$(string.GCM_trace2_perfTarget_Explain)" presentation="$(presentation.GCM_trace2_perfTarget)" key="SOFTWARE\GitCredentialManager\Configuration" valueName="trace2.perfTarget">
+      <parentCategory ref="GCM_Trace2" />
+      <supportedOn ref="SUPPORTED_GCM" />
+      <elements>
+        <text id="GCM_trace2_perfTarget_Text" valueName="trace2.perfTarget" />
+      </elements>
+    </policy>
+  </policies>
+</policyDefinitions>

--- a/src/windows/policy-templates/en-US/GitCredentialManager.adml
+++ b/src/windows/policy-templates/en-US/GitCredentialManager.adml
@@ -1,0 +1,686 @@
+<?xml version="1.0" encoding="utf-8"?>
+<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+  <displayName>Git Credential Manager Policy Settings</displayName>
+  <description>Group Policy settings for Git Credential Manager.</description>
+  <resources>
+    <stringTable>
+      <string id="SUPPORTED_GCM">Git Credential Manager (any version)</string>
+      <string id="Cat_GitCredentialManager">Git Credential Manager</string>
+      <string id="Cat_GCM_Trace2">Trace2</string>
+      <string id="Cat_GCM_Tracing">Tracing</string>
+      <string id="Cat_GCM_Credentials">Credential Storage</string>
+      <string id="Cat_GCM_Authentication">Authentication</string>
+      <string id="Cat_GCM_AzureRepos">Azure Repos</string>
+      <string id="Cat_GCM_GitHub">GitHub</string>
+      <string id="Cat_GCM_Bitbucket">Bitbucket</string>
+      <string id="Cat_GCM_GitLab">GitLab</string>
+      <string id="Cat_GCM_General">General</string>
+      <string id="GCM_interactive">Interactive</string>
+      <string id="GCM_interactive_Explain">Permit or disable GCM from interacting with the user (showing GUI or TTY
+prompts). If interaction is required but has been disabled, an error is returned.
+
+This can be helpful when using GCM in headless and unattended environments, such
+as build servers, where it would be preferable to fail than to hang indefinitely
+waiting for a non-existent user.
+
+To disable interactivity set this to false or 0.
+
+Corresponds to git config key: credential.interactive</string>
+      <string id="GCM_trace">Trace</string>
+      <string id="GCM_trace_Explain">Enables trace logging of all activities.
+Configuring Git and GCM to trace to the same location is often desirable, and
+GCM is compatible and cooperative with GIT_TRACE.
+
+Corresponds to git config key: credential.trace</string>
+      <string id="GCM_traceSecrets">Trace Secrets</string>
+      <string id="GCM_traceSecrets_Explain">Enables tracing of secret and sensitive information, which is by default masked
+in trace output. Requires that credential.trace is also enabled.
+
+Corresponds to git config key: credential.traceSecrets</string>
+      <string id="GCM_traceMsAuth">Trace Ms Auth</string>
+      <string id="GCM_traceMsAuth_Explain">Enables inclusion of Microsoft Authentication library (MSAL) logs in GCM trace
+output. Requires that credential.trace is also enabled.
+
+Corresponds to git config key: credential.traceMsAuth</string>
+      <string id="GCM_debug">Debug</string>
+      <string id="GCM_debug_Explain">Pauses execution of GCM at launch to wait for a debugger to be attached.
+
+Corresponds to git config key: credential.debug</string>
+      <string id="GCM_provider">Provider</string>
+      <string id="GCM_provider_Explain">Define the host provider to use when authenticating.
+
+auto (default): [automatic] (learn more (autodetect.md))
+azure-repos: Azure Repos
+github: GitHub
+bitbucket: Bitbucket
+gitlab: GitLab (supports OAuth in browser, personal access token and Basic Authentication)
+generic: Generic (any other provider not listed above)
+
+Automatic provider selection is based on the remote URL.
+
+This setting is typically used with a scoped URL to map a particular set of
+remote URLs to providers, for example to mark a host as a GitHub Enterprise
+instance.
+
+Corresponds to git config key: credential.provider</string>
+      <string id="GCM_provider_Enum_auto">auto - [automatic] (learn more)</string>
+      <string id="GCM_provider_Enum_azure_repos">azure-repos - Azure Repos</string>
+      <string id="GCM_provider_Enum_github">github - GitHub</string>
+      <string id="GCM_provider_Enum_bitbucket">bitbucket - Bitbucket</string>
+      <string id="GCM_provider_Enum_gitlab">gitlab - GitLab (supports OAuth in browser, personal access token and Basic Authentication)</string>
+      <string id="GCM_provider_Enum_generic">generic - Generic (any other provider not listed above)</string>
+      <string id="GCM_authority">Authority</string>
+      <string id="GCM_authority_Explain">DEPRECATED. This setting is deprecated and should be replaced by credential.provider
+with the corresponding provider ID value.
+
+See the migration guide (migration.md#gcm_authority) for more information.
+
+Select the host provider to use when authenticating by which authority is
+supported by the providers.
+
+Authority: Provider(s)
+
+auto (default): [automatic]
+msa, microsoft, microsoftaccount, aad, azure, azuredirectory, live, liveconnect, liveid: Azure Repos (supports Microsoft Authentication)
+github: GitHub (supports GitHub Authentication)
+bitbucket: Bitbucket.org (supports Basic Authentication and OAuth), Bitbucket Server (supports Basic Authentication)
+gitlab: GitLab (supports OAuth in browser, personal access token and Basic Authentication)
+basic, integrated, windows, kerberos, ntlm, tfs, sso: Generic (supports Basic and Windows Integrated Authentication)
+
+Corresponds to git config key: credential.authority</string>
+      <string id="GCM_authority_Enum_auto">auto - [automatic]</string>
+      <string id="GCM_authority_Enum_msa">msa - Azure Repos (supports Microsoft Authentication)</string>
+      <string id="GCM_authority_Enum_github">github - GitHub (supports GitHub Authentication)</string>
+      <string id="GCM_authority_Enum_bitbucket">bitbucket - Bitbucket.org (supports Basic Authentication and OAuth), Bitbucket Server (supports Basic Authentication)</string>
+      <string id="GCM_authority_Enum_gitlab">gitlab - GitLab (supports OAuth in browser, personal access token and Basic Authentication)</string>
+      <string id="GCM_authority_Enum_basic">basic - Generic (supports Basic and Windows Integrated Authentication)</string>
+      <string id="GCM_guiPrompt">Gui Prompt</string>
+      <string id="GCM_guiPrompt_Explain">Permit or disable GCM from presenting GUI prompts. If an equivalent terminal/
+text-based prompt is available, that will be shown instead.
+
+To disable all interactivity see credential.interactive (#credentialinteractive).
+
+Corresponds to git config key: credential.guiPrompt</string>
+      <string id="GCM_guiSoftwareRendering">Gui Software Rendering</string>
+      <string id="GCM_guiSoftwareRendering_Explain">Force the use of software rendering for GUI prompts.
+
+This is currently only applicable on Windows.
+
+Corresponds to git config key: credential.guiSoftwareRendering</string>
+      <string id="GCM_allowUnsafeRemotes">Allow Unsafe Remotes</string>
+      <string id="GCM_allowUnsafeRemotes_Explain">Allow transmitting credentials to unsafe remote URLs such as unencrypted HTTP
+URLs. This setting is not recommended for general use and should only be used
+when necessary.
+
+Defaults false (disallow unsafe remote URLs).
+
+Corresponds to git config key: credential.allowUnsafeRemotes</string>
+      <string id="GCM_autoDetectTimeout">Auto Detect Timeout</string>
+      <string id="GCM_autoDetectTimeout_Explain">Set the maximum length of time, in milliseconds, that GCM should wait for a
+network response during host provider auto-detection probing.
+
+See auto-detection (autodetect.md) for more information.
+
+Note: Use a negative or zero value to disable probing altogether.
+
+Defaults to 2000 milliseconds (2 seconds).
+
+Corresponds to git config key: credential.autoDetectTimeout</string>
+      <string id="GCM_allowWindowsAuth">Allow Windows Auth</string>
+      <string id="GCM_allowWindowsAuth_Explain">Allow detection of Windows Integrated Authentication (WIA) support for generic
+host providers. Setting this value to false will prevent the use of WIA and
+force a basic authentication prompt when using the Generic host provider.
+
+Note: WIA is only supported on Windows.
+
+Note: WIA is an umbrella term for NTLM and Kerberos (and Negotiate).
+
+true (default): Permitted
+false: Not permitted
+
+Corresponds to git config key: credential.allowWindowsAuth</string>
+      <string id="GCM_allowWindowsAuth_Enum_true">true - Permitted</string>
+      <string id="GCM_allowWindowsAuth_Enum_false">false - Not permitted</string>
+      <string id="GCM_httpProxy">Http Proxy</string>
+      <string id="GCM_httpProxy_Explain">DEPRECATED. This setting is deprecated and should be replaced by the
+standard http.proxy Git configuration option (https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpproxy).
+
+See HTTP Proxy (netconfig.md#http-proxy) for more information.
+
+Configure GCM to use the a proxy for network operations.
+
+Note: Git itself does not respect this setting; this affects GCM only.
+
+Corresponds to git config key: credential.httpProxy</string>
+      <string id="GCM_bitbucketAuthModes">Bitbucket Auth Modes</string>
+      <string id="GCM_bitbucketAuthModes_Explain">Override the available authentication modes presented during Bitbucket
+authentication. If this option is not set, then the available authentication
+modes will be automatically detected.
+
+Note: This setting only applies to Bitbucket.org, and not Server or DC
+instances.
+
+Note: This setting supports multiple values separated by commas.
+
+(unset): Automatically detect modes
+oauth: OAuth-based authentication
+basic: Basic/PAT-based authentication
+
+Corresponds to git config key: credential.bitbucketAuthModes</string>
+      <string id="GCM_bitbucketAlwaysRefreshCredentials">Bitbucket Always Refresh Credentials</string>
+      <string id="GCM_bitbucketAlwaysRefreshCredentials_Explain">Forces GCM to ignore any existing stored Basic Auth or OAuth access tokens and
+always run through the process to refresh the credentials before returning them
+to Git.
+
+This is especially relevant to OAuth credentials. Bitbucket.org access tokens
+expire after 2 hours, after that the refresh token must be used to get a new
+access token.
+
+Enabling this option will improve performance when using Oauth2 and interacting
+with Bitbucket.org if, on average, commits are done less frequently than every
+2 hours.
+
+Enabling this option will decrease performance when using Basic Auth by
+requiring the user the re-enter credentials every time.
+
+true, 1, yes, on : Always
+false, 0, no, off_(default)_: Only when the credentials are found to be invalid
+
+Corresponds to git config key: credential.bitbucketAlwaysRefreshCredentials</string>
+      <string id="GCM_bitbucketAlwaysRefreshCredentials_Enum_true">true - Always</string>
+      <string id="GCM_bitbucketAlwaysRefreshCredentials_Enum_false">false - Only when the credentials are found to be invalid</string>
+      <string id="GCM_bitbucketValidateStoredCredentials">Bitbucket Validate Stored Credentials</string>
+      <string id="GCM_bitbucketValidateStoredCredentials_Explain">Forces GCM to validate any stored credentials before returning them to Git. It
+does this by calling a REST API resource that requires authentication.
+
+Disabling this option reduces the HTTP traffic within GCM when it is retrieving
+credentials. This may improve user performance, but will increase the number of
+times Git remote calls fail to authenticate with the host and therefore require
+the user to re-try the Git remote call.
+
+Enabling this option helps ensure Git is always provided with valid credentials.
+
+true, 1, yes, on_(default)_: Always
+false, 0, no, off: Never
+
+Corresponds to git config key: credential.bitbucketValidateStoredCredentials</string>
+      <string id="GCM_bitbucketValidateStoredCredentials_Enum_true">true - Always</string>
+      <string id="GCM_bitbucketValidateStoredCredentials_Enum_false">false - Never</string>
+      <string id="GCM_bitbucketDataCenterOAuthClientId">Bitbucket Data Center OAuth Client Id</string>
+      <string id="GCM_bitbucketDataCenterOAuthClientId_Explain">To use OAuth with Bitbucket DC it is necessary to create an external, incoming
+AppLink (https://confluence.atlassian.com/bitbucketserver/configure-an-incoming-link-1108483657.html).
+
+It is then necessary to configure the local GCM installation with both the OAuth
+ClientId and
+ClientSecret from
+the AppLink.
+
+Corresponds to git config key: credential.bitbucketDataCenterOAuthClientId</string>
+      <string id="GCM_bitbucketDataCenterOAuthClientSecret">Bitbucket Data Center OAuth Client Secret</string>
+      <string id="GCM_bitbucketDataCenterOAuthClientSecret_Explain">To use OAuth with Bitbucket DC it is necessary to create an external, incoming
+AppLink (https://confluence.atlassian.com/bitbucketserver/configure-an-incoming-link-1108483657.html).
+
+It is then necessary to configure the local GCM installation with both the OAuth
+ClientId and
+ClientSecret
+from the AppLink.
+
+Corresponds to git config key: credential.bitbucketDataCenterOAuthClientSecret</string>
+      <string id="GCM_gitHubAccountFiltering">GitHub Account Filtering</string>
+      <string id="GCM_gitHubAccountFiltering_Explain">Enable or disable automatic account filtering for GitHub based on server hints
+when there are multiple available accounts. This setting is only applicable to
+GitHub.com with Enterprise Managed Users (https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users).
+
+true (default): Filter available accounts based on server hints.
+false: Show all available accounts.
+
+Corresponds to git config key: credential.gitHubAccountFiltering</string>
+      <string id="GCM_gitHubAccountFiltering_Enum_true">true - Filter available accounts based on server hints.</string>
+      <string id="GCM_gitHubAccountFiltering_Enum_false">false - Show all available accounts.</string>
+      <string id="GCM_gitHubAuthModes">GitHub Auth Modes</string>
+      <string id="GCM_gitHubAuthModes_Explain">Override the available authentication modes presented during GitHub
+authentication. If this option is not set, then the available authentication
+modes will be automatically detected.
+
+Note: This setting supports multiple values separated by commas.
+
+(unset): Automatically detect modes
+oauth: Expands to: browser, device
+browser: OAuth authentication via a web browser (requires a GUI)
+device: OAuth authentication with a device code
+basic: Basic authentication using username and password
+pat: Personal Access Token (pat)-based authentication
+
+Corresponds to git config key: credential.gitHubAuthModes</string>
+      <string id="GCM_gitLabAuthModes">GitLab Auth Modes</string>
+      <string id="GCM_gitLabAuthModes_Explain">Override the available authentication modes presented during GitLab
+authentication. If this option is not set, then the available authentication
+modes will be automatically detected.
+
+Note: This setting supports multiple values separated by commas.
+
+(unset): Automatically detect modes
+browser: OAuth authentication via a web browser (requires a GUI)
+basic: Basic authentication using username and password
+pat: Personal Access Token (pat)-based authentication
+
+Corresponds to git config key: credential.gitLabAuthModes</string>
+      <string id="GCM_namespace">Namespace</string>
+      <string id="GCM_namespace_Explain">Use a custom namespace prefix for credentials read and written in the OS
+credential store. Credentials will be stored in the format
+{namespace}:{service}.
+
+Defaults to the value git.
+
+Corresponds to git config key: credential.namespace</string>
+      <string id="GCM_credentialStore">Credential Store</string>
+      <string id="GCM_credentialStore_Explain">Select the type of credential store to use on supported platforms.
+
+Default value on Windows is wincredman, on macOS is keychain, and is unset
+on Linux.
+
+Note: See more information about configuring secret stores in
+cred-stores (credstores.md).
+
+(unset): Windows: wincredman, macOS: keychain, Linux: (none): -
+wincredman: Windows Credential Manager (not available over SSH).: Windows
+dpapi: DPAPI protected files. Customize the DPAPI store location with credential.dpapiStorePath (#credentialdpapistorepath): Windows
+keychain: macOS Keychain.: macOS
+secretservice: freedesktop.org Secret Service API (https://specifications.freedesktop.org/secret-service-spec/) via libsecret (https://wiki.gnome.org/Projects/Libsecret) (requires a graphical interface to unlock secret collections).: Linux
+gpg: Use GPG to store encrypted files that are compatible with the pass (https://www.passwordstore.org/) (requires GPG and pass to initialize the store).: macOS, Linux
+cache: Git's built-in credential cache (https://git-scm.com/docs/git-credential-cache).: macOS, Linux
+plaintext: Store credentials in plaintext files (UNSECURE). Customize the plaintext store location with credential.plaintextStorePath (#credentialplaintextstorepath).: Windows, macOS, Linux
+none: Do not store credentials via GCM.: Windows, macOS, Linux
+
+Corresponds to git config key: credential.credentialStore</string>
+      <string id="GCM_credentialStore_Enum_wincredman">wincredman - Windows Credential Manager (not available over SSH).</string>
+      <string id="GCM_credentialStore_Enum_dpapi">dpapi - DPAPI protected files. Customize the DPAPI store location with credential.dpapiStorePath</string>
+      <string id="GCM_credentialStore_Enum_keychain">keychain - macOS Keychain.</string>
+      <string id="GCM_credentialStore_Enum_secretservice">secretservice - freedesktop.org Secret Service API via libsecret (requires a graphical interface to unlock secret collections).</string>
+      <string id="GCM_credentialStore_Enum_gpg">gpg - Use GPG to store encrypted files that are compatible with the pass (requires GPG and pass to initialize the store).</string>
+      <string id="GCM_credentialStore_Enum_cache">cache - Git's built-in credential cache.</string>
+      <string id="GCM_credentialStore_Enum_plaintext">plaintext - Store credentials in plaintext files (UNSECURE). Customize the plaintext store location with credential.plaintextStorePath.</string>
+      <string id="GCM_credentialStore_Enum_none">none - Do not store credentials via GCM.</string>
+      <string id="GCM_cacheOptions">Cache Options</string>
+      <string id="GCM_cacheOptions_Explain">Pass options (https://git-scm.com/docs/git-credential-cache#_options) to the Git credential cache when
+credential.credentialStore (#credentialcredentialstore)
+is set to cache. This allows you to select a different amount
+of time to cache credentials (the default is 900 seconds) by passing
+"--timeout &lt;seconds&gt;". Use of other options like --socket is untested
+and unsupported, but there's no reason it shouldn't work.
+
+Defaults to empty.
+
+Corresponds to git config key: credential.cacheOptions</string>
+      <string id="GCM_plaintextStorePath">Plaintext Store Path</string>
+      <string id="GCM_plaintextStorePath_Explain">Specify a custom directory to store plaintext credential files in when
+credential.credentialStore (#credentialcredentialstore) is set to plaintext.
+
+Defaults to the value ~/.gcm/store or %USERPROFILE%\.gcm\store.
+
+Corresponds to git config key: credential.plaintextStorePath</string>
+      <string id="GCM_dpapiStorePath">Dpapi Store Path</string>
+      <string id="GCM_dpapiStorePath_Explain">Specify a custom directory to store DPAPI protected credential files in when
+credential.credentialStore (#credentialcredentialstore) is set to dpapi.
+
+Defaults to the value %USERPROFILE%\.gcm\dpapi_store.
+
+Corresponds to git config key: credential.dpapiStorePath</string>
+      <string id="GCM_gpgPassStorePath">Gpg Pass Store Path</string>
+      <string id="GCM_gpgPassStorePath_Explain">Specify a custom directory to store GPG-encrypted pass (https://www.passwordstore.org/)-compatible credential files
+in when credential.credentialStore (#credentialcredentialstore) is set to gpg.
+
+Defaults to the value ~/.password-store or %USERPROFILE%\.password-store.
+
+Corresponds to git config key: credential.gpgPassStorePath</string>
+      <string id="GCM_msauthFlow">Msauth Flow</string>
+      <string id="GCM_msauthFlow_Explain">Specify which authentication flow should be used when performing Microsoft
+authentication and an interactive flow is required.
+
+Defaults to auto.
+
+Note: If credential.msauthUseBroker (#credentialmsauthusebroker-experimental) is set
+to true and the operating system authentication broker is available, all flows
+will be delegated to the broker. If both of those things are true, then the
+value of credential.msauthFlow has no effect.
+
+auto (default): Select the best option depending on the current environment and platform.
+embedded: Show a window with embedded web view control.
+system: Open the user's default web browser.
+devicecode: Show a device code.
+
+Corresponds to git config key: credential.msauthFlow</string>
+      <string id="GCM_msauthFlow_Enum_auto">auto - Select the best option depending on the current environment and platform.</string>
+      <string id="GCM_msauthFlow_Enum_embedded">embedded - Show a window with embedded web view control.</string>
+      <string id="GCM_msauthFlow_Enum_system">system - Open the user's default web browser.</string>
+      <string id="GCM_msauthFlow_Enum_devicecode">devicecode - Show a device code.</string>
+      <string id="GCM_msauthUseBroker">Msauth Use Broker</string>
+      <string id="GCM_msauthUseBroker_Explain">Use the operating system account manager where available.
+
+Defaults to false. In certain cloud hosted environments when using a work or
+school account, such as Microsoft DevBox (https://azure.microsoft.com/en-us/products/dev-box), the default is true.
+
+These defaults are subject to change in the future.
+
+_Note: before you enable this option on Windows, please review the
+Windows Broker (windows-broker.md) details for what this means to your local Windows user
+account._
+
+true: Use the operating system account manager as an authentication broker.
+false (default): Do not use the broker.
+
+Corresponds to git config key: credential.msauthUseBroker</string>
+      <string id="GCM_msauthUseBroker_Enum_true">true - Use the operating system account manager as an authentication broker.</string>
+      <string id="GCM_msauthUseBroker_Enum_false">false - Do not use the broker.</string>
+      <string id="GCM_msauthUseDefaultAccount">Msauth Use Default Account</string>
+      <string id="GCM_msauthUseDefaultAccount_Explain">Use the current operating system account by default when the broker is enabled.
+
+Defaults to false. In certain cloud hosted environments when using a work or
+school account, such as Microsoft DevBox (https://azure.microsoft.com/en-us/products/dev-box), the default is true.
+
+These defaults are subject to change in the future.
+
+true: Use the current operating system account by default.
+false (default): Do not assume any account to use by default.
+
+Corresponds to git config key: credential.msauthUseDefaultAccount</string>
+      <string id="GCM_msauthUseDefaultAccount_Enum_true">true - Use the current operating system account by default.</string>
+      <string id="GCM_msauthUseDefaultAccount_Enum_false">false - Do not assume any account to use by default.</string>
+      <string id="GCM_useHttpPath">Use Http Path</string>
+      <string id="GCM_useHttpPath_Explain">Tells Git to pass the entire repository URL, rather than just the hostname, when
+calling out to a credential provider. (This setting
+comes from Git itself (https://git-scm.com/docs/gitcredentials/#Documentation/gitcredentials.txt-useHttpPath), not GCM.)
+
+Defaults to false.
+
+Note: GCM sets this value to true for dev.azure.com (Azure Repos) hosts
+after installation by default.
+
+This is because dev.azure.com alone is not enough information to determine the
+correct Azure authentication authority - we require a part of the path. The
+fallout of this is that for dev.azure.com remote URLs we do not support
+storing credentials against the full-path. We always store against the
+dev.azure.com/org-name stub.
+
+In order to use Azure Repos and store credentials against a full-path URL, you
+must use the org-name.visualstudio.com remote URL format instead.
+
+false (default): Git will use only user and hostname to look up credentials.
+true: Git will use the full repository URL to look up credentials.
+
+Corresponds to git config key: credential.useHttpPath</string>
+      <string id="GCM_useHttpPath_Enum_false">false - Git will use only user and hostname to look up credentials.</string>
+      <string id="GCM_useHttpPath_Enum_true">true - Git will use the full repository URL to look up credentials.</string>
+      <string id="GCM_azreposCredentialType">Azrepos Credential Type</string>
+      <string id="GCM_azreposCredentialType_Explain">Specify the type of credential the Azure Repos host provider should return.
+
+Defaults to the value pat. In certain cloud hosted environments when using a
+work or school account, such as Microsoft DevBox (https://azure.microsoft.com/en-us/products/dev-box), the default value is
+oauth.
+
+pat: Azure DevOps personal access tokens
+oauth: Microsoft identity OAuth tokens (AAD or MSA tokens)
+
+Here is more information about Azure Access tokens (azrepos-users-and-tokens.md).
+
+Corresponds to git config key: credential.azreposCredentialType</string>
+      <string id="GCM_azreposCredentialType_Enum_pat">pat - Azure DevOps personal access tokens</string>
+      <string id="GCM_azreposCredentialType_Enum_oauth">oauth - Microsoft identity OAuth tokens (AAD or MSA tokens)</string>
+      <string id="GCM_azreposManagedIdentity">Azrepos Managed Identity</string>
+      <string id="GCM_azreposManagedIdentity_Explain">Use a Managed Identity (https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) to authenticate with Azure Repos.
+
+The value system will tell GCM to use the system-assigned Managed Identity.
+
+To specify a user-assigned Managed Identity, use the format id://{clientId}
+where {clientId} is the client ID of the Managed Identity. Alternatively any
+GUID-like value will also be interpreted as a user-assigned Managed Identity
+client ID.
+
+To specify a Managed Identity associated with an Azure resource, you can use the
+format resource://{resourceId} where {resourceId} is the ID of the resource.
+
+For more information about managed identities, see the Azure DevOps
+documentation (https://learn.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/service-principal-managed-identity).
+
+system: System-Assigned Managed Identity
+[guid]: User-Assigned Managed Identity with the specified client ID
+id://[guid]: User-Assigned Managed Identity with the specified client ID
+resource://[guid]: User-Assigned Managed Identity for the associated resource
+
+Also see: GCM_AZREPOS_MANAGEDIDENTITY (environment.md#GCM_AZREPOS_MANAGEDIDENTITY)
+
+Corresponds to git config key: credential.azreposManagedIdentity</string>
+      <string id="GCM_azreposServicePrincipal">Azrepos Service Principal</string>
+      <string id="GCM_azreposServicePrincipal_Explain">Specify the client and tenant IDs of a service principal (https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals)
+to use when performing Microsoft authentication for Azure Repos.
+
+The value of this setting should be in the format: {tenantId}/{clientId}.
+
+You must also set at least one authentication mechanism if you set this value:
+
+- credential.azreposServicePrincipalSecret (#credentialazreposserviceprincipalsecret)
+- credential.azreposServicePrincipalCertificateThumbprint (#credentialazreposserviceprincipalcertificatethumbprint)
+- credential.azreposServicePrincipalCertificateSendX5C (#credentialazreposserviceprincipalcertificatesendx5c)
+
+For more information about service principals, see the Azure DevOps
+documentation (https://learn.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/service-principal-managed-identity).
+
+Corresponds to git config key: credential.azreposServicePrincipal</string>
+      <string id="GCM_azreposServicePrincipalSecret">Azrepos Service Principal Secret</string>
+      <string id="GCM_azreposServicePrincipalSecret_Explain">Specifies the client secret for the service principal (https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals) when
+performing Microsoft authentication for Azure Repos with
+credential.azreposServicePrincipalSecret (#credentialazreposserviceprincipal) set.
+
+Corresponds to git config key: credential.azreposServicePrincipalSecret</string>
+      <string id="GCM_azreposServicePrincipalCertificateThumbprint">Azrepos Service Principal Certificate Thumbprint</string>
+      <string id="GCM_azreposServicePrincipalCertificateThumbprint_Explain">Specifies the thumbprint of a certificate to use when authenticating as a
+service principal (https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals) for Azure Repos when
+GCM_AZREPOS_SERVICE_PRINCIPAL (#credentialazreposserviceprincipal) is set.
+
+Corresponds to git config key: credential.azreposServicePrincipalCertificateThumbprint</string>
+      <string id="GCM_azreposServicePrincipalCertificateSendX5C">Azrepos Service Principal Certificate Send X5C</string>
+      <string id="GCM_azreposServicePrincipalCertificateSendX5C_Explain">When using a certificate for service principal (https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals) authentication, this configuration
+specifies whether the X5C claim should be should be sent to the STS. Sending the x5c
+enables application developers to achieve easy certificate rollover in Azure AD:
+this method will send the public certificate to Azure AD along with the token request,
+so that Azure AD can use it to validate the subject name based on a trusted issuer
+policy. This saves the application admin from the need to explicitly manage the
+certificate rollover. For details see https://aka.ms/msal-net-sni (https://aka.ms/msal-net-sni).
+
+Corresponds to git config key: credential.azreposServicePrincipalCertificateSendX5C</string>
+      <string id="GCM_trace2_normalTarget">Normal Target</string>
+      <string id="GCM_trace2_normalTarget_Explain">Turns on Trace2 Normal Format tracing - see Git's Trace2 Normal Format
+documentation (https://git-scm.com/docs/api-trace2#_the_normal_format_target) for more details.
+
+Corresponds to git config key: trace2.normalTarget</string>
+      <string id="GCM_trace2_eventTarget">Event Target</string>
+      <string id="GCM_trace2_eventTarget_Explain">Turns on Trace2 Event Format tracing - see Git's Trace2 Event Format
+documentation (https://git-scm.com/docs/api-trace2#_the_event_format_target) for more details.
+
+Corresponds to git config key: trace2.eventTarget</string>
+      <string id="GCM_trace2_perfTarget">Perf Target</string>
+      <string id="GCM_trace2_perfTarget_Explain">Turns on Trace2 Performance Format tracing - see Git's Trace2 Performance
+Format documentation (https://git-scm.com/docs/api-trace2#_the_performance_format_target) for more details.
+
+Corresponds to git config key: trace2.perfTarget</string>
+    </stringTable>
+    <presentationTable>
+      <presentation id="GCM_interactive">
+        <textBox refId="GCM_interactive_Text">
+          <label>Interactive:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_trace">
+        <textBox refId="GCM_trace_Text">
+          <label>Trace:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_traceSecrets">
+        <textBox refId="GCM_traceSecrets_Text">
+          <label>Trace Secrets:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_traceMsAuth">
+        <textBox refId="GCM_traceMsAuth_Text">
+          <label>Trace Ms Auth:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_debug">
+        <textBox refId="GCM_debug_Text">
+          <label>Debug:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_provider">
+        <dropdownList refId="GCM_provider_Enum" noSort="true">Provider:</dropdownList>
+      </presentation>
+      <presentation id="GCM_authority">
+        <dropdownList refId="GCM_authority_Enum" noSort="true">Authority:</dropdownList>
+      </presentation>
+      <presentation id="GCM_guiPrompt">
+        <textBox refId="GCM_guiPrompt_Text">
+          <label>Gui Prompt:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_guiSoftwareRendering">
+        <textBox refId="GCM_guiSoftwareRendering_Text">
+          <label>Gui Software Rendering:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_allowUnsafeRemotes">
+        <textBox refId="GCM_allowUnsafeRemotes_Text">
+          <label>Allow Unsafe Remotes:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_autoDetectTimeout">
+        <textBox refId="GCM_autoDetectTimeout_Text">
+          <label>Auto Detect Timeout:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_allowWindowsAuth">
+        <dropdownList refId="GCM_allowWindowsAuth_Enum" noSort="true">Allow Windows Auth:</dropdownList>
+      </presentation>
+      <presentation id="GCM_httpProxy">
+        <textBox refId="GCM_httpProxy_Text">
+          <label>Http Proxy:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_bitbucketAuthModes">
+        <textBox refId="GCM_bitbucketAuthModes_Text">
+          <label>Bitbucket Auth Modes:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_bitbucketAlwaysRefreshCredentials">
+        <dropdownList refId="GCM_bitbucketAlwaysRefreshCredentials_Enum" noSort="true">Bitbucket Always Refresh Credentials:</dropdownList>
+      </presentation>
+      <presentation id="GCM_bitbucketValidateStoredCredentials">
+        <dropdownList refId="GCM_bitbucketValidateStoredCredentials_Enum" noSort="true">Bitbucket Validate Stored Credentials:</dropdownList>
+      </presentation>
+      <presentation id="GCM_bitbucketDataCenterOAuthClientId">
+        <textBox refId="GCM_bitbucketDataCenterOAuthClientId_Text">
+          <label>Bitbucket Data Center OAuth Client Id:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_bitbucketDataCenterOAuthClientSecret">
+        <textBox refId="GCM_bitbucketDataCenterOAuthClientSecret_Text">
+          <label>Bitbucket Data Center OAuth Client Secret:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_gitHubAccountFiltering">
+        <dropdownList refId="GCM_gitHubAccountFiltering_Enum" noSort="true">GitHub Account Filtering:</dropdownList>
+      </presentation>
+      <presentation id="GCM_gitHubAuthModes">
+        <textBox refId="GCM_gitHubAuthModes_Text">
+          <label>GitHub Auth Modes:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_gitLabAuthModes">
+        <textBox refId="GCM_gitLabAuthModes_Text">
+          <label>GitLab Auth Modes:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_namespace">
+        <textBox refId="GCM_namespace_Text">
+          <label>Namespace:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_credentialStore">
+        <dropdownList refId="GCM_credentialStore_Enum" noSort="true">Credential Store:</dropdownList>
+      </presentation>
+      <presentation id="GCM_cacheOptions">
+        <textBox refId="GCM_cacheOptions_Text">
+          <label>Cache Options:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_plaintextStorePath">
+        <textBox refId="GCM_plaintextStorePath_Text">
+          <label>Plaintext Store Path:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_dpapiStorePath">
+        <textBox refId="GCM_dpapiStorePath_Text">
+          <label>Dpapi Store Path:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_gpgPassStorePath">
+        <textBox refId="GCM_gpgPassStorePath_Text">
+          <label>Gpg Pass Store Path:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_msauthFlow">
+        <dropdownList refId="GCM_msauthFlow_Enum" noSort="true">Msauth Flow:</dropdownList>
+      </presentation>
+      <presentation id="GCM_msauthUseBroker">
+        <dropdownList refId="GCM_msauthUseBroker_Enum" noSort="true">Msauth Use Broker:</dropdownList>
+      </presentation>
+      <presentation id="GCM_msauthUseDefaultAccount">
+        <dropdownList refId="GCM_msauthUseDefaultAccount_Enum" noSort="true">Msauth Use Default Account:</dropdownList>
+      </presentation>
+      <presentation id="GCM_useHttpPath">
+        <dropdownList refId="GCM_useHttpPath_Enum" noSort="true">Use Http Path:</dropdownList>
+      </presentation>
+      <presentation id="GCM_azreposCredentialType">
+        <dropdownList refId="GCM_azreposCredentialType_Enum" noSort="true">Azrepos Credential Type:</dropdownList>
+      </presentation>
+      <presentation id="GCM_azreposManagedIdentity">
+        <textBox refId="GCM_azreposManagedIdentity_Text">
+          <label>Azrepos Managed Identity:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_azreposServicePrincipal">
+        <textBox refId="GCM_azreposServicePrincipal_Text">
+          <label>Azrepos Service Principal:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_azreposServicePrincipalSecret">
+        <textBox refId="GCM_azreposServicePrincipalSecret_Text">
+          <label>Azrepos Service Principal Secret:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_azreposServicePrincipalCertificateThumbprint">
+        <textBox refId="GCM_azreposServicePrincipalCertificateThumbprint_Text">
+          <label>Azrepos Service Principal Certificate Thumbprint:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_azreposServicePrincipalCertificateSendX5C">
+        <textBox refId="GCM_azreposServicePrincipalCertificateSendX5C_Text">
+          <label>Azrepos Service Principal Certificate Send X5C:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_trace2_normalTarget">
+        <textBox refId="GCM_trace2_normalTarget_Text">
+          <label>Normal Target:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_trace2_eventTarget">
+        <textBox refId="GCM_trace2_eventTarget_Text">
+          <label>Event Target:</label>
+        </textBox>
+      </presentation>
+      <presentation id="GCM_trace2_perfTarget">
+        <textBox refId="GCM_trace2_perfTarget_Text">
+          <label>Perf Target:</label>
+        </textBox>
+      </presentation>
+    </presentationTable>
+  </resources>
+</policyDefinitionResources>

--- a/src/windows/policy-templates/generate-admx.ps1
+++ b/src/windows/policy-templates/generate-admx.ps1
@@ -1,0 +1,347 @@
+<#
+.SYNOPSIS
+    Generates Windows Group Policy ADMX/ADML templates for Git Credential Manager.
+
+.DESCRIPTION
+    Parses docs/configuration.md to extract all GCM configuration settings and
+    generates GitCredentialManager.admx and en-US/GitCredentialManager.adml in
+    the same directory as this script.
+
+.EXAMPLE
+    ./generate-admx.ps1
+
+.EXAMPLE
+    ./generate-admx.ps1 -ConfigurationMd ../../../docs/configuration.md
+#>
+
+param(
+    [string]$ConfigurationMd = (Join-Path $PSScriptRoot '../../../docs/configuration.md'),
+    [string]$OutputDir       = $PSScriptRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$REGISTRY_KEY = 'SOFTWARE\GitCredentialManager\Configuration'
+$GP_NS        = 'http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions'
+$XSD_NS       = 'http://www.w3.org/2001/XMLSchema'
+$XSI_NS       = 'http://www.w3.org/2001/XMLSchema-instance'
+$XMLNS_NS     = 'http://www.w3.org/2000/xmlns/'
+
+$categories = @(
+    [ordered]@{ Name = 'GitCredentialManager'; Display = 'Git Credential Manager'; Parent = $null;                  Pattern = $null }
+    [ordered]@{ Name = 'GCM_Trace2';           Display = 'Trace2';                 Parent = 'GitCredentialManager'; Pattern = '^trace2\.' }
+    [ordered]@{ Name = 'GCM_Tracing';          Display = 'Tracing';                Parent = 'GitCredentialManager'; Pattern = '\.trace' }
+    [ordered]@{ Name = 'GCM_Credentials';      Display = 'Credential Storage';     Parent = 'GitCredentialManager'; Pattern = 'Store(Path)?$|\.cacheOptions$' }
+    [ordered]@{ Name = 'GCM_Authentication';   Display = 'Authentication';         Parent = 'GitCredentialManager'; Pattern = '\.msauth' }
+    [ordered]@{ Name = 'GCM_AzureRepos';       Display = 'Azure Repos';            Parent = 'GitCredentialManager'; Pattern = '\.azrepos' }
+    [ordered]@{ Name = 'GCM_GitHub';           Display = 'GitHub';                 Parent = 'GitCredentialManager'; Pattern = '\.github' }
+    [ordered]@{ Name = 'GCM_Bitbucket';        Display = 'Bitbucket';              Parent = 'GitCredentialManager'; Pattern = '\.bitbucket' }
+    [ordered]@{ Name = 'GCM_GitLab';           Display = 'GitLab';                 Parent = 'GitCredentialManager'; Pattern = '\.gitlab' }
+    [ordered]@{ Name = 'GCM_General';          Display = 'General';                Parent = 'GitCredentialManager'; Pattern = $null }
+)
+
+function New-XmlWriter {
+    param([string]$Path)
+    $xs = [System.Xml.XmlWriterSettings]::new()
+    $xs.Indent          = $true
+    $xs.IndentChars     = '  '
+    $xs.Encoding        = [System.Text.UTF8Encoding]::new($false)
+    $xs.NewLineHandling = [System.Xml.NewLineHandling]::Replace
+    return [System.Xml.XmlWriter]::Create($Path, $xs)
+}
+
+function Write-AdmlString {
+    param($Writer, [string]$Id, [string]$Value)
+    $Writer.WriteStartElement('string')
+    $Writer.WriteAttributeString('id', $Id)
+    $Writer.WriteString($Value)
+    $Writer.WriteEndElement()
+}
+
+$content = Get-Content -LiteralPath $ConfigurationMd -Raw
+$settings = [System.Collections.Generic.List[hashtable]]::new()
+
+# Build a map of link-reference -> URL from the document footer
+$linkDefs = @{}
+foreach ($ld in [regex]::Matches($content, '(?m)^\[([^\]]+)\]:\s*(\S+)')) {
+    $linkDefs[$ld.Groups[1].Value.ToLower()] = $ld.Groups[2].Value
+}
+
+# Match any namespace.setting heading plus the description paragraph that
+# immediately follows it (up to the first subheading, horizontal rule, or EOF).
+$pattern = '(?ms)^### ((\w+)\.(\S+?))(?:\s+_\([^)]+\)_)* *\n\n(.*?)(?=\n####|\n---|\Z)'
+foreach ($m in [regex]::Matches($content, $pattern)) {
+    $fullKey   = $m.Groups[1].Value
+    $namespace = $m.Groups[2].Value
+    $valueName = $m.Groups[3].Value
+
+    $rawDesc = $m.Groups[4].Value
+    $plain   = $rawDesc
+
+    # Check if this setting supports multiple comma-separated values
+    $multiValue = $rawDesc -match 'multiple values separated by commas'
+
+    # Extract enum options from a markdown table if present and not multi-value
+    $enumOptions = $null
+    if (-not $multiValue) {
+        $optRows = [System.Collections.Generic.List[hashtable]]::new()
+        foreach ($row in [regex]::Matches($rawDesc, '(?m)^\s*`([^`]+)`[^|\n]*\|([^|\n]+)')) {
+            $val = $row.Groups[1].Value
+            # Skip placeholder/template values (e.g. [guid], id://[guid])
+            if ($val -match '[\[\{]|//') { continue }
+            # Strip markdown from the description column
+            $desc = $row.Groups[2].Value.Trim() `
+                -replace '`([^`]+)`',              '$1' `
+                -replace '\*\*(.+?)\*\*',          '$1' `
+                -replace '(?<![_\w])_(.+?)_(?![_\w])', '$1' `
+                -replace '\\\[',                   '[' `
+                -replace '\\\]',                   ']' `
+                -replace '\[([^\]]+)\]\[[^\]]*\]', '$1' `
+                -replace '\[([^\]]+)\]\([^\)]*\)', '$1' `
+                -replace '<https?://[^>]+>',        ''
+            $optRows.Add(@{ Value = $val; Id = ($val -replace '[^A-Za-z0-9]', '_'); Display = "$val - $($desc.Trim())" })
+        }
+        if ($optRows.Count -ge 2) { $enumOptions = $optRows.ToArray() }
+    }
+
+    # Strip fenced code blocks
+    $plain = $plain -replace '(?ms)```[^`]*?```', ''
+
+    # Strip table header rows (plain word|word lines with no backticks) before pipe processing
+    $plain = $plain -replace '(?m)^[A-Za-z][\w ]*(\|[\w ]+)+\s*$', ''
+
+    # Strip inline code markers, keeping the text
+    $plain = $plain -replace '`([^`]+)`', '$1'
+
+    # Resolve reference-style links [text][ref]: include URL/path for all known links
+    foreach ($ld in $linkDefs.GetEnumerator()) {
+        $escaped = [regex]::Escape($ld.Key)
+        $plain = $plain -replace "\[([^\]]+)\]\[$escaped\]", "`$1 ($($ld.Value))"
+    }
+    $plain = $plain -replace '\[([^\]]+)\]\[[^\]]*\]', '$1'
+
+    # Resolve inline links [text](url): keep HTTP URLs, drop relative ones
+    $plain = [regex]::Replace($plain, '\[([^\]]+)\]\(([^\)]*)\)', {
+        param($match)
+        $text = $match.Groups[1].Value
+        $url  = $match.Groups[2].Value
+        if ($url -match '^https?://') { return "$text ($url)" }
+        return $text
+    })
+
+    # Preserve bare autolinks <https://...>
+    $plain = $plain -replace '<(https?://[^>]+)>', '$1'
+
+    $plain = $plain `
+        -replace '\\\[',                              '[' `
+        -replace '\\\]',                              ']' `
+        -replace '\*\*(.+?)\*\*',                    '$1' `
+        -replace '(?<!\*)\*(.+?)(?<!\*)\*(?!\*)',    '$1' `
+        -replace '(?<![_\w])_(.+?)_(?![_\w])',       '$1' `
+        -replace '(?m)^> ?',                         '' `
+        -replace '(?m)^[\-|: ]+$',                   '' `
+        -replace '\|',                               ': '
+    $plain = ($plain -split '\r?\n' | ForEach-Object { $_.TrimEnd() }) -join "`n"
+    $plain = [regex]::Replace($plain, '\n{3,}', "`n`n").Trim()
+
+    $deprecated  = $m.Value -match '_\(deprecated\)_'
+    $explainText = if ($plain) { "$plain`n`nCorresponds to git config key: $fullKey" }
+                  else         { "Corresponds to git config key: $fullKey" }
+    if ($deprecated) { $explainText = "DEPRECATED. $explainText" }
+
+    $policyName = if ($namespace -eq 'trace2') {
+        "GCM_trace2_$($valueName -replace '[^A-Za-z0-9]', '_')"
+    } else {
+        "GCM_$($valueName -replace '[^A-Za-z0-9]', '_')"
+    }
+
+    # Split camelCase on lowercase-to-uppercase boundaries only (not digit-to-uppercase)
+    $displayName = [regex]::Replace($valueName, '(?<=[a-z])(?=[A-Z])', ' ')
+    $displayName = $displayName.Substring(0,1).ToUpper() + $displayName.Substring(1)
+    # Preserve known compound brand names that camelCase splitting would break
+    $displayName = $displayName -replace '\bGit Hub\b', 'GitHub' -replace '\bGit Lab\b', 'GitLab'
+
+    $matched  = $categories | Where-Object { $_.Pattern -and $fullKey -match $_.Pattern } | Select-Object -First 1
+    $category = if ($matched) { $matched.Name } else { 'GCM_General' }
+
+    $settings.Add(@{
+        PolicyName  = $policyName
+        ValueName   = $fullKey
+        Category    = $category
+        DisplayName = $displayName
+        Explain     = $explainText
+        EnumOptions = $enumOptions
+    })
+}
+
+Write-Host "Parsed $($settings.Count) settings from $(Split-Path $ConfigurationMd -Leaf)"
+
+$admxPath = Join-Path $OutputDir 'GitCredentialManager.admx'
+$xw = New-XmlWriter $admxPath
+
+$xw.WriteStartDocument()
+$xw.WriteStartElement('policyDefinitions', $GP_NS)
+$xw.WriteAttributeString('xmlns', 'xsd', $XMLNS_NS, $XSD_NS)
+$xw.WriteAttributeString('xmlns', 'xsi', $XMLNS_NS, $XSI_NS)
+$xw.WriteAttributeString('revision', '1.0')
+$xw.WriteAttributeString('schemaVersion', '1.0')
+
+$xw.WriteStartElement('policyNamespaces')
+$xw.WriteStartElement('target')
+$xw.WriteAttributeString('prefix', 'GCM')
+$xw.WriteAttributeString('namespace', 'Git.Policies.GitCredentialManager')
+$xw.WriteEndElement()
+$xw.WriteStartElement('using')
+$xw.WriteAttributeString('prefix', 'windows')
+$xw.WriteAttributeString('namespace', 'Microsoft.Policies.Windows')
+$xw.WriteEndElement()
+$xw.WriteEndElement()
+
+$xw.WriteStartElement('supersededAdm')
+$xw.WriteAttributeString('fileName', '')
+$xw.WriteEndElement()
+$xw.WriteStartElement('resources')
+$xw.WriteAttributeString('minRequiredRevision', '1.0')
+$xw.WriteEndElement()
+
+$xw.WriteStartElement('supportedOn')
+$xw.WriteStartElement('definitions')
+$xw.WriteStartElement('definition')
+$xw.WriteAttributeString('name', 'SUPPORTED_GCM')
+$xw.WriteAttributeString('displayName', '$(string.SUPPORTED_GCM)')
+$xw.WriteEndElement()
+$xw.WriteEndElement()
+$xw.WriteEndElement()
+
+$xw.WriteStartElement('categories')
+foreach ($cat in $categories) {
+    $xw.WriteStartElement('category')
+    $xw.WriteAttributeString('name', $cat.Name)
+    $xw.WriteAttributeString('displayName', "`$(string.Cat_$($cat.Name))")
+    if ($cat.Parent) {
+        $xw.WriteStartElement('parentCategory')
+        $xw.WriteAttributeString('ref', $cat.Parent)
+        $xw.WriteEndElement()
+    }
+    $xw.WriteEndElement()
+}
+$xw.WriteEndElement()
+
+$xw.WriteStartElement('policies')
+foreach ($s in $settings) {
+    $xw.WriteStartElement('policy')
+    $xw.WriteAttributeString('name', $s.PolicyName)
+    $xw.WriteAttributeString('class', 'Machine')
+    $xw.WriteAttributeString('displayName', "`$(string.$($s.PolicyName))")
+    $xw.WriteAttributeString('explainText', "`$(string.$($s.PolicyName)_Explain)")
+    $xw.WriteAttributeString('presentation', "`$(presentation.$($s.PolicyName))")
+    $xw.WriteAttributeString('key', $REGISTRY_KEY)
+    $xw.WriteAttributeString('valueName', $s.ValueName)
+
+    $xw.WriteStartElement('parentCategory')
+    $xw.WriteAttributeString('ref', $s.Category)
+    $xw.WriteEndElement()
+
+    $xw.WriteStartElement('supportedOn')
+    $xw.WriteAttributeString('ref', 'SUPPORTED_GCM')
+    $xw.WriteEndElement()
+
+    $xw.WriteStartElement('elements')
+    if ($s.EnumOptions) {
+        $xw.WriteStartElement('enum')
+        $xw.WriteAttributeString('id', "$($s.PolicyName)_Enum")
+        $xw.WriteAttributeString('valueName', $s.ValueName)
+        foreach ($opt in $s.EnumOptions) {
+            $xw.WriteStartElement('item')
+            $xw.WriteAttributeString('displayName', "`$(string.$($s.PolicyName)_Enum_$($opt.Id))")
+            $xw.WriteStartElement('value')
+            $xw.WriteStartElement('string')
+            $xw.WriteString($opt.Value)
+            $xw.WriteEndElement()
+            $xw.WriteEndElement()
+            $xw.WriteEndElement()
+        }
+        $xw.WriteEndElement()
+    } else {
+        $xw.WriteStartElement('text')
+        $xw.WriteAttributeString('id', "$($s.PolicyName)_Text")
+        $xw.WriteAttributeString('valueName', $s.ValueName)
+        $xw.WriteEndElement()
+    }
+    $xw.WriteEndElement()
+
+    $xw.WriteEndElement()
+}
+$xw.WriteEndElement()
+
+$xw.WriteEndElement()
+$xw.WriteEndDocument()
+$xw.Flush()
+$xw.Close()
+
+Write-Host "Written: $admxPath"
+
+$enUsDir = Join-Path $OutputDir 'en-US'
+if (-not (Test-Path $enUsDir)) { New-Item -ItemType Directory -Path $enUsDir | Out-Null }
+$admlPath = Join-Path $enUsDir 'GitCredentialManager.adml'
+
+$xw = New-XmlWriter $admlPath
+
+$xw.WriteStartDocument()
+$xw.WriteStartElement('policyDefinitionResources', $GP_NS)
+$xw.WriteAttributeString('xmlns', 'xsd', $XMLNS_NS, $XSD_NS)
+$xw.WriteAttributeString('xmlns', 'xsi', $XMLNS_NS, $XSI_NS)
+$xw.WriteAttributeString('revision', '1.0')
+$xw.WriteAttributeString('schemaVersion', '1.0')
+
+$xw.WriteElementString('displayName', 'Git Credential Manager Policy Settings')
+$xw.WriteElementString('description', 'Group Policy settings for Git Credential Manager.')
+
+$xw.WriteStartElement('resources')
+$xw.WriteStartElement('stringTable')
+
+Write-AdmlString $xw 'SUPPORTED_GCM' 'Git Credential Manager (any version)'
+foreach ($cat in $categories) {
+    Write-AdmlString $xw "Cat_$($cat.Name)" $cat.Display
+}
+foreach ($s in $settings) {
+    Write-AdmlString $xw $s.PolicyName $s.DisplayName
+    Write-AdmlString $xw "$($s.PolicyName)_Explain" $s.Explain
+    if ($s.EnumOptions) {
+        foreach ($opt in $s.EnumOptions) {
+            Write-AdmlString $xw "$($s.PolicyName)_Enum_$($opt.Id)" $opt.Display
+        }
+    }
+}
+
+$xw.WriteEndElement() # stringTable
+
+$xw.WriteStartElement('presentationTable')
+foreach ($s in $settings) {
+    $xw.WriteStartElement('presentation')
+    $xw.WriteAttributeString('id', $s.PolicyName)
+    if ($s.EnumOptions) {
+        $xw.WriteStartElement('dropdownList')
+        $xw.WriteAttributeString('refId', "$($s.PolicyName)_Enum")
+        $xw.WriteAttributeString('noSort', 'true')
+        $xw.WriteString("$($s.DisplayName):")
+        $xw.WriteEndElement()
+    } else {
+        $xw.WriteStartElement('textBox')
+        $xw.WriteAttributeString('refId', "$($s.PolicyName)_Text")
+        $xw.WriteElementString('label', "$($s.DisplayName):")
+        $xw.WriteEndElement()
+    }
+    $xw.WriteEndElement()
+}
+$xw.WriteEndElement() # presentationTable
+
+$xw.WriteEndElement() # resources
+$xw.WriteEndElement() # policyDefinitionResources
+$xw.WriteEndDocument()
+$xw.Flush()
+$xw.Close()
+
+Write-Host "Written: $admlPath"
+Write-Host "Done. Generated $($settings.Count) policy settings."


### PR DESCRIPTION
Windows registry keys are easier to configure using Group Policy templates rather than directly, especially with products like Intune that can only set registry keys through scripts or templates.

I've included a PowerShell script to generate the ADMX/ADML files from `configuration.md`, so they can be regenerated as the doc changes. This approach is used by large projects like browsers and vscode, but the files could be updated manually instead if you think the script is too brittle.

Example of generated UX in the local Group Policy editor:

<img width="1532" height="970" alt="image" src="https://github.com/user-attachments/assets/aecbf2f2-25a2-4a0b-841e-065f5320bf22" />
