### PR TITLE
Fix detection of configured GCM helper

### DIFF
--- a/src/shared/Core.Tests/ApplicationTests.cs
+++ b/src/shared/Core.Tests/ApplicationTests.cs
@@ -179,6 +179,55 @@ namespace GitCredentialManager.Tests
         }
 
         [Fact]
+        public async Task Application_ConfigureAsync_MultiGcmWithValidEmpty_DoesNothing()
+        {
+            const string emptyHelper = "";
+            const string executablePath = "/usr/local/share/gcm-core/git-credential-manager";
+            string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
+
+            var context = new TestCommandContext { AppPath = executablePath };
+            IConfigurableComponent application = new Application(context);
+
+            context.Git.Configuration.Global[key] = new List<string>
+            {
+                executablePath, emptyHelper, executablePath
+            };
+
+            await application.ConfigureAsync(ConfigurationTarget.User);
+
+            Assert.Single(context.Git.Configuration.Global);
+            Assert.True(context.Git.Configuration.Global.TryGetValue(key, out var actualValues));
+            Assert.Equal(3, actualValues.Count);
+            Assert.Equal(executablePath, actualValues[0]);
+            Assert.Equal(emptyHelper, actualValues[1]);
+            Assert.Equal(executablePath, actualValues[2]);
+        }
+
+        [Fact]
+        public async Task Application_ConfigureAsync_EmptyOnly_AddsGcmOnly()
+        {
+            const string emptyHelper = "";
+            const string executablePath = "/usr/local/share/gcm-core/git-credential-manager";
+            string key = $"{Constants.GitConfiguration.Credential.SectionName}.{Constants.GitConfiguration.Credential.Helper}";
+
+            var context = new TestCommandContext { AppPath = executablePath };
+            IConfigurableComponent application = new Application(context);
+
+            context.Git.Configuration.Global[key] = new List<string>
+            {
+                emptyHelper
+            };
+
+            await application.ConfigureAsync(ConfigurationTarget.User);
+
+            Assert.Single(context.Git.Configuration.Global);
+            Assert.True(context.Git.Configuration.Global.TryGetValue(key, out var actualValues));
+            Assert.Equal(2, actualValues.Count);
+            Assert.Equal(emptyHelper, actualValues[0]);
+            Assert.Equal(executablePath, actualValues[1]);
+        }
+
+        [Fact]
         public async Task Application_UnconfigureAsync_NoHelpers_DoesNothing()
         {
             const string executablePath = "/usr/local/share/gcm-core/git-credential-manager";

--- a/src/shared/Core/Application.cs
+++ b/src/shared/Core/Application.cs
@@ -217,9 +217,15 @@ namespace GitCredentialManager
                 // Clear any existing app entries in the configuration
                 config.UnsetAll(configLevel, helperKey, Regex.Escape(appPath));
 
+                // Reload updated helper settings (unset only clears entries in primary file, ignores includes and alternatives)
+                currentValues = config.GetAll(configLevel, GitConfigurationType.Raw, helperKey).ToArray();
+
                 // Add an empty value for `credential.helper`, which has the effect of clearing any helper value
                 // from any lower-level Git configuration, then add a second value which is the actual executable path.
-                config.Add(configLevel, helperKey, string.Empty);
+                if ((currentValues.Length == 0) || !string.IsNullOrWhiteSpace(currentValues.Last()))
+                {
+                    config.Add(configLevel, helperKey, string.Empty);
+                }
                 config.Add(configLevel, helperKey, appPath);
             }
 

--- a/src/shared/Core/Application.cs
+++ b/src/shared/Core/Application.cs
@@ -204,7 +204,7 @@ namespace GitCredentialManager
 
             // Try to locate an existing app entry with a blank reset/clear entry immediately preceding,
             // and no other blank empty/clear entries following (which effectively disable us).
-            int appIndex = Array.FindIndex(currentValues, x => Context.FileSystem.IsSamePath(x, appPath));
+            int appIndex = Array.FindLastIndex(currentValues, x => Context.FileSystem.IsSamePath(x, appPath));
             int lastEmptyIndex = Array.FindLastIndex(currentValues, string.IsNullOrWhiteSpace);
             if (appIndex > 0 && string.IsNullOrWhiteSpace(currentValues[appIndex - 1]) && lastEmptyIndex < appIndex)
             {


### PR DESCRIPTION
Better handling of multiple matching entries (last/first index deviation).
Detect empty trailing value to skip addition of redundant guard entry.