### PR TITLE
NONE: Refactor Bitbucket Cloud's OAuth2 host provider to support rotating refresh tokens

### DIFF
--- a/src/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
+++ b/src/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
@@ -155,7 +155,7 @@ namespace Atlassian.Bitbucket.Tests
                 MockDCSSOEnabled();
             }
             MockStoredAccount(context, request, token);
-            MockRemoteAccessTokenValid(request, token);
+            MockRemoteAccessTokenValid(username, token);
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
 
@@ -210,13 +210,12 @@ namespace Atlassian.Bitbucket.Tests
         public async Task BitbucketHostProvider_GetCredentialAsync_Valid_New_OAuth(
             string protocol, string host, string username, string refreshToken, string accessToken)
         {
-            GitRequest request = MockInput(protocol, host, username);
+            GitRequest request = MockInput(protocol, host, null);
 
             var context = new TestCommandContext();
-
             MockPromptOAuth(request);
             MockRemoteOAuthTokenCreate(request, accessToken, refreshToken);
-            MockRemoteAccessTokenValid(request, accessToken);
+            MockRemoteAccessTokenValid(username, accessToken);
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
 
@@ -229,7 +228,39 @@ namespace Atlassian.Bitbucket.Tests
             VerifyInteractiveAuthRan(request);
             VerifyOAuthFlowRan(request, accessToken);
             VerifyValidateAccessTokenRan(request, accessToken);
-            VerifyOAuthRefreshTokenStored(context, request, refreshToken);
+
+            var refreshService = GetRefreshTokenServiceNameForRequest(request);
+            VerifyOAuthRefreshTokenStored(context, refreshService, username, refreshToken);
+        }
+
+
+        [Theory]
+        // DC/Server does not currently support OAuth
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", MOCK_REFRESH_TOKEN, MOCK_ACCESS_TOKEN)]
+        public async Task BitbucketHostProvider_GetCredentialAsync_Valid_New_OAuth_With_Null_Request_Username(
+            string protocol, string host, string username, string refreshToken, string accessToken)
+        {
+            GitRequest request = MockInput(protocol, host, null);
+
+            var context = new TestCommandContext();
+            MockPromptOAuth(request);
+            MockRemoteOAuthTokenCreate(request, accessToken, refreshToken);
+            MockRemoteAccessTokenValid(username, accessToken);
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
+
+            var result = await provider.GetCredentialAsync(request);
+            ICredential credential = result.Credential;
+
+            Assert.Equal(username, credential.Account);
+            Assert.Equal(accessToken, credential.Password);
+
+            VerifyInteractiveAuthRan(request);
+            VerifyOAuthFlowRan(request, accessToken);
+            VerifyValidateAccessTokenRan(request, accessToken);
+            
+            var refreshService = GetRefreshTokenServiceNameForRequest(request);
+            VerifyOAuthRefreshTokenStored(context, refreshService, username, refreshToken);
         }
 
         [Theory]
@@ -244,7 +275,7 @@ namespace Atlassian.Bitbucket.Tests
 
             // AT has does not exist, but RT is still valid
             MockStoredRefreshToken(context, request, refreshToken);
-            MockRemoteAccessTokenValid(request, accessToken);
+            MockRemoteAccessTokenValid(username, accessToken);
             MockRemoteRefreshTokenValid(request, refreshToken, accessToken);
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
@@ -275,7 +306,7 @@ namespace Atlassian.Bitbucket.Tests
             MockRemoteAccessTokenExpired(request, expiredAccessToken);
 
             MockStoredRefreshToken(context, request, refreshToken);
-            MockRemoteAccessTokenValid(request, accessToken);
+            MockRemoteAccessTokenValid(username, accessToken);
             MockRemoteRefreshTokenValid(request, refreshToken, accessToken);
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
@@ -304,7 +335,7 @@ namespace Atlassian.Bitbucket.Tests
 
             // We have a stored RT so we can just use that without any prompts
             MockStoredRefreshToken(context, request, refreshToken);
-            MockRemoteAccessTokenValid(request, accessToken);
+            MockRemoteAccessTokenValid(username, accessToken);
             MockRemoteRefreshTokenValid(request, refreshToken, accessToken);
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
@@ -332,7 +363,7 @@ namespace Atlassian.Bitbucket.Tests
             // User has stored access token that we shouldn't use - RT should be used to mint new AT
             MockStoredAccount(context, request, storedToken);
             MockStoredRefreshToken(context, request, refreshToken);
-            MockRemoteAccessTokenValid(request, newToken);
+            MockRemoteAccessTokenValid(username, newToken);
             MockRemoteRefreshTokenValid(request, refreshToken, newToken);
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
@@ -537,10 +568,10 @@ namespace Atlassian.Bitbucket.Tests
                 .ReturnsAsync(new RestApiResult<IUserInfo>(System.Net.HttpStatusCode.Unauthorized));
         }
 
-        private void MockRemoteAccessTokenValid(GitRequest request, string token)
+        private void MockRemoteAccessTokenValid(string username, string token)
         {
             var userInfo = new Mock<IUserInfo>(MockBehavior.Strict);
-            userInfo.Setup(ui => ui.UserName).Returns(request.UserName);
+            userInfo.Setup(ui => ui.UserName).Returns(username);
 
             // OAuth
             bitbucketApi.Setup(x => x.GetUserInformationAsync(null, token, true))
@@ -567,20 +598,25 @@ namespace Atlassian.Bitbucket.Tests
             context.CredentialStore.Add(refreshService, new TestCredential(refreshService, request.UserName, token));
         }
 
+        private string GetRefreshTokenServiceNameForRequest(GitRequest request)
+        {
+            var remoteUri = request.GetRemoteUri();
+            return BitbucketHostProvider.GetRefreshTokenServiceName(remoteUri);
+        }
+
         private void MockRemoteOAuthTokenCreate(GitRequest request, string accessToken, string refreshToken)
         {
             bitbucketAuthentication.Setup(x => x.CreateOAuthCredentialsAsync(request))
                 .ReturnsAsync(new OAuth2TokenResult(accessToken, "access_token") { RefreshToken = refreshToken });
         }
 
-        private void VerifyOAuthRefreshTokenStored(TestCommandContext context, GitRequest request, string refreshToken)
+        private void VerifyOAuthRefreshTokenStored(TestCommandContext context, string refreshService, string expectedAccount, string expectedRefreshToken)
         {
-            var remoteUri = request.GetRemoteUri();
-            string refreshService = BitbucketHostProvider.GetRefreshTokenServiceName(remoteUri);
-            bool result = context.CredentialStore.TryGet(refreshService, request.UserName, out var credential);
+            bool result = context.CredentialStore.TryGet(refreshService, expectedAccount, out var credential);
 
             Assert.True(result);
-            Assert.Equal(refreshToken, credential.Password);
+            Assert.Equal(expectedAccount, credential.Account);
+            Assert.Equal(expectedRefreshToken, credential.Password);
         }
 
         private static Mock<IRegistry<IBitbucketRestApi>> MockRestApiRegistry(GitRequest request, Mock<IBitbucketRestApi> bitbucketApi)

--- a/src/Atlassian.Bitbucket/BitbucketHostProvider.cs
+++ b/src/Atlassian.Bitbucket/BitbucketHostProvider.cs
@@ -139,8 +139,16 @@ namespace Atlassian.Bitbucket
             // Check for presence of refresh_token entry in credential store
             Uri remoteUri = request.GetRemoteUri();
             var refreshTokenService = GetRefreshTokenServiceName(remoteUri);
-
-            _context.Trace.WriteLine("Checking for refresh token...");
+            
+            _context.Trace.WriteLine($"Checking for refresh token stored against user: '{request.UserName}'...");
+            // request.UserName can either be be null or the registered Bitbucket username of the user attempting the
+            // git operation.
+            // * In the case of null the CredentialStore.Get will find the *first* refresh token stored for Bitbucket in
+            // the credential store - The storing of the refresh token is stored against the resolved Bitbucket username
+            // as part of the access token validation flow (calls 2.0/user)
+            // * When request.UserName is set the refresh token must exist under the provided username in the credential
+            // store.
+            // If a refresh token is unable to be found a full OAuth authorization flow is initiated.
             ICredential refreshToken = SupportsOAuth(authModes)
                 ? _context.CredentialStore.Get(refreshTokenService, request.UserName)
                 : null;
@@ -203,51 +211,39 @@ namespace Atlassian.Bitbucket
 
         private async Task<ICredential> GetOAuthCredentialsViaRefreshFlow(GitRequest request, ICredential refreshToken)
         {
-            Uri remoteUri = request.GetRemoteUri();
-
-            var refreshTokenService = GetRefreshTokenServiceName(remoteUri);
             _context.Trace.WriteLine("Refreshing OAuth credentials using refresh token...");
-
             OAuth2TokenResult refreshResult = await _bitbucketAuth.RefreshOAuthCredentialsAsync(request, refreshToken.Password);
-
-            // Resolve the username
-            _context.Trace.WriteLine("Resolving username for refreshed OAuth credential...");
-            string refreshUserName = await ResolveOAuthUserNameAsync(request, refreshResult.AccessToken);
-            _context.Trace.WriteLine($"Username for refreshed OAuth credential is '{refreshUserName}'");
-
-            // Store the refreshed RT
-            _context.Trace.WriteLine("Storing new refresh token...");
-            _context.CredentialStore.AddOrUpdate(refreshTokenService, remoteUri.GetUserName(), refreshResult.RefreshToken);
-
-            // Return new access token
-            return new GitCredential(refreshUserName, refreshResult.AccessToken);
+            return await ResolveCredsAndStoreRefreshToken(request, refreshResult);
         }
 
         private async Task<ICredential> GetOAuthCredentialsViaInteractiveBrowserFlow(GitRequest request)
         {
-            Uri remoteUri = request.GetRemoteUri();
-
-            var refreshTokenService = GetRefreshTokenServiceName(remoteUri);
-
             // We failed to use the refresh token either because it didn't exist, or because the refresh token is no
             // longer valid. Either way we must now try authenticating using OAuth interactively.
 
             // Start OAuth authentication flow
             _context.Trace.WriteLine("Starting OAuth authentication flow...");
             OAuth2TokenResult oauthResult = await _bitbucketAuth.CreateOAuthCredentialsAsync(request);
+            return await ResolveCredsAndStoreRefreshToken(request, oauthResult);
+        }
 
-            // Resolve the username
+        private async Task<ICredential> ResolveCredsAndStoreRefreshToken(GitRequest request, OAuth2TokenResult tokenSet)
+        {
+            Uri remoteUri = request.GetRemoteUri();
+
+            var refreshTokenService = GetRefreshTokenServiceName(remoteUri);
+            // Resolve the username to authenticate the git call
             _context.Trace.WriteLine("Resolving username for OAuth credential...");
-            string newUserName = await ResolveOAuthUserNameAsync(request, oauthResult.AccessToken);
-            _context.Trace.WriteLine($"Username for OAuth credential is '{newUserName}'");
+            string bitbucketUsername = await ResolveOAuthUserNameAsync(request, tokenSet.AccessToken);
+            _context.Trace.WriteLine($"Username for OAuth credential is '{bitbucketUsername}'");
 
-            // Store the new RT
-            _context.Trace.WriteLine("Storing new refresh token...");
-            _context.CredentialStore.AddOrUpdate(refreshTokenService, newUserName, oauthResult.RefreshToken);
+            // Store the new refresh token in the credential store against the resolved Bitbucket username
+            _context.Trace.WriteLine($"Storing new refresh token against user: '{bitbucketUsername}'...");
+            _context.CredentialStore.AddOrUpdate(refreshTokenService, bitbucketUsername, tokenSet.RefreshToken);    
             _context.Trace.WriteLine("Refresh token was successfully stored.");
 
             // Return the new AT as the credential
-            return new GitCredential(newUserName, oauthResult.AccessToken);
+            return new GitCredential(bitbucketUsername, tokenSet.AccessToken);
         }
 
         private static bool SupportsOAuth(AuthenticationModes authModes)


### PR DESCRIPTION
Updates the `BitbucketHostProvider` to always store the refresh credentials using the resolved **username** from bitbucket.

## Background
Bitbucket Cloud's OAuth implementation is moving to rotating refresh tokens. These refresh tokens have a TTL of 3 months, but are immediately expired (~10 minutes) after their first usage. This means after each `refresh_token` grant flow it's expected that clients store the newly issued `refresh_token` from the OAuth token set.

Another change is that the `access_token` and `refresh_token` are far larger than the previous tokens. Regularly exceeding 2500 characters. This will cause issues with `CredentialStore` which have limits on the credential length. The default for windows `wincredman` is one such store which has issues. We will be asking customers using GCM on windows (likely via **git output** and a deprecation notice) that they'll need to change credential store that git credential manager is configured to use to `dpapi` which doesn't have the size constraints.

### Why does the Bitbucket OAuth code in GCM need changing?
When the initial `authorization_code` grant flow is run, the `access_token` and `refresh_token` returned are stored in the configured `CredentialStore` against the validated Bitbucket `username` (resolved by calling `api.bitbucket.org/2.0/user` with the `access_token`).

When the `access_token` stored expires, the `refresh_token` grant flow automatically runs to generate fresh credentials. This flow looks for a `refresh_token` in the Credential Store stored under the `account` provided by the `request.UserName` property.

In some cases this property is null (if the git remote URI configured specifies no username). When the account is null, the Credential Store will return back the first **Credential** that matches the git host. This will find the `refresh_token` stored by the original authorization flow. For git remotes configured with a `username` the CredentialManager will look for a secret belonging exactly to that account.

When, the `refresh_token` grant flow has concluded and the `access_token` has been validated the new `refresh_token` is stored in CredentialStore against the `account` provided by the `remoteUri.GetUserName()` function. However, because `remoteUri` is built with `includeUser=False` (which is the default) the `refresh_token` credential will always be stored against a `null` account in the credential store.

Now on some `credentialStores` this will find the first credential configured (as the `account` is null and that's the behaviour documented by `AddOrUpdate`) however on file system based backends (Which we will be requiring windows users to move to with `dpapi`) it appears as though it will create a new file for the credential:
<img width="794" height="275" alt="image" src="https://github.com/user-attachments/assets/b1369b7e-2337-4268-b2b6-2038092916e6" />
Notice from this image above the "latest" refresh token is store in a file called `.credential`. However, when the next git operation needs to auth, the `CredentialStore.get` appears to take the `<username>.credential` file over the account-less `.credential` file. This behaviour appears consistent between both Windows and MacOSX when using a file system based `CredentialStore` (tried both `dpapi` and `plaintext`). Note that if the user has specified a `username` in their remote git URI the backend will always return back the `<username>.credential` file and will not ever fall back to the `.credential` file - in this case a reauthorization flow would be triggered.


Because of the discrepency between the locations where we store the `refresh_token` and retrieve it, The `refresh_token` will only works the first time the `refresh_token` grant flow is executed. Subsequent `refresh_token` grant flows will retrieve the original (and now expired) `refresh_token` - which will be blocked. This causes the auth code will fall into a new authorization grant flow. The broken behaviour would then loop in this manner indefinitely requiring constant reauthorization.

### The change
This fix brings the `refresh_token` grant flow inline with the implementation of the `authorization_code` grant flow. This stores the `refresh_token` against the `account` which is the resolved Bitbucket `username`. This should mean that regardless of whether you've set your `username` in the git remote URI, the latest `refresh_token` will be used to initiate the `refresh_token` flow.

### Rollout
Once the version containing this release is shipped / bundled into Git for Windows, we will be announcing a deprecation and publicly documenting the steps required to continue authing using the OAuth credentials. We will likely run a series of brownouts against the older versions of GCM prior to the complete disablement of the non-rotating refresh tokens.

We will also highlight in our deprecation / announcement (In official Atlassian channels) that any Windows users need to move from using the default `CredentialStore` of `wincredman` onto `dpapi`. 

###
I sparred with the problem and fix with my colleague @mminns who worked on some of the original code some 8+ years ago.

Fixes: https://github.com/git-ecosystem/git-credential-manager/issues/2428