### PR TITLE
http: fix SYSLIB0057 warning for X509Certificate2Collection.Import

### DIFF
--- a/src/shared/Core/HttpClientFactory.cs
+++ b/src/shared/Core/HttpClientFactory.cs
@@ -130,7 +130,11 @@ namespace GitCredentialManager
 
                     // Import the custom certs
                     X509Certificate2Collection certBundle = new X509Certificate2Collection();
+#if NETFRAMEWORK
                     certBundle.Import(certBundlePath);
+#else
+                    certBundle.ImportFromPemFile(certBundlePath);
+#endif
 
                     try
                     {


### PR DESCRIPTION
Use `ImportFromPemFile` on modern .NET to resolve the `SYSLIB0057` deprecation warning, while keeping the original `Import` call on .NET Framework where the new API is not available.

We know this is always a PEM file since this is a Git defined option, and it is passed to libcurl via `CURLINFO_CAINFO` which expects PEM format.