### PR TITLE
esrp: use new Linux signing key

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -639,7 +639,7 @@ extends:
                       inlineOperation: |
                         [
                           {
-                            "KeyCode": "CP-453387-Pgp",
+                            "KeyCode": "CP-500207-Pgp",
                             "OperationCode": "LinuxSign",
                             "ToolName": "sign",
                             "ToolVersion": "1.0",

--- a/docs/linux-validate-gpg.md
+++ b/docs/linux-validate-gpg.md
@@ -63,7 +63,7 @@ curl -Os https://packages.microsoft.com/keys/microsoft-2025.asc
 gpg --import microsoft-2025.asc
 
 # Download the tarball and its signature file
-curl -s https://api.github.com/repos/ldennington/git-credential-manager/releases/latest \
+curl -s https://api.github.com/repos/git-ecosystem/git-credential-manager/releases/latest \
 | grep -E 'browser_download_url.*gcm-linux.*[0-9].[0-9].[0-9].tar.gz' \
 | cut -d : -f 2,3 \
 | tr -d \" \

--- a/docs/linux-validate-gpg.md
+++ b/docs/linux-validate-gpg.md
@@ -10,46 +10,42 @@ the latest Debian package and/or tarball signature.
 apt-get install -y curl debsig-verify
 
 # Download public key signature file
-curl -s https://api.github.com/repos/git-ecosystem/git-credential-manager/releases/latest \
-| grep -E 'browser_download_url.*gcm-public.asc' \
-| cut -d : -f 2,3 \
-| tr -d \" \
-| xargs -I 'url' curl -L -o gcm-public.asc 'url'
+curl -Os https://packages.microsoft.com/keys/microsoft-2025.asc
 
 # De-armor public key signature file
-gpg --output gcm-public.gpg --dearmor gcm-public.asc
+gpg --output microsoft-2025.gpg --dearmor microsoft-2025.asc
 
-# Note that the fingerprint of this key is "3C853823978B07FA", which you can
+# Note that the fingerprint of this key is "EE4D7792F748182B", which you can
 # determine by running:
-gpg --show-keys gcm-public.asc | head -n 2 | tail -n 1 | tail -c 17
+gpg --show-keys microsoft-2025.asc | head -n 2 | tail -n 1 | tail -c 17
 
 # Copy de-armored public key to debsig keyring folder
-mkdir /usr/share/debsig/keyrings/3C853823978B07FA
-mv gcm-public.gpg /usr/share/debsig/keyrings/3C853823978B07FA/
+mkdir /usr/share/debsig/keyrings/EE4D7792F748182B
+mv microsoft-2025.gpg /usr/share/debsig/keyrings/EE4D7792F748182B/
 
 # Create an appropriate policy file
-mkdir /etc/debsig/policies/3C853823978B07FA
-cat > /etc/debsig/policies/3C853823978B07FA/generic.pol << EOL
+mkdir /etc/debsig/policies/EE4D7792F748182B
+cat > /etc/debsig/policies/EE4D7792F748182B/generic.pol << EOL
 <?xml version="1.0"?>
 <!DOCTYPE Policy SYSTEM "https://www.debian.org/debsig/1.0/policy.dtd">
 <Policy xmlns="https://www.debian.org/debsig/1.0/">
 
-  <Origin Name="Git Credential Manager" id="3C853823978B07FA" Description="Git Credential Manager public key"/>
+  <Origin Name="Git Credential Manager" id="EE4D7792F748182B" Description="Git Credential Manager public key"/>
 
   <Selection>
-    <Required Type="origin" File="gcm-public.gpg" id="3C853823978B07FA"/>
+    <Required Type="origin" File="microsoft-2025.gpg" id="EE4D7792F748182B"/>
   </Selection>
 
   <Verification MinOptional="0">
-    <Required Type="origin" File="gcm-public.gpg" id="3C853823978B07FA"/>
+    <Required Type="origin" File="microsoft-2025.gpg" id="EE4D7792F748182B"/>
   </Verification>
 
 </Policy>
 EOL
 
-# Download Debian package
+# Download Debian package (substitute `x64` with `arm64` on ARM machines)
 curl -s https://api.github.com/repos/git-ecosystem/git-credential-manager/releases/latest \
-| grep "browser_download_url.*deb" \
+| grep "browser_download_url.*-x64-.*deb" \
 | cut -d : -f 2,3 \
 | tr -d \" \
 | xargs -I 'url' curl -L -o gcm.deb 'url'
@@ -61,14 +57,10 @@ debsig-verify gcm.deb
 ## Tarball
 ```shell
 # Download the public key signature file
-curl -s https://api.github.com/repos/git-ecosystem/git-credential-manager/releases/latest \
-| grep -E 'browser_download_url.*gcm-public.asc' \
-| cut -d : -f 2,3 \
-| tr -d \" \
-| xargs -I 'url' curl -L -o gcm-public.asc 'url'
+curl -Os https://packages.microsoft.com/keys/microsoft-2025.asc
 
 # Import the public key
-gpg --import gcm-public.asc
+gpg --import microsoft-2025.asc
 
 # Download the tarball and its signature file
 curl -s https://api.github.com/repos/ldennington/git-credential-manager/releases/latest \
@@ -78,7 +70,7 @@ curl -s https://api.github.com/repos/ldennington/git-credential-manager/releases
 | xargs -I 'url' curl -LO 'url'
 
 # Trust the public key
-echo -e "5\ny\n" |  gpg --command-fd 0 --expert --edit-key 3C853823978B07FA trust
+echo -e "5\ny\n" |  gpg --command-fd 0 --expert --edit-key EE4D7792F748182B trust
 
 # Verify the signature
 gpg --verify gcm-linux_amd64*.tar.gz.asc gcm-linux*.tar.gz


### PR DESCRIPTION
With ESRP-based signing applied even to the Debian packages, we need to use the correct PGP key. This PR is a companion of https://github.com/microsoft/git/pull/946.