### PR TITLE
release: install .NET 8 SDK for ESRP codesigning on macOS and Linux

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -302,6 +302,11 @@ extends:
                     script: |
                       echo "##vso[task.setvariable variable=version;isReadOnly=true]$(cat ./VERSION | sed -E 's/.[0-9]+$//')"
                 - task: UseDotNet@2
+                  displayName: 'Use .NET 8 SDK (ESRP dependency)'
+                  inputs:
+                    packageType: sdk
+                    version: '8.x'
+                - task: UseDotNet@2
                   displayName: 'Use .NET 10 SDK'
                   inputs:
                     packageType: sdk
@@ -571,6 +576,11 @@ extends:
                     targetType: inline
                     script: |
                       echo "##vso[task.setvariable variable=version;isReadOnly=true]$(cat ./VERSION | sed -E 's/.[0-9]+$//')"
+                - task: UseDotNet@2
+                  displayName: 'Use .NET 8 SDK (ESRP dependency)'
+                  inputs:
+                    packageType: sdk
+                    version: '8.x'
                 - task: UseDotNet@2
                   displayName: 'Use .NET 10 SDK'
                   inputs:


### PR DESCRIPTION
.NET 8 (or 6 or 9) is a a required dependency for ESRP steps on Mac/Linux.. lovely. Also installing .NET 8 since this was the prior LTS before 10.