### PR TITLE
azrepos: fall back to OAuth when org DisablePatCreationPolicyViolation policy is set

### DIFF
--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -20,6 +20,8 @@ namespace Microsoft.AzureRepos
         private readonly IMicrosoftAuthentication _msAuth;
         private readonly IAzureDevOpsAuthorityCache _authorityCache;
         private readonly IAzureReposBindingManager _bindingManager;
+        // Set to true if PAT creation was blocked by org policy this invocation, forcing OAuth fallback.
+        private bool _forcedOAuth;
 
         public AzureReposHostProvider(ICommandContext context)
             : this(context, new AzureDevOpsRestApi(context), new MicrosoftAuthentication(context),
@@ -118,20 +120,28 @@ namespace Microsoft.AzureRepos
 
                     // No existing credential was found, create a new one
                     _context.Trace.WriteLine("Creating new credential...");
-                    credential = await GeneratePersonalAccessTokenAsync(input);
-                    _context.Trace.WriteLine("Credential created.");
+                    try
+                    {
+                        credential = await GeneratePersonalAccessTokenAsync(input);
+                        _context.Trace.WriteLine("Credential created.");
+                        return new GetCredentialResult(credential);
+                    }
+                    catch (Exception ex) when (IsPatPolicyViolation(ex))
+                    {
+                        HandlePatPolicyViolation();
+                        // Fall through to OAuth path below
+                    }
                 }
                 else
                 {
                     _context.Trace.WriteLine("Existing credential found.");
+                    return new GetCredentialResult(credential);
                 }
-
-                return new GetCredentialResult(credential);
             }
-            else
+
+            // Include the username request here so that we may use it as an override
+            // for user account lookups when getting Azure Access Tokens.
             {
-                // Include the username request here so that we may use it as an override
-                // for user account lookups when getting Azure Access Tokens.
                 var azureResult = await GetAzureAccessTokenAsync(input);
                 var azureCredential = new GitCredential(azureResult.AccountUpn, azureResult.AccessToken);
                 return new GetCredentialResult(azureCredential);
@@ -485,8 +495,26 @@ namespace Microsoft.AzureRepos
         /// Check if Azure DevOps Personal Access Tokens should be used or not.
         /// </summary>
         /// <returns>True if Personal Access Tokens should be used, false otherwise.</returns>
+        private static bool IsPatPolicyViolation(Exception ex) =>
+            ex.Message.Contains("DisablePatCreationPolicyViolation", StringComparison.OrdinalIgnoreCase);
+
+        private void HandlePatPolicyViolation()
+        {
+            _context.Trace.WriteLine("PAT creation blocked by org policy, falling back to OAuth for this request.");
+            _context.Streams.Error.WriteLine(
+                "warning: PAT creation is disabled by your Azure DevOps organization policy.");
+            _context.Streams.Error.WriteLine(
+                "hint: To permanently use OAuth, run:");
+            _context.Streams.Error.WriteLine(
+                $"hint:   git config --global credential.{AzureDevOpsConstants.GitConfiguration.Credential.CredentialType} {AzureDevOpsConstants.OAuthCredentialType}");
+
+            _forcedOAuth = true;
+        }
+
         private bool UsePersonalAccessTokens()
         {
+            if (_forcedOAuth) return false;
+
             // Default to using PATs except on DevBox where we prefer OAuth tokens
             bool defaultValue = !PlatformUtils.IsDevBox();
 


### PR DESCRIPTION
## Problem

When an Azure DevOps organization disables PAT creation via policy, GCM surfaces a raw fatal error with no recovery path:

```
fatal: Failed to create PAT: DisablePatCreationPolicyViolation
```
<img width="1918" height="178" alt="image" src="https://github.com/user-attachments/assets/6350f895-c064-4420-aa55-9388cb7254ce" />

The user has no indication what to do. The [documented fix](https://learn.microsoft.com/en-us/azure/devops/repos/git/set-up-credential-managers?view=azure-devops#configure-microsoft-entra-id-authentication-recommended) (`git config --global credential.azreposCredentialType oauth`) is buried in docs.

The reason is, after installing the Extension and trying to clone a repo, it ends-up creating teh PAT with "package" only permissions because the org's default PAT creation policy is been disabled.  And it's not there in the default allowed list (AZDO PAT Allowlist - CORP Tenant - SERVICE ACCOUNTS ONLY)

## Fix/WorkAround
In `AzureReposHostProvider.GetCredentialAsync`, wrap PAT creation in a `catch` that recognizes the `DisablePatCreationPolicyViolation` error and:

1. Falls back to OAuth for the current invocation
2. Prints a clear warning with the exact `git config` command to make it permanent

A `_forcedOAuth` instance flag propagates the fallback to `StoreCredentialAsync` and `EraseCredentialAsync` within the same process (necessary because `Settings` caches git config entries on first read and won't pick up a disk write mid-invocation).

**Deliberately not done:** auto-writing `credential.azreposCredentialType = oauth` to global git config — that setting affects all Azure DevOps orgs, not just the one with the policy, which would be too broad.

## User experience after this change

```
warning: PAT creation is disabled by your Azure DevOps organization policy.
hint: To permanently use OAuth, run:
hint:   git config --global credential.azreposCredentialType oauth
```

The clone then succeeds via OAuth without any user action needed for that invocation.

## Test plan
- [ ] Clone from an org with `DisablePatCreationPolicyViolation` policy — should fall back to OAuth and print the hint
- [ ] Clone from a normal org — PAT path unchanged
- [ ] After running the hinted `git config` command, subsequent clones go directly to OAuth (no policy call at all)
