### PR TITLE
install: update install-from-source to use .NET 10.0

### DIFF
--- a/.github/workflows/validate-install-from-source.yml
+++ b/.github/workflows/validate-install-from-source.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         vector:
         - image: ubuntu
-        - image: debian:bullseye
+        - image: debian:bookworm
         - image: fedora
         # Centos no longer officially maintains images on Docker Hub. However,
         # tgagor is a contributor who pushes updated images weekly, which should

--- a/.github/workflows/validate-install-from-source.yml
+++ b/.github/workflows/validate-install-from-source.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   docker:

--- a/docs/install.md
+++ b/docs/install.md
@@ -210,7 +210,7 @@ the preferred install method for Linux because you can use it to install on any
 distribution][dotnet-supported-distributions]. You
 can also use this method on macOS if you so choose.
 
-**Note:** Make sure you have installed [version 8.0 of the .NET
+**Note:** Make sure you have installed [version 10.0 of the .NET
 SDK][dotnet-install] before attempting to run the following `dotnet tool`
 commands. After installing, you will also need to follow the output instructions
 to add the tools directory to your `PATH`.

--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -91,7 +91,7 @@ ensure_dotnet_installed() {
     if [ -z "$(verify_existing_dotnet_installation)" ]; then
         curl -LO https://dot.net/v1/dotnet-install.sh
         chmod +x ./dotnet-install.sh
-        bash -c "./dotnet-install.sh --channel 8.0"
+        bash -c "./dotnet-install.sh --channel 10.0"
 
         # Since we have to run the dotnet install script with bash, dotnet isn't
         # added to the process PATH, so we manually add it here.
@@ -103,10 +103,10 @@ ensure_dotnet_installed() {
 
 verify_existing_dotnet_installation() {
     # Get initial pieces of installed sdk version(s).
-    sdks=$(dotnet --list-sdks | cut -c 1-3)
+    sdks=$(dotnet --list-sdks | cut -d' ' -f1 | cut -d. -f1,2)
 
     # If we have a supported version installed, return.
-    supported_dotnet_versions="8.0"
+    supported_dotnet_versions="10.0"
     for v in $supported_dotnet_versions; do
         if [ $(echo $sdks | grep "$v") ]; then
             echo $sdks
@@ -185,7 +185,7 @@ case "$distribution" in
                 $sudo_cmd apt update
                 $sudo_cmd apt install apt-transport-https -y
                 $sudo_cmd apt update
-                $sudo_cmd apt install dotnet-sdk-8.0 dpkg-dev -y
+                $sudo_cmd apt install dotnet-sdk-10.0 dpkg-dev -y
             fi
         fi
     ;;


### PR DESCRIPTION
The project now targets net10.0 but the install-from-source script still referenced .NET SDK 8.0. Update all references to 10.0 and fix the version parsing to use field-based extraction instead of fixed-width character slicing, which broke for two-digit major versions.