### PR TITLE
azrepos: use GCM's own Entra application

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -827,6 +827,27 @@ Credential: "git:https://bob@github.com/example/myrepo" (user = bob)
 
 ---
 
+### credential.azreposUseLegacyClientId
+
+Use the legacy Visual Studio Entra application when authenticating to Azure
+Repos with Microsoft identity OAuth tokens. Set this value to `true` to restore
+the application identity used by earlier versions of GCM.
+
+The legacy application does not support broker authentication on macOS or
+Linux.
+
+Defaults to `false`.
+
+#### Example
+
+```shell
+git config --global credential.azreposUseLegacyClientId true
+```
+
+**Also see: [GCM_AZREPOS_USE_LEGACY_CLIENTID][gcm-azrepos-legacy-client-id]**
+
+---
+
 ### credential.azreposCredentialType
 
 Specify the type of credential the Azure Repos host provider should return.
@@ -1179,6 +1200,7 @@ Defaults to disabled.
 [gcm-authority]: environment.md#GCM_AUTHORITY-deprecated
 [gcm-autodetect-timeout]: environment.md#GCM_AUTODETECT_TIMEOUT
 [gcm-azrepos-credentialtype]: environment.md#GCM_AZREPOS_CREDENTIALTYPE
+[gcm-azrepos-legacy-client-id]: environment.md#GCM_AZREPOS_USE_LEGACY_CLIENTID
 [gcm-azrepos-credentialmanagedidentity]: environment.md#GCM_AZREPOS_MANAGEDIDENTITY
 [gcm-azrepos-wif]: environment.md#GCM_AZREPOS_WIF
 [gcm-azrepos-wif-clientid]: environment.md#GCM_AZREPOS_WIF_CLIENTID

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -920,6 +920,33 @@ export GCM_MSAUTH_USEDEFAULTACCOUNT="false"
 
 ---
 
+### GCM_AZREPOS_USE_LEGACY_CLIENTID
+
+Use the legacy Visual Studio Entra application when authenticating to Azure
+Repos with Microsoft identity OAuth tokens. Set this value to `true` to restore
+the application identity used by earlier versions of GCM.
+
+The legacy application does not support broker authentication on macOS or
+Linux.
+
+Defaults to `false`.
+
+#### Windows
+
+```batch
+SET GCM_AZREPOS_USE_LEGACY_CLIENTID="true"
+```
+
+#### macOS/Linux
+
+```bash
+export GCM_AZREPOS_USE_LEGACY_CLIENTID="true"
+```
+
+**Also see: [credential.azreposUseLegacyClientId][legacy-client-id]**
+
+---
+
 ### GCM_AZREPOS_CREDENTIALTYPE
 
 Specify the type of credential the Azure Repos host provider should return.
@@ -1351,6 +1378,7 @@ Defaults to disabled.
 [credential-authority]: configuration.md#credentialauthority-deprecated
 [credential-autodetecttimeout]: configuration.md#credentialautodetecttimeout
 [credential-azrepos-credential-type]: configuration.md#credentialazreposcredentialtype
+[legacy-client-id]: configuration.md#credentialazreposuselegacyclientid
 [credential-azrepos-managedidentity]: configuration.md#credentialazreposmanagedidentity
 [credential-azrepos-wif]: configuration.md#credentialazreposworkloadfederation
 [credential-azrepos-wif-clientid]: configuration.md#credentialazreposworkloadfederationclientid

--- a/src/Core/Authentication/Entra/EntraAuthentication.Caching.cs
+++ b/src/Core/Authentication/Entra/EntraAuthentication.Caching.cs
@@ -103,7 +103,7 @@ public partial class EntraAuthentication
         // If we are using the shared Microsoft Developer cache there are a different set of
         // file paths, names, and keychain/keyring attributes to use.
         // The shared cache is used by other Microsoft developer tools such as the Azure PowerShell CLI.
-        if (_publicClientConfig.UseSharedCache)
+        if (PublicClientConfig.UseSharedCache)
         {
             Context.Trace.WriteLine("Using shared Microsoft Developer MSAL cache");
 

--- a/src/Core/Authentication/Entra/EntraAuthentication.PublicClient.cs
+++ b/src/Core/Authentication/Entra/EntraAuthentication.PublicClient.cs
@@ -68,7 +68,8 @@ public record PublicClientConfig
 public partial class EntraAuthentication
 {
     private const string MacBrokerRedirectUrl = "msauth.com.msauth.unsignedapp://auth";
-    private readonly PublicClientConfig _publicClientConfig;
+
+    public PublicClientConfig PublicClientConfig { get; }
 
     public async Task<InteractionMode> GetInteractionModeAsync(CancellationToken ct = default)
     {
@@ -219,7 +220,7 @@ public partial class EntraAuthentication
         try
         {
             return await app.AcquireTokenSilent(scopes, msalAccount)
-                .WithMsaPassthroughTransfer(_publicClientConfig.IsMsaPassthroughEnabled, msalAccount)
+                .WithMsaPassthroughTransfer(PublicClientConfig.IsMsaPassthroughEnabled, msalAccount)
                 .ExecuteAsync(ct);
         }
         catch (MsalUiRequiredException)
@@ -439,7 +440,7 @@ public partial class EntraAuthentication
     /// <param name="useBroker">True if the broker will be used for this applications build using this builder.</param>
     private PublicClientApplicationBuilder GetPublicAppBuilder(out bool useBroker)
     {
-        if (_publicClientConfig is null)
+        if (PublicClientConfig is null)
         {
             throw new InvalidOperationException(
                 "Public client configuration is required for user authentication.");
@@ -448,7 +449,7 @@ public partial class EntraAuthentication
         if (_publicBuilder is null)
         {
             Context.Trace.WriteLine("Creating public client application builder...");
-            var builder = PublicClientApplicationBuilder.Create(_publicClientConfig.ClientId)
+            var builder = PublicClientApplicationBuilder.Create(PublicClientConfig.ClientId)
                 .WithHttpClientFactory(_httpFactory)
                 .WithTraceLogging(Context)
                 .WithLegacyCacheCompatibility(false)
@@ -459,9 +460,9 @@ public partial class EntraAuthentication
             if (Context.SessionManager.IsDesktopSession && IsBrokerEnabled())
             {
                 // Check that the app config supports the broker on this platform
-                if (_publicClientConfig.SupportsWindowsBroker && PlatformUtils.IsWindows() ||
-                    _publicClientConfig.SupportsMacBroker && PlatformUtils.IsMacOS() ||
-                    _publicClientConfig.SupportsLinuxBroker && PlatformUtils.IsLinux())
+                if (PublicClientConfig.SupportsWindowsBroker && PlatformUtils.IsWindows() ||
+                    PublicClientConfig.SupportsMacBroker && PlatformUtils.IsMacOS() ||
+                    PublicClientConfig.SupportsLinuxBroker && PlatformUtils.IsLinux())
                 {
                     Context.Trace.WriteLine("Broker is supported by the app and enabled by the user.");
 
@@ -514,20 +515,20 @@ public partial class EntraAuthentication
     {
         var oses = BrokerOptions.OperatingSystems.None;
 
-        if (_publicClientConfig.SupportsWindowsBroker)
+        if (PublicClientConfig.SupportsWindowsBroker)
             oses |= BrokerOptions.OperatingSystems.Windows;
 
-        if (_publicClientConfig.SupportsMacBroker)
+        if (PublicClientConfig.SupportsMacBroker)
             oses |= BrokerOptions.OperatingSystems.OSX;
 
-        if (_publicClientConfig.SupportsLinuxBroker)
+        if (PublicClientConfig.SupportsLinuxBroker)
             oses |= BrokerOptions.OperatingSystems.Linux;
 
         return new BrokerOptions(oses)
         {
             Title = "Git Credential Manager",
             ListOperatingSystemAccounts = true,
-            MsaPassthrough = _publicClientConfig.IsMsaPassthroughEnabled
+            MsaPassthrough = PublicClientConfig.IsMsaPassthroughEnabled
         };
     }
 

--- a/src/Core/Authentication/Entra/EntraAuthentication.cs
+++ b/src/Core/Authentication/Entra/EntraAuthentication.cs
@@ -21,7 +21,7 @@ public partial class EntraAuthentication : AuthenticationBase, IEntraAuthenticat
     public EntraAuthentication(ICommandContext context, PublicClientConfig publicClientConfig = null)
         : base(context)
     {
-        _publicClientConfig = publicClientConfig;
+        PublicClientConfig = publicClientConfig;
         _httpFactory = new MsalHttpClientFactoryAdaptor(context.HttpClientFactory);
     }
 

--- a/src/Core/Authentication/Entra/IEntraAuthentication.cs
+++ b/src/Core/Authentication/Entra/IEntraAuthentication.cs
@@ -7,6 +7,12 @@ namespace GitCredentialManager.Authentication.Entra;
 public interface IEntraAuthentication
 {
     /// <summary>
+    /// The public client configuration used for authentication.
+    /// </summary>
+    /// <remarks>If this property is null then public client APIs cannot be called.</remarks>
+    PublicClientConfig PublicClientConfig { get; }
+
+    /// <summary>
     /// Ask the user which interaction mode they would like to use for authentication.
     /// </summary>
     /// <remarks>

--- a/src/Microsoft.AzureRepos/AzureDevOpsConstants.cs
+++ b/src/Microsoft.AzureRepos/AzureDevOpsConstants.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Microsoft.AzureRepos
 {
     internal static class AzureDevOpsConstants
@@ -11,9 +9,11 @@ namespace Microsoft.AzureRepos
         public const string AzureDevOpsResourceId = "499b84ac-1321-427f-aa17-267ca6975798";
         public static readonly string[] AzureDevOpsDefaultScopes = {$"{AzureDevOpsResourceId}/.default"};
 
+        // The GCM first party application client ID
+        public const string ClientId = "d735b71b-9eee-4a4f-ad23-421660877ba6";
+
         // Visual Studio's client ID
-        // We share this to be able to consume existing access tokens from the VS caches
-        public const string AadClientId = "872cd9fa-d31f-45e0-9eab-6e460a02d1f1";
+        public const string LegacyClientId = "872cd9fa-d31f-45e0-9eab-6e460a02d1f1";
 
         public const string VstsHostSuffix = ".visualstudio.com";
         public const string AzureDevOpsHost = "dev.azure.com";
@@ -34,8 +34,7 @@ namespace Microsoft.AzureRepos
 
         public static class EnvironmentVariables
         {
-            public const string DevAadClientId = "GCM_DEV_AZREPOS_CLIENTID";
-            public const string DevAadAuthorityBaseUri = "GCM_DEV_AZREPOS_AUTHORITYBASEURI";
+            public const string UseLegacyClientId = "GCM_AZREPOS_USE_LEGACY_CLIENTID";
             public const string CredentialType = "GCM_AZREPOS_CREDENTIALTYPE";
             public const string ServicePrincipalId = "GCM_AZREPOS_SERVICE_PRINCIPAL";
             public const string ServicePrincipalSecret = "GCM_AZREPOS_SP_SECRET";
@@ -54,8 +53,7 @@ namespace Microsoft.AzureRepos
         {
             public static class Credential
             {
-                public const string DevAadClientId = "azreposDevClientId";
-                public const string DevAadAuthorityBaseUri = "azreposDevAuthorityBaseUri";
+                public const string UseLegacyClientId = "azreposUseLegacyClientId";
                 public const string CredentialType = "azreposCredentialType";
                 public const string AzureAuthority = "azureAuthority";
                 public const string ServicePrincipal = "azreposServicePrincipal";

--- a/src/Microsoft.AzureRepos/AzureDevOpsRestApi.cs
+++ b/src/Microsoft.AzureRepos/AzureDevOpsRestApi.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AzureRepos
         {
             EnsureArgument.AbsoluteUri(organizationUri, nameof(organizationUri));
 
-            Uri authorityBase = GetAuthorityBaseUri();
+            Uri authorityBase = new(AzureDevOpsConstants.AadAuthorityBaseUrl);
             var commonAuthority = new Uri(authorityBase, "common");
 
             // We should be using "/common" or "/consumer" as the authority for MSA but since
@@ -86,21 +86,6 @@ namespace Microsoft.AzureRepos
             // Use the common authority if we can't determine a specific one
             _context.Trace.WriteLine($"Unable to determine AAD/MSA tenant - falling back to common authority");
             return commonAuthority.ToString();
-        }
-
-        private Uri GetAuthorityBaseUri()
-        {
-            // Check for developer override value
-            if (_context.Settings.TryGetSetting(
-                    AzureDevOpsConstants.EnvironmentVariables.DevAadAuthorityBaseUri,
-                    Constants.GitConfiguration.Credential.SectionName, AzureDevOpsConstants.GitConfiguration.Credential.DevAadAuthorityBaseUri,
-                    out string redirectUriStr) &&
-                Uri.TryCreate(redirectUriStr, UriKind.Absolute, out Uri authorityBase))
-            {
-                return authorityBase;
-            }
-
-            return new Uri(AzureDevOpsConstants.AadAuthorityBaseUrl);
         }
 
         public async Task<string> CreatePersonalAccessTokenAsync(Uri organizationUri, string accessToken, IEnumerable<string> scopes)

--- a/src/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -402,31 +402,37 @@ namespace Microsoft.AzureRepos
 
         private PublicClientConfig GetEntraConfig()
         {
+            (string clientId, bool isLegacy) = GetClientAppInfo();
+
+            _context.Trace.WriteLine(isLegacy
+                ? $"Using legacy Entra client ID '{clientId}'"
+                : $"Using new Entra client ID '{clientId}'");
+
             return new PublicClientConfig
             {
-                ClientId = GetClientId(),
+                ClientId = clientId,
                 IsMsaPassthroughEnabled = true,
                 UseSharedCache = true,
                 SupportsWindowsBroker = true,
-                // TODO: enable once our app registration has the appropriate redirect URLs
-                //SupportsMacBroker = true,
-                //SupportsLinuxBroker = true,
+                // Only the new client ID supports broker on Mac and Linux
+                SupportsMacBroker = !isLegacy,
+                SupportsLinuxBroker = !isLegacy,
             };
         }
 
-        private string GetClientId()
+        private (string clientId, bool isLegacy) GetClientAppInfo()
         {
-            // Check for developer override value
+            // Check for override to use the legacy client ID
             if (_context.Settings.TryGetSetting(
-                    AzureDevOpsConstants.EnvironmentVariables.DevAadClientId,
+                    AzureDevOpsConstants.EnvironmentVariables.UseLegacyClientId,
                     Constants.GitConfiguration.Credential.SectionName,
-                    AzureDevOpsConstants.GitConfiguration.Credential.DevAadClientId,
-                    out string clientId))
+                    AzureDevOpsConstants.GitConfiguration.Credential.UseLegacyClientId,
+                    out string str) && str.IsTruthy())
             {
-                return clientId;
+                return (AzureDevOpsConstants.LegacyClientId, true);
             }
 
-            return AzureDevOpsConstants.AadClientId;
+            return (AzureDevOpsConstants.ClientId, false);
         }
 
         /// <remarks>


### PR DESCRIPTION
This PR has been a long time in the making! We are giving Git Credential Manager its own first-party Microsoft Entra client application for Azure Repos!

GCM previously authenticated as the Visual Studio application, whose registration could not safely be extended for all of GCM's broker and Microsoft account requirements.

The dedicated application enables broker authentication on Windows, macOS, and Linux. In particular, this avoids unnecessary browser prompts on platforms where the broker can provide an existing signed-in account.

## Changes

- Use GCM's dedicated Entra client application for Azure Repos OAuth.
- Enable broker support for the new application on macOS and Linux, in addition to the existing Windows support. (Note that broker support is still opt-in at this time!)
- Preserve the Visual Studio client as a documented compatibility option through `credential.azreposUseLegacyClientId` and `GCM_AZREPOS_USE_LEGACY_CLIENTID`.
- If user authentication fails, then print a message informing the user they can switch back to the legacy client if MSAL, and asks them to report the failure.
- Replace the unrestricted developer client-ID and authority overrides with the focused legacy-client compatibility setting.

## Compatibility

The new GCM application is the default. Users who need the previous behaviour can select the legacy client explicitly. An MSAL failure in the new application triggers an advice message to retry with the old client when obtaining a user Entra token, either directly for OAuth credentials or as part of PAT creation.

Managed identity, workload federation, and service-principal flows are unaffected.

Fixes git-ecosystem/git-credential-manager#47