### PR TITLE
Report credential store name

### DIFF
--- a/src/Core/CredentialCacheStore.cs
+++ b/src/Core/CredentialCacheStore.cs
@@ -23,6 +23,8 @@ namespace GitCredentialManager
 
         #region ICredentialStore
 
+        public string Name => "Git Credential Cache";
+
         public IList<string> GetAccounts(string service)
         {
             // Listing accounts is not supported by the credential-cache store so we just attempt to retrieve

--- a/src/Core/CredentialStore.cs
+++ b/src/Core/CredentialStore.cs
@@ -25,6 +25,15 @@ namespace GitCredentialManager
 
         #region ICredentialStore
 
+        public string Name
+        {
+            get
+            {
+                EnsureBackingStore();
+                return _backingStore.Name;
+            }
+        }
+
         public IList<string> GetAccounts(string service)
         {
             EnsureBackingStore();

--- a/src/Core/Diagnostics/CredentialStoreDiagnostic.cs
+++ b/src/Core/Diagnostics/CredentialStoreDiagnostic.cs
@@ -13,7 +13,7 @@ namespace GitCredentialManager.Diagnostics
 
         protected override Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
         {
-            log.AppendLine($"ICredentialStore instance is of type: {CommandContext.CredentialStore.GetType().Name}");
+            log.AppendLine($"Credential store is: {CommandContext.CredentialStore.Name}");
 
             // Create a service that is guaranteed to be unique
             string service = $"https://example.com/{Guid.NewGuid():N}";

--- a/src/Core/ICredentialStore.cs
+++ b/src/Core/ICredentialStore.cs
@@ -8,6 +8,11 @@ namespace GitCredentialManager
     public interface ICredentialStore
     {
         /// <summary>
+        /// Get the name of the credential store.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
         /// Get all accounts from the store for the given service.
         /// </summary>
         /// <param name="service">Name of the service to match against. Use null to match all values.</param>

--- a/src/Core/Interop/Linux/SecretServiceCollection.cs
+++ b/src/Core/Interop/Linux/SecretServiceCollection.cs
@@ -37,6 +37,8 @@ namespace GitCredentialManager.Interop.Linux
 
         #region ICredentialStore
 
+        public string Name => "freedesktop.org Secret Service";
+
         public IList<string> GetAccounts(string service)
         {
             return Enumerate(service, null).Select(x => x.Account).Distinct().ToList();

--- a/src/Core/Interop/MacOS/MacOSKeychain.cs
+++ b/src/Core/Interop/MacOS/MacOSKeychain.cs
@@ -31,6 +31,8 @@ namespace GitCredentialManager.Interop.MacOS
 
         #region ICredentialStore
 
+        public string Name => "macOS Keychain";
+
         public IList<string> GetAccounts(string service)
         {
             IntPtr query = IntPtr.Zero;

--- a/src/Core/Interop/Posix/GpgPassCredentialStore.cs
+++ b/src/Core/Interop/Posix/GpgPassCredentialStore.cs
@@ -19,6 +19,8 @@ namespace GitCredentialManager.Interop.Posix
             _gpg = gpg;
         }
 
+        public override string Name => "GPG/Pass";
+
         protected override string CredentialFileExtension => ".gpg";
 
         private string GetGpgId(string credentialFullPath)

--- a/src/Core/Interop/Windows/DpapiCredentialStore.cs
+++ b/src/Core/Interop/Windows/DpapiCredentialStore.cs
@@ -14,6 +14,8 @@ namespace GitCredentialManager.Interop.Windows
             PlatformUtils.EnsureWindows();
         }
 
+        public override string Name => "DPAPI";
+
         protected override bool TryDeserializeCredential(string path, out FileCredential credential)
         {
             string text;

--- a/src/Core/Interop/Windows/WindowsCredentialManager.cs
+++ b/src/Core/Interop/Windows/WindowsCredentialManager.cs
@@ -24,6 +24,8 @@ namespace GitCredentialManager.Interop.Windows
             _namespace = @namespace;
         }
 
+        public string Name => "Windows Credential Manager";
+
         public IList<string> GetAccounts(string service)
         {
             return Enumerate(service, null).Select(x => x.UserName).Distinct().ToList();

--- a/src/Core/NullCredentialStore.cs
+++ b/src/Core/NullCredentialStore.cs
@@ -9,6 +9,8 @@ namespace GitCredentialManager;
 /// </summary>
 public class NullCredentialStore : ICredentialStore
 {
+    public string Name => "No-op";
+
     public IList<string> GetAccounts(string service) => Array.Empty<string>();
 
     public ICredential Get(string service, string account) => null;

--- a/src/Core/PlaintextCredentialStore.cs
+++ b/src/Core/PlaintextCredentialStore.cs
@@ -23,6 +23,8 @@ namespace GitCredentialManager
         protected string Namespace { get; }
         protected virtual string CredentialFileExtension => ".credential";
 
+        public virtual string Name => "Plaintext";
+
         public IList<string> GetAccounts(string service)
         {
             return Enumerate(service, null).Select(x => x.Account).Distinct().ToList();

--- a/src/TestInfrastructure/Objects/TestCredentialStore.cs
+++ b/src/TestInfrastructure/Objects/TestCredentialStore.cs
@@ -14,6 +14,8 @@ namespace GitCredentialManager.Tests.Objects
 
         #region ICredentialStore
 
+        public string Name => "Test Credential Store";
+
         public IList<string> GetAccounts(string service)
         {
             return Query(service, null).Select(x => x.Account).Distinct().ToList();


### PR DESCRIPTION
Allow credential stores to report back their name. This also allows callers who are using the `CredentialStore` facade class to see which backing store was selected.

Update the credential store diagnostic to report the actual credential backing store name rather than the runtime type (which is always `CredentialStore`; and not helpful).