### PR TITLE
windows: use Inno Setup 7.0.2 and x64 native installer

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Spectre.Console" Version="0.57.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
-    <PackageVersion Include="Tools.InnoSetup" Version="6.7.3" />
+    <PackageVersion Include="Tools.InnoSetup" Version="7.0.2" />
 
     <!-- Testing -->
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />

--- a/build/windows/installer/Setup.iss
+++ b/build/windows/installer/Setup.iss
@@ -1,10 +1,10 @@
-; This script requires Inno Setup Compiler 6.0.0 or later to compile
+; This script requires Inno Setup Compiler 7.0.0 or later to compile
 ; The Inno Setup Compiler (and IDE) can be found at http://www.jrsoftware.org/isinfo.php
 ; General documentation on how to use InnoSetup scripts: http://www.jrsoftware.org/ishelp/index.php
 
 ; Ensure minimum Inno Setup tooling version
-#if VER < EncodeVer(6,0,0)
-  #error Update your Inno Setup version (6.0.0 or newer)
+#if VER < EncodeVer(7,0,0)
+  #error Update your Inno Setup version (7.0.0 or newer)
 #endif
 
 #ifndef PayloadDir
@@ -70,6 +70,12 @@ AppUpdatesURL={#GcmUrl}
 AppContact={#GcmUrl}
 AppCopyright={#GcmCopyright}
 AppReadmeFile={#GcmReadme}
+; We prefer to use the x64 installer for x64 and ARM64 systems
+#if RuntimeIdentifier=="win-x86"
+SetupArchitecture=x86
+#else
+SetupArchitecture=x64
+#endif
 ; Windows ARM64 supports installing and running x64 binaries, but not vice versa.
 #if RuntimeIdentifier=="win-x64"
   ArchitecturesAllowed=x64compatible


### PR DESCRIPTION
Update to Inno Setup 7.0.2, and use the new 64-bit installer for win-x64 and win-arm64 targets, falling back to the classic 32-bit installer for win-x86 targets.

https://jrsoftware.org/ishelp/topic_setup_setuparchitecture.htm
https://jrsoftware.org/ishelp/topic_64bit.htm