### PR TITLE
release: run nuget publish job on windows

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -872,9 +872,13 @@ extends:
             dependsOn: release_validation
             condition: and(succeeded(), eq('${{ parameters.nuget }}', true))
             pool:
+              # Run on Windows so the underlying NuGetCommand@2 task can use the
+              # native nuget.exe. On Ubuntu 24.04+ the legacy NuGet task fails
+              # because Mono is no longer available.
+              # See https://aka.ms/nuget-task-mono.
               name: GitClientPME-1ESHostedPool-intel-pc
-              image: ubuntu-x86_64-ado1es
-              os: linux
+              image: win-x86_64-ado1es
+              os: windows
             variables:
               version: $[dependencies.release_validation.outputs['version.value']]
             templateContext:


### PR DESCRIPTION
The legacy `NuGetCommand@2` task (used internally by the 1ES `output: nuget` template) requires Mono on Linux. Recent updates to the `ubuntu-x86_64-ado1es` image to Ubuntu 24.04+ removed Mono availability, breaking the publish step with:

> The task has failed because you are using Ubuntu 24.04 or later without mono installed.

Move the nuget publish job to the `win-x86_64-ado1es` image so the task uses the native `nuget.exe` and avoids the Mono dependency entirely. The same Windows pool is already used by the `dotnet_tool` build job that produces these packages.

There will be a small performance hit in the build pipeline since Windows agents take longer to provision (but better than this job failing as it does now).