### PR TITLE
Update Kerberos/NTLM docs

### DIFF
--- a/docs/ntlm-kerberos.md
+++ b/docs/ntlm-kerberos.md
@@ -85,6 +85,18 @@ On Windows, Git can use the native Windows [SSPI][sspi-wiki] (Security Support
 Provider Interface) to perform NTLM and Kerberos authentication. This allows Git
 to integrate seamlessly with the Windows authentication infrastructure.
 
+> [!IMPORTANT]
+> Kerberos authentication is not enabled by default in Git due to a known bug.
+>
+> To workaround this bug and enable Kerberos authentication, you must set the
+> `http.<url>.emptyAuth` configuration option to `true` for your remote URL.
+>
+> For example:
+>
+> ```shell
+> git config --global http.https://example.com.emptyAuth true
+> ```
+
 > [!NOTE]
 > As of Git for Windows version 2.53.0.2, **NTLM support is disabled by
 > default**.

--- a/docs/ntlm-kerberos.md
+++ b/docs/ntlm-kerberos.md
@@ -49,6 +49,30 @@ server to agree on which authentication protocol to use (Kerberos or NTLM) based
 on their capabilities. Typically Kerberos is preferred if both the client and
 server support it, with NTLM acting as a fallback.
 
+#### NTLM-over-SPNEGO
+
+> [!CAUTION]
+> When using SPNEGO negotiation if either the client or server does not support
+> Kerberos, or if there is an issue with Kerberos authentication, _NTLM may be
+> selected as a fallback authentication protocol_.
+>
+> **This can expose you to all the security risks associated with NTLM.**
+
+Currently the only way to prevent NTLM from being used as a fallback when SPNEGO
+negotiation is in use on Windows is to set the following registry key on your
+client system to the value `2` (type `DWORD`) to disable NTLM support
+system-wide:
+
+```text
+HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0\RestrictSendingNTLMTraffic
+```
+
+> [!WARNING]
+> Disabling NTLM support system-wide can have unintended consequences.
+>
+> NTLM is still often used in various legacy applications and services, and
+> disabling it may cause authentication failures in those applications.
+
 ## Built-in Support in Git
 
 Git provides built-in support for NTLM and Kerberos authentication through the


### PR DESCRIPTION
Clarify the risks of NTLM fallback during SPNEGO negotiation and offer instructions for disabling NTLM.

Detail the bug and workaround for enabling Kerberos authentication in Git.