### PR TITLE
fix(config): enable file include in scoped queries

### DIFF
--- a/src/shared/Core.Tests/GitConfigurationTests.cs
+++ b/src/shared/Core.Tests/GitConfigurationTests.cs
@@ -656,5 +656,31 @@ namespace GitCredentialManager.Tests
             // Value should be canonicalized path, not raw "~/example"
             Assert.NotEqual("~/example", value);
         }
+
+        [Fact]
+        public void GitConfiguration_ScopedConfig_ProcessesIncludes()
+        {
+            const string configKey = "test.value";
+            const string configValue = "foo123";
+            string repoPath = CreateRepository(out string workDirPath);
+            ExecGit(repoPath, workDirPath, $"config --file {workDirPath}/git.config {configKey} {configValue}").AssertSuccess();
+            ExecGit(repoPath, workDirPath, $"config --global include.path {workDirPath}/git.config").AssertSuccess();
+            ExecGit(repoPath, workDirPath, $"config --local include.path {workDirPath}/git.config").AssertSuccess();
+
+            string gitPath = GetGitPath();
+            var trace = new NullTrace();
+            var trace2 = new NullTrace2();
+            var processManager = new TestProcessManager();
+
+            var git = new GitProcess(trace, trace2, processManager, gitPath, repoPath);
+            IGitConfiguration config = git.GetConfiguration();
+
+            // value of included file set in scopes
+            foreach (var scope in new GitConfigurationLevel[] { GitConfigurationLevel.Global, GitConfigurationLevel.Local })
+            {
+                Assert.True(config.TryGet(scope, GitConfigurationType.Raw, configKey, out string value));
+                Assert.Equal(configValue, value);
+            }
+        }
     }
 }

--- a/src/shared/Core/Application.cs
+++ b/src/shared/Core/Application.cs
@@ -204,7 +204,7 @@ namespace GitCredentialManager
 
             // Try to locate an existing app entry with a blank reset/clear entry immediately preceding,
             // and no other blank empty/clear entries following (which effectively disable us).
-            int appIndex = Array.FindIndex(currentValues, x => Context.FileSystem.IsSamePath(x, appPath));
+            int appIndex = Array.FindLastIndex(currentValues, x => Context.FileSystem.IsSamePath(x, appPath));
             int lastEmptyIndex = Array.FindLastIndex(currentValues, string.IsNullOrWhiteSpace);
             if (appIndex > 0 && string.IsNullOrWhiteSpace(currentValues[appIndex - 1]) && lastEmptyIndex < appIndex)
             {
@@ -219,7 +219,10 @@ namespace GitCredentialManager
 
                 // Add an empty value for `credential.helper`, which has the effect of clearing any helper value
                 // from any lower-level Git configuration, then add a second value which is the actual executable path.
-                config.Add(configLevel, helperKey, string.Empty);
+                if ((currentValues.Length == 0) || (lastEmptyIndex != (currentValues.Length - 1)))
+                {
+                    config.Add(configLevel, helperKey, string.Empty);
+                }
                 config.Add(configLevel, helperKey, appPath);
             }
 

--- a/src/shared/Core/GitConfiguration.cs
+++ b/src/shared/Core/GitConfiguration.cs
@@ -463,7 +463,7 @@ namespace GitCredentialManager
 
             // Fall back to original implementation
             string levelArg = GetLevelFilterArg(level);
-            using (ChildProcess git = _git.CreateProcess($"config --null {levelArg} --list"))
+            using (ChildProcess git = _git.CreateProcess($"config --null {levelArg} --includes --list"))
             {
                 git.Start(Trace2ProcessClass.Git);
                 // To avoid deadlocks, always read the output stream first and then wait
@@ -545,7 +545,7 @@ namespace GitCredentialManager
             // Fall back to individual git config command if cache not available
             string levelArg = GetLevelFilterArg(level);
             string typeArg = GetCanonicalizeTypeArg(type);
-            using (ChildProcess git = _git.CreateProcess($"config --null {levelArg} {typeArg} {QuoteCmdArg(name)}"))
+            using (ChildProcess git = _git.CreateProcess($"config --null {levelArg} --includes {typeArg} {QuoteCmdArg(name)}"))
             {
                 git.Start(Trace2ProcessClass.Git);
                 // To avoid deadlocks, always read the output stream first and then wait
@@ -667,7 +667,7 @@ namespace GitCredentialManager
             string levelArg = GetLevelFilterArg(level);
             string typeArg = GetCanonicalizeTypeArg(type);
 
-            var gitArgs = $"config --null {levelArg} {typeArg} --get-all {QuoteCmdArg(name)}";
+            var gitArgs = $"config --null {levelArg} --includes {typeArg} --get-all {QuoteCmdArg(name)}";
 
             using (ChildProcess git = _git.CreateProcess(gitArgs))
             {
@@ -705,7 +705,7 @@ namespace GitCredentialManager
             string levelArg = GetLevelFilterArg(level);
             string typeArg = GetCanonicalizeTypeArg(type);
 
-            var gitArgs = $"config --null {levelArg} {typeArg} --get-regex {QuoteCmdArg(nameRegex)}";
+            var gitArgs = $"config --null {levelArg} --includes {typeArg} --get-regex {QuoteCmdArg(nameRegex)}";
             if (valueRegex != null)
             {
                 gitArgs += $" {QuoteCmdArg(valueRegex)}";


### PR DESCRIPTION
Avoid duplication of entries already present in included files:
- [x] enable config cache for `Raw` values in all Git versions supporting `--show-scope`
- [x] consistent _include_ of files in Git config queries with [scope limit](https://git-scm.de/docs/git-config#Documentation/git-config.txt---includes)
- [x] add test for file includes

Improves consistency regarding _include_ behavior and

Fixes #2342
Fixes #2328
Fixes #1696
Fixes #1337