### PR TITLE
windows: ensure app manifest version is formatted correctly

### DIFF
--- a/build/msbuild/GenerateWindowsAppManifest.cs
+++ b/build/msbuild/GenerateWindowsAppManifest.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System.IO;
@@ -25,11 +26,26 @@ namespace GitCredentialManager.MSBuild
                 Directory.CreateDirectory(manifestDirectory);
             }
 
+            // Construct a version object to ensure it is normalised to the "x.y.z.w" format
+            // that Windows expects and requires.
+            if (!System.Version.TryParse(Version, out Version version))
+            {
+                Log.LogError("Invalid version '{0}' specified for application manifest.", Version);
+                return false;
+            }
+
+            // If we don't have a 4-component version, we need to add a revision component of 0,
+            // otherwise Windows will reject the manifest.
+            if (version.Revision < 0)
+            {
+                version = new Version(version.Major, version.Minor, version.Build, 0);
+            }
+
             File.WriteAllText(
                 OutputFile,
                 $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <assembly manifestVersion=""1.0"" xmlns=""urn:schemas-microsoft-com:asm.v1"">
-  <assemblyIdentity version=""{Version}"" name=""{ApplicationName}""/>
+  <assemblyIdentity version=""{version.ToString(4)}"" name=""{ApplicationName}""/>
   <compatibility xmlns=""urn:schemas-microsoft-com:compatibility.v1"">
     <application>
       <!-- Windows 10 and Windows 11 -->


### PR DESCRIPTION
Windows requires the version property in an application manifest to be of the format "x.y.z.w" which specific rules about the min/max values for each component (16-bit numbers).

Use `System.Version` to parse the version and normalise/validate before writing the manifest file.