### PR TITLE
Fix several small bugs that an AI agent detected

### DIFF
--- a/src/osx/Installer.Mac/notarize.sh
+++ b/src/osx/Installer.Mac/notarize.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+die () {
+    echo "$*" >&2
+    exit 1
+}
 
 for i in "$@"
 do

--- a/src/shared/Core.Tests/Commands/DiagnoseCommandTests.cs
+++ b/src/shared/Core.Tests/Commands/DiagnoseCommandTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http;
 using System.Security.AccessControl;
 using System.Text;
+using System.Threading.Tasks;
 using GitCredentialManager.Diagnostics;
 using GitCredentialManager.Tests.Objects;
 using Xunit;
@@ -11,7 +12,7 @@ namespace Core.Tests.Commands;
 public class DiagnoseCommandTests
 {
     [Fact]
-    public void NetworkingDiagnostic_SendHttpRequest_Primary_OK()
+    public async Task NetworkingDiagnostic_SendHttpRequest_Primary_OK()
     {
         var primaryUriString = "http://example.com";
         var sb = new StringBuilder();
@@ -24,14 +25,14 @@ public class DiagnoseCommandTests
 
         httpHandler.Setup(HttpMethod.Head, primaryUri, httpResponse);
 
-        networkingDiagnostic.SendHttpRequest(sb, new HttpClient(httpHandler));
+        await networkingDiagnostic.SendHttpRequestAsync(sb, new HttpClient(httpHandler));
 
         httpHandler.AssertRequest(HttpMethod.Head, primaryUri, expectedNumberOfCalls: 1);
         Assert.Contains(expected, sb.ToString());
     }
 
     [Fact]
-    public void NetworkingDiagnostic_SendHttpRequest_Backup_OK()
+    public async Task NetworkingDiagnostic_SendHttpRequest_Backup_OK()
     {
         var primaryUriString = "http://example.com";
         var backupUriString = "http://httpforever.com";
@@ -48,7 +49,7 @@ public class DiagnoseCommandTests
         httpHandler.Setup(HttpMethod.Head, primaryUri, httpResponse);
         httpHandler.Setup(HttpMethod.Head, backupUri, httpResponse);
 
-        networkingDiagnostic.SendHttpRequest(sb, new HttpClient(httpHandler));
+        await networkingDiagnostic.SendHttpRequestAsync(sb, new HttpClient(httpHandler));
 
         httpHandler.AssertRequest(HttpMethod.Head, primaryUri, expectedNumberOfCalls: 1);
         httpHandler.AssertRequest(HttpMethod.Head, backupUri, expectedNumberOfCalls: 1);
@@ -56,7 +57,7 @@ public class DiagnoseCommandTests
     }
 
     [Fact]
-    public void NetworkingDiagnostic_SendHttpRequest_No_Network()
+    public async Task NetworkingDiagnostic_SendHttpRequest_No_Network()
     {
         var primaryUriString = "http://example.com";
         var backupUriString = "http://httpforever.com";
@@ -73,7 +74,7 @@ public class DiagnoseCommandTests
         httpHandler.Setup(HttpMethod.Head, primaryUri, httpResponse);
         httpHandler.Setup(HttpMethod.Head, backupUri, httpResponse);
 
-        networkingDiagnostic.SendHttpRequest(sb, new HttpClient(httpHandler));
+        await networkingDiagnostic.SendHttpRequestAsync(sb, new HttpClient(httpHandler));
 
         httpHandler.AssertRequest(HttpMethod.Head, primaryUri, expectedNumberOfCalls: 1);
         httpHandler.AssertRequest(HttpMethod.Head, backupUri, expectedNumberOfCalls: 1);

--- a/src/shared/Core.Tests/EnvironmentTests.cs
+++ b/src/shared/Core.Tests/EnvironmentTests.cs
@@ -94,6 +94,7 @@ namespace GitCredentialManager.Tests
                     [expectedPath] = Array.Empty<byte>(),
                 }
             };
+            fs.SetExecutable(expectedPath);
             var envars = new Dictionary<string, string> {["PATH"] = PosixPathVar};
             var env = new PosixEnvironment(fs, envars);
 
@@ -116,6 +117,32 @@ namespace GitCredentialManager.Tests
                     ["/bin/foo"] = Array.Empty<byte>(),
                 }
             };
+            fs.SetExecutable(expectedPath);
+            fs.SetExecutable("/usr/local/bin/foo");
+            fs.SetExecutable("/bin/foo");
+            var envars = new Dictionary<string, string> {["PATH"] = PosixPathVar};
+            var env = new PosixEnvironment(fs, envars);
+
+            bool actualResult = env.TryLocateExecutable(PosixExecName, out string actualPath);
+
+            Assert.True(actualResult);
+            Assert.Equal(expectedPath, actualPath);
+        }
+
+        [PosixFact]
+        public void PosixEnvironment_TryLocateExecutable_NotExecutable_SkipsToNextMatch()
+        {
+            string nonExecPath = "/home/john.doe/bin/foo";
+            string expectedPath = "/usr/local/bin/foo";
+            var fs = new TestFileSystem
+            {
+                Files = new Dictionary<string, byte[]>
+                {
+                    [nonExecPath] = Array.Empty<byte>(),
+                    [expectedPath] = Array.Empty<byte>(),
+                }
+            };
+            fs.SetExecutable(expectedPath);
             var envars = new Dictionary<string, string> {["PATH"] = PosixPathVar};
             var env = new PosixEnvironment(fs, envars);
 
@@ -142,6 +169,8 @@ namespace GitCredentialManager.Tests
                     [expectedPath] = Array.Empty<byte>(),
                 }
             };
+            fs.SetExecutable(pathsToIgnore.FirstOrDefault());
+            fs.SetExecutable(expectedPath);
             var envars = new Dictionary<string, string> {["PATH"] = PosixPathVar};
             var env = new PosixEnvironment(fs, envars);
 

--- a/src/shared/Core.Tests/StreamExtensionsTests.cs
+++ b/src/shared/Core.Tests/StreamExtensionsTests.cs
@@ -381,12 +381,13 @@ namespace GitCredentialManager.Tests
             {
                 ["a"] = new[] {"1", "2", "", "3", "4"},
                 ["b"] = new[] {"5"},
-                ["c"] = new[] {"6", "7", ""}
+                ["c"] = new[] {"6", "7", ""},
+                ["d"] = new[] {"8", "", "9"}
             };
 
             string output = WriteStringStream(input, StreamExtensions.WriteDictionary, newLine: LF);
 
-            Assert.Equal("a[]=3\na[]=4\nb=5\n\n", output);
+            Assert.Equal("a[]=3\na[]=4\nb=5\nd=9\n\n", output);
         }
 
         #endregion

--- a/src/shared/Core.Tests/Trace2MessageTests.cs
+++ b/src/shared/Core.Tests/Trace2MessageTests.cs
@@ -12,6 +12,8 @@ public class Trace2MessageTests
     [InlineData(26.316083,    " 26.316083 ")]
     [InlineData(100.316083,   "100.316083 ")]
     [InlineData(1000.316083,  "1000.316083")]
+    [InlineData(10000.316083, "10000.316083")]
+    [InlineData(100000.31608, "100000.316080")]
     public void BuildTimeSpan_Match_Returns_Expected_String(double input, string expected)
     {
         var actual = Trace2Message.BuildTimeSpan(input);

--- a/src/shared/Core/Authentication/OAuthAuthentication.cs
+++ b/src/shared/Core/Authentication/OAuthAuthentication.cs
@@ -247,7 +247,7 @@ namespace GitCredentialManager.Authentication
                 VerificationUrl = dcr.VerificationUri.ToString(),
             };
 
-            return AvaloniaUi.ShowViewAsync<DeviceCodeView>(viewModel, GetParentWindowHandle(), CancellationToken.None);
+            return AvaloniaUi.ShowViewAsync<DeviceCodeView>(viewModel, GetParentWindowHandle(), ct);
         }
 
         private Task ShowDeviceCodeViaHelperAsync(

--- a/src/shared/Core/Diagnostics/NetworkingDiagnostic.cs
+++ b/src/shared/Core/Diagnostics/NetworkingDiagnostic.cs
@@ -29,7 +29,7 @@ namespace GitCredentialManager.Diagnostics
             bool hasNetwork = NetworkInterface.GetIsNetworkAvailable();
             log.AppendLine($"IsNetworkAvailable: {hasNetwork}");
 
-            SendHttpRequest(log, httpClient);
+            await SendHttpRequestAsync(log, httpClient);
 
             log.Append($"Sending HEAD request to {TestHttpsUri}...");
             using var httpsResponse = await httpClient.HeadAsync(TestHttpsUri);
@@ -98,7 +98,7 @@ namespace GitCredentialManager.Diagnostics
             return true;
         }
 
-        internal /* For testing purposes */ async void SendHttpRequest(StringBuilder log, HttpClient httpClient)
+        internal /* For testing purposes */ async Task SendHttpRequestAsync(StringBuilder log, HttpClient httpClient)
         {
             foreach (var uri in new List<string> { TestHttpUri, TestHttpUriFallback })
             {

--- a/src/shared/Core/EnvironmentBase.cs
+++ b/src/shared/Core/EnvironmentBase.cs
@@ -138,7 +138,8 @@ namespace GitCredentialManager
                 {
                     string candidatePath = Path.Combine(basePath, program);
                     if (FileSystem.FileExists(candidatePath) && (pathsToIgnore is null ||
-                        !pathsToIgnore.Contains(candidatePath, StringComparer.OrdinalIgnoreCase)))
+                        !pathsToIgnore.Contains(candidatePath, StringComparer.OrdinalIgnoreCase))
+                        && FileSystem.FileIsExecutable(candidatePath))
                     {
                         path = candidatePath;
                         return true;

--- a/src/shared/Core/FileSystem.cs
+++ b/src/shared/Core/FileSystem.cs
@@ -35,6 +35,14 @@ namespace GitCredentialManager
         bool FileExists(string path);
 
         /// <summary>
+        /// Check if a file has execute permissions.
+        /// On Windows this always returns true. On POSIX it checks for any execute bit.
+        /// </summary>
+        /// <param name="path">Full path to file to test.</param>
+        /// <returns>True if the file is executable, false otherwise.</returns>
+        bool FileIsExecutable(string path);
+
+        /// <summary>
         /// Check if a directory exists at the specified path.
         /// </summary>
         /// <param name="path">Full path to directory to test.</param>
@@ -121,6 +129,23 @@ namespace GitCredentialManager
         public abstract bool IsSamePath(string a, string b);
 
         public bool FileExists(string path) => File.Exists(path);
+
+#if NETFRAMEWORK
+        public bool FileIsExecutable(string path) => true;
+#else
+        public bool FileIsExecutable(string path)
+        {
+            if (!PlatformUtils.IsPosix())
+                return true;
+
+#pragma warning disable CA1416 // Platform guard via PlatformUtils.IsPosix()
+            var mode = File.GetUnixFileMode(path);
+            return (mode & (UnixFileMode.UserExecute |
+                            UnixFileMode.GroupExecute |
+                            UnixFileMode.OtherExecute)) != 0;
+#pragma warning restore CA1416
+        }
+#endif
 
         public bool DirectoryExists(string path) => Directory.Exists(path);
 

--- a/src/shared/Core/Git.cs
+++ b/src/shared/Core/Git.cs
@@ -146,6 +146,15 @@ namespace GitCredentialManager
                 }
 
                 git.Start(Trace2ProcessClass.Git);
+
+                // Drain and throw away stderr asynchronously to avoid a deadlock
+                // if the child process fills the stderr pipe buffer.
+                if (suppressStreams)
+                {
+                    git.Process.ErrorDataReceived += (_, _) => { };
+                    git.Process.BeginErrorReadLine();
+                }
+
                 string data = git.StandardOutput.ReadToEnd();
                 git.WaitForExit();
 

--- a/src/shared/Core/Git.cs
+++ b/src/shared/Core/Git.cs
@@ -176,6 +176,8 @@ namespace GitCredentialManager
         {
             using (var git = CreateProcess("remote -v show"))
             {
+                // Redirect stderr so we can check for 'not a git repository' errors
+                git.StartInfo.RedirectStandardError = true;
                 git.Start(Trace2ProcessClass.Git);
                 // To avoid deadlocks, always read the output stream first and then wait
                 // TODO: don't read in all the data at once; stream it
@@ -276,7 +278,9 @@ namespace GitCredentialManager
 
         public static GitException CreateGitException(ChildProcess git, string message, ITrace2 trace2 = null)
         {
-            var gitMessage = git.StandardError.ReadToEnd();
+            var gitMessage = git.StartInfo.RedirectStandardError
+                ? git.StandardError.ReadToEnd()
+                : null;
 
             if (trace2 != null)
                 throw new Trace2GitException(trace2, message, git.ExitCode, gitMessage);

--- a/src/shared/Core/Settings.cs
+++ b/src/shared/Core/Settings.cs
@@ -659,7 +659,7 @@ namespace GitCredentialManager
         }
 
         public bool AutomaticallyUseClientCertificates =>
-            TryGetSetting(null, KnownGitCfg.Credential.SectionName, KnownGitCfg.Http.SslAutoClientCert, out string value) && value.ToBooleanyOrDefault(false);
+            TryGetSetting(null, KnownGitCfg.Http.SectionName, KnownGitCfg.Http.SslAutoClientCert, out string value) && value.ToBooleanyOrDefault(false);
 
         public string CustomCertificateBundlePath =>
             TryGetPathSetting(KnownEnvars.GitSslCaInfo, KnownGitCfg.Http.SectionName, KnownGitCfg.Http.SslCaInfo, out string value) ? value : null;

--- a/src/shared/Core/StreamExtensions.cs
+++ b/src/shared/Core/StreamExtensions.cs
@@ -179,7 +179,7 @@ namespace GitCredentialManager
                         break;
 
                     case 1:
-                        writer.WriteLine($"{kvp.Key}={kvp.Value[0]}");
+                        writer.WriteLine($"{kvp.Key}={values[0]}");
                         break;
 
                     default:

--- a/src/shared/Core/Trace2.cs
+++ b/src/shared/Core/Trace2.cs
@@ -640,7 +640,7 @@ public class Trace2 : DisposableObject, ITrace2
     private static string BuildThreadName()
     {
         // If this is the entry thread, call it "main", per Trace2 convention
-        if (Thread.CurrentThread.ManagedThreadId == 0)
+        if (Thread.CurrentThread.ManagedThreadId == 1)
         {
             return "main";
         }

--- a/src/shared/Core/Trace2.cs
+++ b/src/shared/Core/Trace2.cs
@@ -460,11 +460,11 @@ public class Trace2 : DisposableObject, ITrace2
         {
             try
             {
-                for (int i = 0; i < _writers.Count; i += 1)
+                for (int i = _writers.Count - 1; i >= 0; i--)
                 {
-                    using (var writer = _writers[i])
+                    using (_writers[i])
                     {
-                        _writers.Remove(writer);
+                        _writers.RemoveAt(i);
                     }
                 }
             }

--- a/src/shared/Core/Trace2Message.cs
+++ b/src/shared/Core/Trace2Message.cs
@@ -151,7 +151,7 @@ public abstract class Trace2Message
             if (double.TryParse(data, out _))
             {
                 // Remove all padding for values that take up the entire span
-                if (Math.Abs(sizeDifference) == paddingTotal)
+                if (Math.Abs(sizeDifference) >= paddingTotal)
                 {
                     component.BeginPadding = 0;
                     component.EndPadding = 0;

--- a/src/shared/GitHub/GitHubAuthChallenge.cs
+++ b/src/shared/GitHub/GitHubAuthChallenge.cs
@@ -107,7 +107,15 @@ public class GitHubAuthChallenge : IEquatable<GitHubAuthChallenge>
 
     public override int GetHashCode()
     {
-        return Domain.GetHashCode() * 1019 ^
-               Enterprise.GetHashCode() * 337;
+        int domainHash = Domain is null
+            ? 0
+            : StringComparer.OrdinalIgnoreCase.GetHashCode(Domain);
+
+        int enterpriseHash = Enterprise is null
+            ? 0
+            : StringComparer.OrdinalIgnoreCase.GetHashCode(Enterprise);
+
+        return (domainHash * 1019) ^
+               (enterpriseHash * 337);
     }
 }

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -198,6 +198,7 @@ namespace GitHub
             if (!IsGitHubDotCom(remoteUri))
             {
                 _context.Trace.WriteLine("No account filtering outside of GitHub.com.");
+                return false;
             }
 
             // Allow the user to disable account filtering until this feature stabilises.

--- a/src/shared/GitHub/UI/Commands/CredentialsCommand.cs
+++ b/src/shared/GitHub/UI/Commands/CredentialsCommand.cs
@@ -38,7 +38,7 @@ namespace GitHub.UI.Commands
             this.SetHandler(ExecuteAsync, url, userName, basic, browser, device, pat, all);
         }
 
-        private async Task<int> ExecuteAsync(string userName, string enterpriseUrl,
+        private async Task<int> ExecuteAsync(string enterpriseUrl, string userName,
             bool basic, bool browser, bool device, bool pat, bool all)
         {
             var viewModel = new CredentialsViewModel(Context.SessionManager, Context.ProcessManager)

--- a/src/shared/GitLab/UI/Commands/CredentialsCommand.cs
+++ b/src/shared/GitLab/UI/Commands/CredentialsCommand.cs
@@ -35,7 +35,7 @@ namespace GitLab.UI.Commands
             this.SetHandler(ExecuteAsync, url, userName, basic, browser, pat, all);
         }
 
-        private async Task<int> ExecuteAsync(string userName, string url, bool basic, bool browser, bool pat, bool all)
+        private async Task<int> ExecuteAsync(string url, string userName, bool basic, bool browser, bool pat, bool all)
         {
             var viewModel = new CredentialsViewModel(Context.SessionManager)
             {

--- a/src/shared/TestInfrastructure/Objects/TestFileSystem.cs
+++ b/src/shared/TestInfrastructure/Objects/TestFileSystem.cs
@@ -11,6 +11,7 @@ namespace GitCredentialManager.Tests.Objects
         public string UserHomePath { get; set; }
         public string UserDataDirectoryPath { get; set; }
         public IDictionary<string, byte[]> Files { get; set; } = new Dictionary<string, byte[]>();
+        public ISet<string> ExecutableFiles { get; } = new HashSet<string>();
         public ISet<string> Directories { get; set; } = new HashSet<string>();
         public string CurrentDirectory { get; set; } = Path.GetTempPath();
         public bool IsCaseSensitive { get; set; } = false;
@@ -34,6 +35,18 @@ namespace GitCredentialManager.Tests.Objects
         bool IFileSystem.FileExists(string path)
         {
             return Files.ContainsKey(path);
+        }
+
+        bool IFileSystem.FileIsExecutable(string path)
+        {
+            if (!Files.ContainsKey(path))
+                throw new FileNotFoundException("File not found", path);
+
+            // On Windows, all files are considered executable.
+            if (!PlatformUtils.IsPosix())
+                return true;
+
+            return ExecutableFiles.Contains(path);
         }
 
         bool IFileSystem.DirectoryExists(string path)
@@ -129,6 +142,20 @@ namespace GitCredentialManager.Tests.Objects
         }
 
         #endregion
+
+        /// <summary>
+        /// Mark a test file as executable. File must exist in <see cref="Files"/> already.
+        /// </summary>
+        public void SetExecutable(string path, bool isExecutable = true)
+        {
+            if (!Files.ContainsKey(path))
+                throw new FileNotFoundException("File not found", path);
+
+            if (isExecutable)
+                ExecutableFiles.Add(path);
+            else
+                ExecutableFiles.Remove(path);
+        }
 
         /// <summary>
         /// Trim trailing slashes from a path.

--- a/src/windows/Installer.Windows/Installer.Windows.csproj
+++ b/src/windows/Installer.Windows/Installer.Windows.csproj
@@ -44,7 +44,7 @@
     <Message Text="Lay Out" Importance="High" />
     <Exec Condition="'$(NoLayout)'!='true'"
           ConsoleToMSBuild="true"
-          Command="powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -Command &quot;&amp; {&amp;'$(MSBuildProjectDirectory)\layout.ps1' -Configuration '$(Configuration)' -Output '$(PayloadPath)' -RuntimeIdentifier '$(RuntimeIdentifier)'; if ($?) { exit 0 } else { exit 1 }}&quot;"
+          Command="powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; {&amp;'$(MSBuildProjectDirectory)\layout.ps1' -Configuration '$(Configuration)' -Output '$(PayloadPath)' -RuntimeIdentifier '$(RuntimeIdentifier)'; if ($?) { exit 0 } else { exit 1 }}&quot;"
           IgnoreExitCode="true">
       <!-- If we want to display the console output if the exit code is not 0, we need to capture it and then output it using the <Error /> below -->
       <Output TaskParameter="ExitCode" PropertyName="ExitCodeOfExec" />

--- a/src/windows/Installer.Windows/layout.ps1
+++ b/src/windows/Installer.Windows/layout.ps1
@@ -3,7 +3,10 @@ param ([Parameter(Mandatory)] $Configuration, [Parameter(Mandatory)] $Output, $R
 
 # Trim trailing slashes from output paths
 $Output = $Output.TrimEnd('\','/')
-$SymbolOutput = $SymbolOutput.TrimEnd('\','/')
+
+if ($SymbolOutput) {
+    $SymbolOutput = $SymbolOutput.TrimEnd('\','/')
+}
 
 Write-Output "Output: $Output"
 


### PR DESCRIPTION
A collection of small bug fixes found with the help of an AI agent scanning the codebase. None of these are known to be actively exploited or causing user-reported issues, but each is a latent defect that could cause crashes, hangs, or incorrect behaviour under the right conditions.

## Fixes

**Credential UI** — `github/gitlab: use correct param order`
- Custom credential UI commands had swapped URL and username arguments.

**Stream extensions** — `streamextensions: fix a bug in multi-var reset handling`
- Multi-dictionary writer emitted the wrong value when a reset marker was followed by a single entry.

**GitHub auth** — `github: handle empty domain or enterprise hints`
- Null-reference exception when WWW-Authenticate header is missing domain/enterprise hints.

**GitHub account filtering** — `github: do not filter accounts outside of dotcom`
- Account filtering was applied outside of GitHub.com despite detecting it shouldn't be.

**Network diagnostics** — `diagnose: fix network diag to await HTTP requests`
- HTTP requests in the network diagnostic were not properly awaited.

**macOS notarize script** — `macos: add die function to notarize.sh script`
- Missing `die` function.

**Git stderr handling** — `git: drain stderr on IsInsideRepository`
- Potential hang when Git writes enough to stderr to fill the pipe buffer.

**Windows layout script** — `windows: fix layout.ps1 if symboloutput is not set`
- Null-reference trimming `SymbolOutput` when the variable is unset.

**OAuth device code UI** — `oauth: pass cancellation token to in-proc device code UI`
- Cancellation token was not forwarded, so dismissing the dialog didn't work.

**TRACE2 thread ID** — `trace2: fix main thread identification`
- Main thread ID starts at 1, not 0.

**TRACE2 perf format** — `trace2: fix crash in perf format for large elapsed times`
- `ArgumentOutOfRangeException` crash when elapsed time exceeds 9999 seconds.

**HTTP config** — `http: use correct http.sslAutoClientCert setting name`
- Setting was read from the wrong Git config section.

**TRACE2 writer cleanup** — `trace2: fix incomplete disposal of writers on cleanup`
- Forward iteration with removal skipped every other writer, leaking file handles.

**Git stderr redirect** — `git: fix crash when reading stderr from non-redirected processes`
- `InvalidOperationException` when `GetRemotes`/`CreateGitException` read non-redirected stderr.

**Executable lookup** — `environment: check execute permission in TryLocateExecutable`
- PATH scan didn't verify execute bits on POSIX, unlike the `which` it replaced.

**Installer Exec command** — `windows: fix en-dash characters in installer Exec command`
- Unicode en-dash characters instead of ASCII hyphens broke PowerShell 5.1 parameter parsing.
