### PR TITLE
docs: fix broken links identified by linting

### DIFF
--- a/docs/credstores.md
+++ b/docs/credstores.md
@@ -277,7 +277,7 @@ Note that you'll want to ensure that another credential helper is placed before
 GCM in the `credential.helper` Git configuration or else you will be prompted to
 enter your credentials every time you interact with a remote repository.
 
-[access-windows-credential-manager]: https://support.microsoft.com/en-us/windows/accessing-credential-manager-1b5c916a-6a16-889f-8581-fc16e8165ac0
+[access-windows-credential-manager]: https://support.microsoft.com/en-US/Windows/Security/credential-manager-in-windows
 [aws-cloudshell]: https://aws.amazon.com/cloudshell/
 [azure-cloudshell]: https://docs.microsoft.com/azure/cloud-shell/overview
 [cmdkey]: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmdkey

--- a/docs/github-apideprecation.md
+++ b/docs/github-apideprecation.md
@@ -143,6 +143,6 @@ the new token-based authentication requirements **DO NOT** apply to GHES:
 [windows-cli-save-pat-image]: img/windows-cli-save-pat.png
 [vs-2019]: https://docs.microsoft.com/en-us/visualstudio/install/update-visual-studio?view=vs-2019
 [vs-2017]: https://docs.microsoft.com/en-us/visualstudio/install/update-visual-studio?view=vs-2017
-[windows-credential-manager]: https://support.microsoft.com/en-us/windows/accessing-credential-manager-1b5c916a-6a16-889f-8581-fc16e8165ac0
+[windows-credential-manager]: https://support.microsoft.com/en-US/Windows/Security/credential-manager-in-windows
 [windows-gui-add-pat-image]: img/windows-gui-add-pat.png
 [windows-gui-credentials-image]: img/windows-gui-credentials.png


### PR DESCRIPTION
The link to the Windows Credential Manager docs was broken - it used to point at:

https://support.microsoft.com/en-us/windows/accessing-credential-manager-1b5c916a-6a16-889f-8581-fc16e8165ac0

..but this now resolves instead to:

https://support.microsoft.com/en-US/Windows/Security/credential-manager-in-windows

..so let's use that URL directly.