### PR TITLE
[Bitbucket Cloud] Implement credential chunking for the wincredman credentialStore to ensure seamless upgrade path for Bitbucket Cloud OAuth changes

### DIFF
--- a/src/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
+++ b/src/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
@@ -7,7 +7,6 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -24,15 +23,16 @@ namespace Atlassian.Bitbucket.Tests
         private const string MOCK_ROTATED_REFRESH_TOKEN = "rt-01189998819991197253";
         
         private const string MOCK_CHUNKED_ACCESS_TOKEN_DESCRIPTOR = "chunks=3";
-        private const string MOCK_CHUNKED_ACCESS_TOKEN_1 = "at-123";
-        private const string MOCK_CHUNKED_ACCESS_TOKEN_2 = "456";
-        private const string MOCK_CHUNKED_ACCESS_TOKEN_3 = "789";
+        private const string MOCK_CHUNKED_ACCESS_TOKEN_1 = "at-12";
+        private const string MOCK_CHUNKED_ACCESS_TOKEN_2 = "45678";
+        private const string MOCK_CHUNKED_ACCESS_TOKEN_3 = "9";
         private const string COMBINED_CHUNKED_ACCESS_TOKEN =
             MOCK_CHUNKED_ACCESS_TOKEN_1 + MOCK_CHUNKED_ACCESS_TOKEN_2 + MOCK_CHUNKED_ACCESS_TOKEN_3;
-        
+
+        private const int MOCK_MAX_CREDENTIAL_SIZE = 5;
         private const string MOCK_CHUNKED_REFRESH_TOKEN_DESCRIPTOR = "chunks=2";
-        private const string MOCK_CHUNKED_REFRESH_TOKEN_1 = "rt-98765";
-        private const string MOCK_CHUNKED_REFRESH_TOKEN_2 = "4321";
+        private const string MOCK_CHUNKED_REFRESH_TOKEN_1 = "rt-98";
+        private const string MOCK_CHUNKED_REFRESH_TOKEN_2 = "76543";
         private const string COMBINED_CHUNKED_REFRESH_TOKEN =
             MOCK_CHUNKED_REFRESH_TOKEN_1 + MOCK_CHUNKED_REFRESH_TOKEN_2;
 
@@ -83,17 +83,6 @@ namespace Atlassian.Bitbucket.Tests
 
             var provider = new BitbucketHostProvider(new TestCommandContext());
             Assert.Equal(expected, provider.IsSupported(request));
-        }
-
-        [Theory]
-        [InlineData(null, false)]
-        [InlineData(1, true)]
-        [InlineData(100, true)]
-        public void CredentialStore_SupportsChunking(int? maxCredentialSize, bool supportsChunking)
-        {
-            var context = new TestCommandContext();
-            context.CredentialStore.MaxCredentialSize = maxCredentialSize;
-            Assert.Equal(supportsChunking, context.CredentialStore.SupportsChunking());
         }
         
         [Fact]
@@ -254,7 +243,7 @@ namespace Atlassian.Bitbucket.Tests
 
             var context = new TestCommandContext();
             // Credential store doesn't support chunking
-            context.CredentialStore.MaxCredentialSize = null;
+            context.CredentialStore.MaxCredentialSize = 0;
 
             if (DC_SERVER_HOST.Equals(host))
             {
@@ -507,19 +496,14 @@ namespace Atlassian.Bitbucket.Tests
         
         [Theory]
         // DC/Server does not currently support OAuth
-        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", MOCK_EXPIRED_ACCESS_TOKEN, MOCK_REFRESH_TOKEN, MOCK_ACCESS_TOKEN)]
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", MOCK_EXPIRED_ACCESS_TOKEN, MOCK_REFRESH_TOKEN, MOCK_ACCESS_TOKEN, COMBINED_CHUNKED_REFRESH_TOKEN, MOCK_MAX_CREDENTIAL_SIZE)]
         public async Task BitbucketHostProvider_GetCredentialAsync_ExpiredAT_OAuth_Refresh_StoresChunkedRT(
-            string protocol, string host, string username, string expiredAccessToken, string refreshToken, string accessToken)
+            string protocol, string host, string username, string expiredAccessToken, string refreshToken, string accessToken, string rotatedRefreshToken, int maxCredentialSize)
         {
-            var rotatedRt = BuildRandomStringOfLength(299);
-            string rtChunk1 = rotatedRt.Substring(0, 100);
-            string rtChunk2 = rotatedRt.Substring(100, 100);
-            string rtChunk3 = rotatedRt.Substring(200, 99);
-            
             var request = MockInput(protocol, host, username);
 
             var context = new TestCommandContext();
-            context.CredentialStore.MaxCredentialSize = 100;
+            context.CredentialStore.MaxCredentialSize = maxCredentialSize;
 
             // AT exists but has expired, but RT is still valid
             MockStoredAccount(context, request, expiredAccessToken);
@@ -528,7 +512,7 @@ namespace Atlassian.Bitbucket.Tests
             MockRemoteAccessTokenExpired(request, expiredAccessToken);
             MockRemoteAccessTokenValid(username, accessToken);
             // After refreshing we're given back a wide rotated refresh token which would need chunking on supported credentialStores
-            MockRemoteRefreshTokenValid(request, refreshToken, accessToken, rotatedRt);
+            MockRemoteRefreshTokenValid(request, refreshToken, accessToken, rotatedRefreshToken);
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
 
@@ -542,26 +526,23 @@ namespace Atlassian.Bitbucket.Tests
             VerifyOAuthRefreshRan(request, refreshToken);
             VerifyInteractiveAuthNeverRan();
             // Stored RT as chunked
-            VerifyOAuthTokenStored(context, GetRefreshTokenServiceNameForRequest(request), username, "chunks=3");
+            VerifyOAuthTokenStored(context, GetRefreshTokenServiceNameForRequest(request), username, MOCK_CHUNKED_REFRESH_TOKEN_DESCRIPTOR);
             var chunkRtServiceName = GetRefreshTokenChunkServiceName(request);
-            VerifyOAuthTokenStored(context, chunkRtServiceName, $"{username}_0", rtChunk1);
-            VerifyOAuthTokenStored(context, chunkRtServiceName, $"{username}_1", rtChunk2);
-            VerifyOAuthTokenStored(context, chunkRtServiceName, $"{username}_2", rtChunk3);
+            VerifyOAuthTokenStored(context, chunkRtServiceName, $"{username}_0", MOCK_CHUNKED_REFRESH_TOKEN_1);
+            VerifyOAuthTokenStored(context, chunkRtServiceName, $"{username}_1", MOCK_CHUNKED_REFRESH_TOKEN_2);
         }
         
         [Theory]
         // DC/Server does not currently support OAuth
-        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", MOCK_EXPIRED_ACCESS_TOKEN, MOCK_REFRESH_TOKEN, MOCK_ACCESS_TOKEN)]
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", MOCK_EXPIRED_ACCESS_TOKEN, MOCK_REFRESH_TOKEN, MOCK_ACCESS_TOKEN, COMBINED_CHUNKED_REFRESH_TOKEN)]
         public async Task BitbucketHostProvider_GetCredentialAsync_ExpiredAT_OAuth_Refresh_DoesNotChunkLargeRTForUnsupportedCredentialStore(
-            string protocol, string host, string username, string expiredAccessToken, string refreshToken, string accessToken)
+            string protocol, string host, string username, string expiredAccessToken, string refreshToken, string accessToken,  string rotatedRefreshToken)
         {
-            var rotatedRt = BuildRandomStringOfLength(2500);
-            
             var request = MockInput(protocol, host, username);
 
             var context = new TestCommandContext();
             // Credential store doesn't support chunking
-            context.CredentialStore.MaxCredentialSize = null;
+            context.CredentialStore.MaxCredentialSize = 0;
 
             // AT exists but has expired, but RT is still valid
             MockStoredAccount(context, request, expiredAccessToken);
@@ -569,7 +550,7 @@ namespace Atlassian.Bitbucket.Tests
             
             MockRemoteAccessTokenExpired(request, expiredAccessToken);
             MockRemoteAccessTokenValid(username, accessToken);
-            MockRemoteRefreshTokenValid(request, refreshToken, accessToken, rotatedRt);
+            MockRemoteRefreshTokenValid(request, refreshToken, accessToken, rotatedRefreshToken);
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
 
@@ -583,7 +564,7 @@ namespace Atlassian.Bitbucket.Tests
             VerifyOAuthRefreshRan(request, refreshToken);
             VerifyInteractiveAuthNeverRan();
             // Stored RT without chunking
-            VerifyOAuthTokenStored(context, GetRefreshTokenServiceNameForRequest(request), username, rotatedRt);
+            VerifyOAuthTokenStored(context, GetRefreshTokenServiceNameForRequest(request), username, rotatedRefreshToken);
         }
         
         [Theory]
@@ -761,15 +742,10 @@ namespace Atlassian.Bitbucket.Tests
         }
         
         [Theory]
-        [InlineData("https", BITBUCKET_DOT_ORG_HOST,  "jsquire",100)]
-        public async Task BitbucketHostProvider_StoreCredentialAsync_SplitsIntoChunksForSupportedCredentialStores(string protocol, string host, string username, int credentialWidth)
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST,  "jsquire",COMBINED_CHUNKED_ACCESS_TOKEN, MOCK_MAX_CREDENTIAL_SIZE)]
+        public async Task BitbucketHostProvider_StoreCredentialAsync_SplitsIntoChunksForSupportedCredentialStores(string protocol, string host, string username, string password, int credentialWidth)
         {
-            string longToken = BuildRandomStringOfLength(250);
-            string chunk1 = longToken.Substring(0, credentialWidth);
-            string chunk2 = longToken.Substring(credentialWidth, credentialWidth);
-            string chunk3 = longToken.Substring(200, 50);
-
-            var request = MockInput(protocol, host, username, longToken);
+            var request = MockInput(protocol, host, username, password);
             var context = new TestCommandContext();
             context.CredentialStore.MaxCredentialSize = credentialWidth;
             
@@ -782,25 +758,22 @@ namespace Atlassian.Bitbucket.Tests
             // The chunk descriptor and 3 chunks
             Assert.Equal(4, context.CredentialStore.Count);
             var serviceName = GetAccessTokenServiceName(request);
-            VerifyOAuthTokenStored(context, serviceName, username, "chunks=3");
+            VerifyOAuthTokenStored(context, serviceName, username, MOCK_CHUNKED_ACCESS_TOKEN_DESCRIPTOR);
             var chunkServiceName = GetAccessTokenChunkServiceName(request);
-            VerifyOAuthTokenStored(context, chunkServiceName, $"{username}_0", chunk1);
-            VerifyOAuthTokenStored(context, chunkServiceName, $"{username}_1", chunk2);
-            VerifyOAuthTokenStored(context, chunkServiceName, $"{username}_2", chunk3);
+            VerifyOAuthTokenStored(context, chunkServiceName, $"{username}_0", MOCK_CHUNKED_ACCESS_TOKEN_1);
+            VerifyOAuthTokenStored(context, chunkServiceName, $"{username}_1", MOCK_CHUNKED_ACCESS_TOKEN_2);
+            VerifyOAuthTokenStored(context, chunkServiceName, $"{username}_2", MOCK_CHUNKED_ACCESS_TOKEN_3);
         }
         
         [Theory]
-        [InlineData("https", BITBUCKET_DOT_ORG_HOST,  "jsquire")]
-        public async Task BitbucketHostProvider_StoreCredentialAsync_DoesNotChunk(string protocol, string host, string username)
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST,"jsquire", COMBINED_CHUNKED_ACCESS_TOKEN)]
+        public async Task BitbucketHostProvider_StoreCredentialAsync_DoesNotChunk(string protocol, string host,string username, string password) 
         {
-            // The width is deliberately wider than the known maximum that some credential managers support.
-            string almostTooLongToken = BuildRandomStringOfLength(5000);
-
-            var request = MockInput(protocol, host, username, almostTooLongToken);
+            var request = MockInput(protocol, host, username, password);
 
             var context = new TestCommandContext();
             // Credential store doesn't support chunking
-            context.CredentialStore.MaxCredentialSize = null;
+            context.CredentialStore.MaxCredentialSize = 0;
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
 
@@ -809,7 +782,27 @@ namespace Atlassian.Bitbucket.Tests
             await provider.StoreCredentialAsync(request);
             Assert.Equal(1, context.CredentialStore.Count);
             var serviceName = GetAccessTokenServiceName(request);
-            VerifyOAuthTokenStored(context, serviceName, username, almostTooLongToken);
+            VerifyOAuthTokenStored(context, serviceName, username, password);
+        }
+        
+        [Theory]
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST,"jsquire", COMBINED_CHUNKED_ACCESS_TOKEN)]
+        public async Task BitbucketHostProvider_StoreCredentialAsync_DoesNotChunkForSecretsSmallerThanMaximumCredentialSize(string protocol, string host,string username, string password) 
+        {
+            var request = MockInput(protocol, host, username, password);
+
+            var context = new TestCommandContext();
+            // Set the length to the exact size of the password we're trying to store. We can fully fit this secret and thus won't chunk
+            context.CredentialStore.MaxCredentialSize = password.Length;
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
+
+            Assert.Equal(0, context.CredentialStore.Count);
+
+            await provider.StoreCredentialAsync(request);
+            Assert.Equal(1, context.CredentialStore.Count);
+            var serviceName = GetAccessTokenServiceName(request);
+            VerifyOAuthTokenStored(context, serviceName, username, password);
         }
         
 
@@ -1015,19 +1008,6 @@ namespace Atlassian.Bitbucket.Tests
             restApiRegistry.Setup(rar => rar.Get(request)).Returns(bitbucketApi.Object);
 
             return restApiRegistry;
-        }
-
-        private static String BuildRandomStringOfLength(int length)
-        {
-            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-
-            StringBuilder sb = new StringBuilder(length);
-
-            for (int i = 0; i < length; i++)
-            {
-                sb.Append(chars[Random.Shared.Next(chars.Length)]);
-            }
-            return sb.ToString();
         }
 
         #endregion

--- a/src/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
+++ b/src/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
@@ -7,6 +7,7 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -20,8 +21,24 @@ namespace Atlassian.Bitbucket.Tests
         private const string MOCK_ACCESS_TOKEN_ALT = "at-onetwothreefour-1234";
         private const string MOCK_EXPIRED_ACCESS_TOKEN = "at-1234567890-expired";
         private const string MOCK_REFRESH_TOKEN = "rt-1234567809";
+        private const string MOCK_ROTATED_REFRESH_TOKEN = "rt-01189998819991197253";
+        
+        private const string MOCK_CHUNKED_ACCESS_TOKEN_DESCRIPTOR = "chunks=3";
+        private const string MOCK_CHUNKED_ACCESS_TOKEN_1 = "at-123";
+        private const string MOCK_CHUNKED_ACCESS_TOKEN_2 = "456";
+        private const string MOCK_CHUNKED_ACCESS_TOKEN_3 = "789";
+        private const string COMBINED_CHUNKED_ACCESS_TOKEN =
+            MOCK_CHUNKED_ACCESS_TOKEN_1 + MOCK_CHUNKED_ACCESS_TOKEN_2 + MOCK_CHUNKED_ACCESS_TOKEN_3;
+        
+        private const string MOCK_CHUNKED_REFRESH_TOKEN_DESCRIPTOR = "chunks=2";
+        private const string MOCK_CHUNKED_REFRESH_TOKEN_1 = "rt-98765";
+        private const string MOCK_CHUNKED_REFRESH_TOKEN_2 = "4321";
+        private const string COMBINED_CHUNKED_REFRESH_TOKEN =
+            MOCK_CHUNKED_REFRESH_TOKEN_1 + MOCK_CHUNKED_REFRESH_TOKEN_2;
+
         private const string BITBUCKET_DOT_ORG_HOST = "bitbucket.org";
         private const string DC_SERVER_HOST = "example.com";
+        
         private Mock<IBitbucketAuthentication> bitbucketAuthentication = new Mock<IBitbucketAuthentication>(MockBehavior.Strict);
         private Mock<IBitbucketRestApi> bitbucketApi = new Mock<IBitbucketRestApi>(MockBehavior.Strict);
 
@@ -69,6 +86,17 @@ namespace Atlassian.Bitbucket.Tests
             Assert.Equal(expected, provider.IsSupported(request));
         }
 
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData(1, true)]
+        [InlineData(100, true)]
+        public void CredentialStore_SupportsChunking(int? maxCredentialSize, bool supportsChunking)
+        {
+            var context = new TestCommandContext();
+            context.CredentialStore.MaxCredentialSize = maxCredentialSize;
+            Assert.Equal(supportsChunking, context.CredentialStore.SupportsChunking());
+        }
+        
         [Fact]
         public void BitbucketHostProvider_IsSupported_FailsForNullInput()
         {
@@ -171,6 +199,86 @@ namespace Atlassian.Bitbucket.Tests
             // Stored credentials so don't ask for more
             VerifyInteractiveAuthNeverRan();
         }
+        
+        [Theory]
+        // Cloud
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", MOCK_CHUNKED_ACCESS_TOKEN_DESCRIPTOR,COMBINED_CHUNKED_ACCESS_TOKEN)]
+        public async Task BitbucketHostProvider_GetCredentialAsync_Valid_Stored_ChunkedOAuth(
+            string protocol, string host, string username, string storedAccessToken, string expectedAccessToken)
+        {
+            GitRequest request = MockInput(protocol, host, username);
+
+            var context = new TestCommandContext();
+            // The MaxCredentialSize is not used outside of being a gate to enforce whether to support de-chunking a token.
+            context.CredentialStore.MaxCredentialSize = 100;
+
+            if (DC_SERVER_HOST.Equals(host))
+            {
+                MockDCSSOEnabled();
+            }
+            MockStoredAccount(context, request, storedAccessToken);
+            var chunkServiceName = GetAccessTokenChunkServiceName(request);
+            MockStoredToken(context, chunkServiceName,
+                BitbucketHostProvider.GetChunkAccount(username, 0), MOCK_CHUNKED_ACCESS_TOKEN_1);
+            MockStoredToken(context, chunkServiceName,
+                BitbucketHostProvider.GetChunkAccount(username, 1), MOCK_CHUNKED_ACCESS_TOKEN_2);
+            MockStoredToken(context, chunkServiceName,
+                BitbucketHostProvider.GetChunkAccount(username, 2), MOCK_CHUNKED_ACCESS_TOKEN_3);
+            
+            MockRemoteAccessTokenValid(username, expectedAccessToken);
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
+
+            var result = await provider.GetCredentialAsync(request);
+            ICredential credential = result.Credential;
+
+            Assert.Equal(username, credential.Account);
+            Assert.Equal(expectedAccessToken, credential.Password);
+
+            // Verify bitbucket.org credentials were validated
+            VerifyValidateAccessTokenRan(request, expectedAccessToken);
+
+            // Stored credentials so don't ask for more
+            VerifyInteractiveAuthNeverRan();
+        }
+        
+        [Theory]
+        // Cloud
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", MOCK_CHUNKED_ACCESS_TOKEN_DESCRIPTOR)]
+        public async Task BitbucketHostProvider_GetCredentialAsync_Valid_IgnoresChunkedOAuthForUnsupportedCredentialStore(
+            string protocol, string host, string username, string token)
+        {
+            // This is a contrived test - but it's showing that the password even though it's got the appearance of
+            // being chunked, is not read as chunked password, it's passed directly on and the CredentialStore doesn't
+            // need to support chunking.
+            GitRequest request = MockInput(protocol, host, username);
+
+            var context = new TestCommandContext();
+            // Credential store doesn't support chunking
+            context.CredentialStore.MaxCredentialSize = null;
+
+            if (DC_SERVER_HOST.Equals(host))
+            {
+                MockDCSSOEnabled();
+            }
+            MockStoredAccount(context, request, token);
+            
+            MockRemoteAccessTokenValid(username, token);
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
+
+            var result = await provider.GetCredentialAsync(request);
+            ICredential credential = result.Credential;
+
+            Assert.Equal(username, credential.Account);
+            Assert.Equal(token, credential.Password);
+
+            // Verify bitbucket.org credentials were validated
+            VerifyValidateAccessTokenRan(request, token);
+
+            // Stored credentials so don't ask for more
+            VerifyInteractiveAuthNeverRan();
+        }
 
         private void MockDCSSOEnabled()
         {
@@ -230,7 +338,7 @@ namespace Atlassian.Bitbucket.Tests
             VerifyValidateAccessTokenRan(request, accessToken);
 
             var refreshService = GetRefreshTokenServiceNameForRequest(request);
-            VerifyOAuthRefreshTokenStored(context, refreshService, username, refreshToken);
+            VerifyOAuthTokenStored(context, refreshService, username, refreshToken);
         }
 
 
@@ -260,7 +368,7 @@ namespace Atlassian.Bitbucket.Tests
             VerifyValidateAccessTokenRan(request, accessToken);
             
             var refreshService = GetRefreshTokenServiceNameForRequest(request);
-            VerifyOAuthRefreshTokenStored(context, refreshService, username, refreshToken);
+            VerifyOAuthTokenStored(context, refreshService, username, refreshToken);
         }
 
         [Theory]
@@ -274,7 +382,7 @@ namespace Atlassian.Bitbucket.Tests
             var context = new TestCommandContext();
 
             // AT has does not exist, but RT is still valid
-            MockStoredRefreshToken(context, request, refreshToken);
+            MockStoredRefreshTokenForRequest(context, request, refreshToken);
             MockRemoteAccessTokenValid(username, accessToken);
             MockRemoteRefreshTokenValid(request, refreshToken, accessToken);
 
@@ -289,6 +397,43 @@ namespace Atlassian.Bitbucket.Tests
             VerifyValidateAccessTokenRan(request, accessToken);
             VerifyOAuthRefreshRan(request, refreshToken);
             VerifyInteractiveAuthNeverRan();
+        }
+        
+        [Theory]
+        // DC/Server does not currently support OAuth
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", MOCK_REFRESH_TOKEN, MOCK_ACCESS_TOKEN, MOCK_ROTATED_REFRESH_TOKEN)]
+        public async Task BitbucketHostProvider_GetCredentialAsync_Invalid_MalformedChunkedAT_OAuth_Refresh(
+            string protocol, string host, string username, string refreshToken, string rotatedAccessToken, string rotatedRefreshToken)
+        {
+            var request = MockInput(protocol, host, username);
+
+            var context = new TestCommandContext();
+
+            // A chunked AT record exists, but we're missing a part of it. This is treated as if we have no AT
+            var chunkServiceName = GetAccessTokenChunkServiceName(request);
+            MockStoredToken(context, chunkServiceName,
+                BitbucketHostProvider.GetChunkAccount(username, 0), MOCK_CHUNKED_ACCESS_TOKEN_1);
+            MockStoredToken(context, chunkServiceName,
+                BitbucketHostProvider.GetChunkAccount(username, 1), MOCK_CHUNKED_ACCESS_TOKEN_2);
+            
+            MockStoredRefreshTokenForRequest(context, request, refreshToken);
+            MockRemoteAccessTokenValid(username, rotatedAccessToken);
+            MockRemoteRefreshTokenValid(request, refreshToken, rotatedAccessToken, rotatedRefreshToken);
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
+
+            var result = await provider.GetCredentialAsync(request);
+            ICredential credential = result.Credential;
+
+            Assert.Equal(username, credential.Account);
+            Assert.Equal(rotatedAccessToken, credential.Password);
+
+            VerifyValidateAccessTokenRan(request, rotatedAccessToken);
+            VerifyOAuthRefreshRan(request, refreshToken);
+            VerifyInteractiveAuthNeverRan();
+
+            var refreshService = GetRefreshTokenServiceNameForRequest(request);
+            VerifyOAuthTokenStored(context, refreshService, username, rotatedRefreshToken);
         }
 
         [Theory]
@@ -305,7 +450,7 @@ namespace Atlassian.Bitbucket.Tests
             MockStoredAccount(context, request, expiredAccessToken);
             MockRemoteAccessTokenExpired(request, expiredAccessToken);
 
-            MockStoredRefreshToken(context, request, refreshToken);
+            MockStoredRefreshTokenForRequest(context, request, refreshToken);
             MockRemoteAccessTokenValid(username, accessToken);
             MockRemoteRefreshTokenValid(request, refreshToken, accessToken);
 
@@ -321,6 +466,168 @@ namespace Atlassian.Bitbucket.Tests
             VerifyOAuthRefreshRan(request, refreshToken);
             VerifyInteractiveAuthNeverRan();
         }
+        
+        [Theory]
+        // DC/Server does not currently support OAuth
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", MOCK_EXPIRED_ACCESS_TOKEN, MOCK_CHUNKED_REFRESH_TOKEN_DESCRIPTOR, COMBINED_CHUNKED_REFRESH_TOKEN, MOCK_ACCESS_TOKEN, MOCK_ROTATED_REFRESH_TOKEN)]
+        public async Task BitbucketHostProvider_GetCredentialAsync_ExpiredAT_OAuth_Refresh_WithChunkedRT(
+            string protocol, string host, string username, string expiredAccessToken, string storedRefreshToken, string expectedRefreshToken, string rotatedAccessToken, string rotatedRefreshToken)
+        {
+            var request = MockInput(protocol, host, username);
+
+            var context = new TestCommandContext();
+            context.CredentialStore.MaxCredentialSize = 100;
+
+            // AT exists but has expired, but RT is still valid
+            MockStoredAccount(context, request, expiredAccessToken);
+            
+            var refreshTokenChunkServiceName = GetRefreshTokenChunkServiceName(request);
+            MockStoredToken(context, refreshTokenChunkServiceName,
+                BitbucketHostProvider.GetChunkAccount(username, 0), MOCK_CHUNKED_REFRESH_TOKEN_1);
+            MockStoredToken(context, refreshTokenChunkServiceName,
+                BitbucketHostProvider.GetChunkAccount(username, 1), MOCK_CHUNKED_REFRESH_TOKEN_2);
+            MockStoredRefreshTokenForRequest(context, request, storedRefreshToken);
+            
+            MockRemoteAccessTokenExpired(request, expiredAccessToken);
+            MockRemoteAccessTokenValid(username, rotatedAccessToken);
+            MockRemoteRefreshTokenValid(request, expectedRefreshToken, rotatedAccessToken, rotatedRefreshToken);
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
+
+            var result = await provider.GetCredentialAsync(request);
+            ICredential credential = result.Credential;
+
+            Assert.Equal(username, credential.Account);
+            Assert.Equal(rotatedAccessToken, credential.Password);
+
+            VerifyValidateAccessTokenRan(request, rotatedAccessToken);
+            VerifyOAuthRefreshRan(request, expectedRefreshToken);
+            VerifyInteractiveAuthNeverRan();
+            VerifyOAuthTokenStored(context, GetRefreshTokenServiceNameForRequest(request), username, rotatedRefreshToken);
+        }
+        
+        [Theory]
+        // DC/Server does not currently support OAuth
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", MOCK_EXPIRED_ACCESS_TOKEN, MOCK_REFRESH_TOKEN, MOCK_ACCESS_TOKEN)]
+        public async Task BitbucketHostProvider_GetCredentialAsync_ExpiredAT_OAuth_Refresh_StoresChunkedRT(
+            string protocol, string host, string username, string expiredAccessToken, string refreshToken, string accessToken)
+        {
+            var rotatedRt = BuildRandomStringOfLength(299);
+            string rtChunk1 = rotatedRt.Substring(0, 100);
+            string rtChunk2 = rotatedRt.Substring(100, 100);
+            string rtChunk3 = rotatedRt.Substring(200, 99);
+            
+            var request = MockInput(protocol, host, username);
+
+            var context = new TestCommandContext();
+            context.CredentialStore.MaxCredentialSize = 100;
+
+            // AT exists but has expired, but RT is still valid
+            MockStoredAccount(context, request, expiredAccessToken);
+            MockStoredRefreshTokenForRequest(context, request, refreshToken);
+            
+            MockRemoteAccessTokenExpired(request, expiredAccessToken);
+            MockRemoteAccessTokenValid(username, accessToken);
+            // After refreshing we're given back a wide rotated refresh token which would need chunking on supported credentialStores
+            MockRemoteRefreshTokenValid(request, refreshToken, accessToken, rotatedRt);
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
+
+            var result = await provider.GetCredentialAsync(request);
+            ICredential credential = result.Credential;
+
+            Assert.Equal(username, credential.Account);
+            Assert.Equal(accessToken, credential.Password);
+
+            VerifyValidateAccessTokenRan(request, accessToken);
+            VerifyOAuthRefreshRan(request, refreshToken);
+            VerifyInteractiveAuthNeverRan();
+            // Stored RT as chunked
+            VerifyOAuthTokenStored(context, GetRefreshTokenServiceNameForRequest(request), username, "chunks=3");
+            var chunkRtServiceName = GetRefreshTokenChunkServiceName(request);
+            VerifyOAuthTokenStored(context, chunkRtServiceName, $"{username}_0", rtChunk1);
+            VerifyOAuthTokenStored(context, chunkRtServiceName, $"{username}_1", rtChunk2);
+            VerifyOAuthTokenStored(context, chunkRtServiceName, $"{username}_2", rtChunk3);
+        }
+        
+        [Theory]
+        // DC/Server does not currently support OAuth
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", MOCK_EXPIRED_ACCESS_TOKEN, MOCK_REFRESH_TOKEN, MOCK_ACCESS_TOKEN)]
+        public async Task BitbucketHostProvider_GetCredentialAsync_ExpiredAT_OAuth_Refresh_DoesNotChunkLargeRTForUnsupportedCredentialStore(
+            string protocol, string host, string username, string expiredAccessToken, string refreshToken, string accessToken)
+        {
+            var rotatedRt = BuildRandomStringOfLength(2500);
+            
+            var request = MockInput(protocol, host, username);
+
+            var context = new TestCommandContext();
+            // Credential store doesn't support chunking
+            context.CredentialStore.MaxCredentialSize = null;
+
+            // AT exists but has expired, but RT is still valid
+            MockStoredAccount(context, request, expiredAccessToken);
+            MockStoredRefreshTokenForRequest(context, request, refreshToken);
+            
+            MockRemoteAccessTokenExpired(request, expiredAccessToken);
+            MockRemoteAccessTokenValid(username, accessToken);
+            MockRemoteRefreshTokenValid(request, refreshToken, accessToken, rotatedRt);
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
+
+            var result = await provider.GetCredentialAsync(request);
+            ICredential credential = result.Credential;
+
+            Assert.Equal(username, credential.Account);
+            Assert.Equal(accessToken, credential.Password);
+
+            VerifyValidateAccessTokenRan(request, accessToken);
+            VerifyOAuthRefreshRan(request, refreshToken);
+            VerifyInteractiveAuthNeverRan();
+            // Stored RT without chunking
+            VerifyOAuthTokenStored(context, GetRefreshTokenServiceNameForRequest(request), username, rotatedRt);
+        }
+        
+        [Theory]
+        // DC/Server does not currently support OAuth
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", MOCK_EXPIRED_ACCESS_TOKEN, MOCK_ACCESS_TOKEN, MOCK_REFRESH_TOKEN)]
+        public async Task BitbucketHostProvider_GetCredentialAsync_ExpiredAT_OAuth_InvalidChunkedRefresh_PromptsConsent(
+            string protocol, string host, string username, string expiredAccessToken, string rotatedAccessToken, string rotatedRefreshToken)
+        {
+            var request = MockInput(protocol, host, username);
+
+            var context = new TestCommandContext();
+            context.CredentialStore.MaxCredentialSize = 100;
+
+            // AT exists but has expired.
+            MockStoredAccount(context, request, expiredAccessToken);
+            // RT is missing a chunk - so it should be ignored
+            var refreshTokenChunkServiceName = GetRefreshTokenChunkServiceName(request);
+            MockStoredToken(context, refreshTokenChunkServiceName,
+                BitbucketHostProvider.GetChunkAccount(username, 0), MOCK_CHUNKED_REFRESH_TOKEN_1);
+            MockStoredRefreshTokenForRequest(context, request, MOCK_CHUNKED_REFRESH_TOKEN_DESCRIPTOR);
+            
+            
+            MockRemoteAccessTokenExpired(request, expiredAccessToken);
+            MockPromptOAuth(request);
+            // On the OAuth prompt - we will create and store the rotated refresh token
+            MockRemoteOAuthTokenCreate(request, rotatedAccessToken, rotatedRefreshToken);
+            MockRemoteAccessTokenValid(username, rotatedAccessToken);
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
+
+            var result = await provider.GetCredentialAsync(request);
+            ICredential credential = result.Credential;
+
+            Assert.Equal(username, credential.Account);
+            Assert.Equal(rotatedAccessToken, credential.Password);
+
+            VerifyInteractiveAuthRan(request);
+            VerifyOAuthFlowRan(request, rotatedAccessToken);
+            VerifyValidateAccessTokenRan(request, rotatedAccessToken);
+
+            var refreshService = GetRefreshTokenServiceNameForRequest(request);
+            VerifyOAuthTokenStored(context, refreshService, username, rotatedRefreshToken);
+        }
 
         [Theory]
         // Cloud
@@ -334,7 +641,7 @@ namespace Atlassian.Bitbucket.Tests
             context.Environment.Variables.Add(BitbucketConstants.EnvironmentVariables.AuthenticationModes, "oauth");
 
             // We have a stored RT so we can just use that without any prompts
-            MockStoredRefreshToken(context, request, refreshToken);
+            MockStoredRefreshTokenForRequest(context, request, refreshToken);
             MockRemoteAccessTokenValid(username, accessToken);
             MockRemoteRefreshTokenValid(request, refreshToken, accessToken);
 
@@ -362,7 +669,7 @@ namespace Atlassian.Bitbucket.Tests
 
             // User has stored access token that we shouldn't use - RT should be used to mint new AT
             MockStoredAccount(context, request, storedToken);
-            MockStoredRefreshToken(context, request, refreshToken);
+            MockStoredRefreshTokenForRequest(context, request, refreshToken);
             MockRemoteAccessTokenValid(username, newToken);
             MockRemoteRefreshTokenValid(request, refreshToken, newToken);
 
@@ -453,6 +760,59 @@ namespace Atlassian.Bitbucket.Tests
 
             Assert.Equal(1, context.CredentialStore.Count);
         }
+        
+        [Theory]
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST,  "jsquire",100)]
+        public async Task BitbucketHostProvider_StoreCredentialAsync_SplitsIntoChunksForSupportedCredentialStores(string protocol, string host, string username, int credentialWidth)
+        {
+            string longToken = BuildRandomStringOfLength(250);
+            string chunk1 = longToken.Substring(0, credentialWidth);
+            string chunk2 = longToken.Substring(credentialWidth, credentialWidth);
+            string chunk3 = longToken.Substring(200, 50);
+
+            var request = MockInput(protocol, host, username, longToken);
+            var context = new TestCommandContext();
+            context.CredentialStore.MaxCredentialSize = credentialWidth;
+            
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
+
+            Assert.Equal(0, context.CredentialStore.Count);
+
+            await provider.StoreCredentialAsync(request);
+            // The chunk descriptor and 3 chunks
+            Assert.Equal(4, context.CredentialStore.Count);
+            var serviceName = GetAccessTokenServiceName(request);
+            VerifyOAuthTokenStored(context, serviceName, username, "chunks=3");
+            var chunkServiceName = GetAccessTokenChunkServiceName(request);
+            VerifyOAuthTokenStored(context, chunkServiceName, $"{username}_0", chunk1);
+            VerifyOAuthTokenStored(context, chunkServiceName, $"{username}_1", chunk2);
+            VerifyOAuthTokenStored(context, chunkServiceName, $"{username}_2", chunk3);
+        }
+        
+        [Theory]
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST,  "jsquire")]
+        public async Task BitbucketHostProvider_StoreCredentialAsync_DoesNotChunk(string protocol, string host, string username)
+        {
+            // The width is deliberately wider than the known maximum that some credential managers support.
+            string almostTooLongToken = BuildRandomStringOfLength(5000);
+
+            var request = MockInput(protocol, host, username, almostTooLongToken);
+
+            var context = new TestCommandContext();
+            // Credential store doesn't support chunking
+            context.CredentialStore.MaxCredentialSize = null;
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, MockRestApiRegistry(request, bitbucketApi).Object);
+
+            Assert.Equal(0, context.CredentialStore.Count);
+
+            await provider.StoreCredentialAsync(request);
+            Assert.Equal(1, context.CredentialStore.Count);
+            var serviceName = GetAccessTokenServiceName(request);
+            VerifyOAuthTokenStored(context, serviceName, username, almostTooLongToken);
+        }
+        
 
         [Theory]
         [InlineData("https", DC_SERVER_HOST, "jsquire", "password")]
@@ -477,14 +837,20 @@ namespace Atlassian.Bitbucket.Tests
 
         #region Test helpers
 
-        private static GitRequest MockInput(string protocol, string host, string username)
+        private static GitRequest MockInput(string protocol, string host, string username, string password=null)
         {
-            return new GitRequest(new Dictionary<string, string>
+            var payload = new Dictionary<string, string>
             {
                 ["protocol"] = protocol,
                 ["host"] = host,
-                ["username"] = username
-            });
+                ["username"] = username,
+            };
+            if (password != null)
+            {
+                payload["password"] = password;
+            }
+                
+            return new GitRequest(payload);
         }
 
         private void VerifyOAuthFlowRan(GitRequest request, string token)
@@ -532,9 +898,10 @@ namespace Atlassian.Bitbucket.Tests
             bitbucketAuthentication.Verify(m => m.RefreshOAuthCredentialsAsync(request, refreshToken), Times.Once);
         }
 
-        private void MockRemoteRefreshTokenValid(GitRequest request, string refreshToken, string accessToken)
+        private void MockRemoteRefreshTokenValid(GitRequest request, string refreshToken, string accessToken, string rotatedRefreshToken = null)
         {
-            bitbucketAuthentication.Setup(m => m.RefreshOAuthCredentialsAsync(request, refreshToken)).ReturnsAsync(new OAuth2TokenResult(accessToken, "access_token"));
+            bitbucketAuthentication.Setup(m => m.RefreshOAuthCredentialsAsync(request, refreshToken)).ReturnsAsync(
+                new OAuth2TokenResult(accessToken, "access_token") { RefreshToken = rotatedRefreshToken });
         }
 
         private void MockPromptBasic(GitRequest request, string password)
@@ -591,11 +958,15 @@ namespace Atlassian.Bitbucket.Tests
             context.CredentialStore.Add(remoteUrl, new TestCredential(request.Host, request.UserName, password));
         }
 
-        private static void MockStoredRefreshToken(TestCommandContext context, GitRequest request, string token)
+        private static void MockStoredRefreshTokenForRequest(TestCommandContext context, GitRequest request, string token)
         {
             var remoteUri = request.GetRemoteUri();
             var refreshService = BitbucketHostProvider.GetRefreshTokenServiceName(remoteUri);
-            context.CredentialStore.Add(refreshService, new TestCredential(refreshService, request.UserName, token));
+            MockStoredToken(context, refreshService, request.UserName, token);
+        }
+        private static void MockStoredToken(TestCommandContext context, String serviceName, String account, string token)
+        {
+            context.CredentialStore.Add(serviceName, new TestCredential(serviceName, account, token));
         }
 
         private string GetRefreshTokenServiceNameForRequest(GitRequest request)
@@ -603,6 +974,25 @@ namespace Atlassian.Bitbucket.Tests
             var remoteUri = request.GetRemoteUri();
             return BitbucketHostProvider.GetRefreshTokenServiceName(remoteUri);
         }
+        
+        private string GetRefreshTokenChunkServiceName(GitRequest request)
+        {
+            var remoteUri = request.GetRemoteUri();
+            var refreshService = BitbucketHostProvider.GetRefreshTokenServiceName(remoteUri);
+            return BitbucketHostProvider.GetChunkServiceName(refreshService);
+        }
+        
+        private string GetAccessTokenChunkServiceName(GitRequest request)
+        {
+            var service = GetAccessTokenServiceName(request);
+            return BitbucketHostProvider.GetChunkServiceName(service);
+        }
+        private string GetAccessTokenServiceName(GitRequest request)
+        {
+            var remoteUri = request.GetRemoteUri();
+            return BitbucketHostProvider.GetServiceName(remoteUri);
+        }
+
 
         private void MockRemoteOAuthTokenCreate(GitRequest request, string accessToken, string refreshToken)
         {
@@ -610,13 +1000,13 @@ namespace Atlassian.Bitbucket.Tests
                 .ReturnsAsync(new OAuth2TokenResult(accessToken, "access_token") { RefreshToken = refreshToken });
         }
 
-        private void VerifyOAuthRefreshTokenStored(TestCommandContext context, string refreshService, string expectedAccount, string expectedRefreshToken)
+        private void VerifyOAuthTokenStored(TestCommandContext context, string serviceName, string expectedAccount, string expectedToken)
         {
-            bool result = context.CredentialStore.TryGet(refreshService, expectedAccount, out var credential);
+            bool result = context.CredentialStore.TryGet(serviceName, expectedAccount, out var credential);
 
             Assert.True(result);
             Assert.Equal(expectedAccount, credential.Account);
-            Assert.Equal(expectedRefreshToken, credential.Password);
+            Assert.Equal(expectedToken, credential.Password);
         }
 
         private static Mock<IRegistry<IBitbucketRestApi>> MockRestApiRegistry(GitRequest request, Mock<IBitbucketRestApi> bitbucketApi)
@@ -626,6 +1016,19 @@ namespace Atlassian.Bitbucket.Tests
             restApiRegistry.Setup(rar => rar.Get(request)).Returns(bitbucketApi.Object);
 
             return restApiRegistry;
+        }
+
+        private static String BuildRandomStringOfLength(int length)
+        {
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+            StringBuilder sb = new StringBuilder(length);
+
+            for (int i = 0; i < length; i++)
+            {
+                sb.Append(chars[Random.Shared.Next(chars.Length)]);
+            }
+            return sb.ToString();
         }
 
         #endregion

--- a/src/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
+++ b/src/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
@@ -38,7 +38,6 @@ namespace Atlassian.Bitbucket.Tests
 
         private const string BITBUCKET_DOT_ORG_HOST = "bitbucket.org";
         private const string DC_SERVER_HOST = "example.com";
-        
         private Mock<IBitbucketAuthentication> bitbucketAuthentication = new Mock<IBitbucketAuthentication>(MockBehavior.Strict);
         private Mock<IBitbucketRestApi> bitbucketApi = new Mock<IBitbucketRestApi>(MockBehavior.Strict);
 

--- a/src/Atlassian.Bitbucket/BitbucketHostProvider.cs
+++ b/src/Atlassian.Bitbucket/BitbucketHostProvider.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Atlassian.Bitbucket.Cloud;
 using GitCredentialManager;
@@ -10,13 +11,16 @@ using System.Text.RegularExpressions;
 
 namespace Atlassian.Bitbucket
 {
-    public class BitbucketHostProvider : IHostProvider
+    public partial class BitbucketHostProvider : IHostProvider
     {
         private readonly ICommandContext _context;
         private readonly IBitbucketAuthentication _bitbucketAuth;
         private readonly IRegistry<IBitbucketRestApi> _restApiRegistry;
-        private const string ChunkRegex = @"^chunks=(?'count'\d+)$";
-
+        
+        private const string ChunkRegexPattern = @"^chunks=(?'count'\d+)$";
+        [GeneratedRegex(ChunkRegexPattern)]
+        private static partial Regex ChunkRegex();
+        
         public BitbucketHostProvider(ICommandContext context)
             : this(context, new BitbucketAuthentication(context), new BitbucketRestApiRegistry(context)) { }
 
@@ -449,17 +453,15 @@ namespace Atlassian.Bitbucket
 
         private void AddOrUpdateCredential(string service, string account, string secret)
         {
-            var chunkConfig = _context.CredentialStore.MaxCredentialSize;
-            
-            if (chunkConfig.HasValue && secret?.Length > chunkConfig.Value)
+            if (SecretRequiresChunking(secret, out var chunkSize))
             {
                 var chunks = secret
-                    .Chunk(chunkConfig.Value)
+                    .Chunk((int)chunkSize)
                     .Select(x => new string(x)).ToList();
                 var chunkCount = chunks.Count;
                 _context.Trace.WriteLine(
-                    $"Storing credential of length {secret.Length} in {chunkCount} chunks for service: {service} and " +
-                    $"account: {account}"
+                    $"Storing credential of length {secret.Length} in {chunkCount} chunks of size {chunkSize} for " +
+                    $"service: {service} and account: {account}"
                 );
                 // We're storing the chunks in a separate service (nested under the provided service). This ensures that
                 // retrieving credentials for the provided service cannot trip up on the chunks when looking up with a
@@ -490,20 +492,32 @@ namespace Atlassian.Bitbucket
             }
         }
 
-        private int? GetChunkCount(ICredential credential)
+        private bool SecretRequiresDechunking(String secret, out int chunkCount)
         {
-            if (_context.CredentialStore.SupportsChunking() && credential.Password is not null)
+            var chunkSize = _context.CredentialStore.MaxCredentialSize;
+            // If the credentialStore has a valid configured chunk size, we have to support reading a chunked secret.
+            if (chunkSize > 0 && secret is not null)
             {
-                var isChunked = Regex.Match(credential.Password, ChunkRegex);
+                var isChunked = ChunkRegex().Match(secret);
                 if (isChunked.Success)
                 {
-                    return int.Parse(isChunked.Groups["count"].Value);
+                    chunkCount = int.Parse(isChunked.Groups["count"].Value);
+                    return true;
                 }
             }
             // If the credentialStore does not support chunking, or the secret wasn't a chunk descriptor, we are
             // returning null to indicate we shouldn't read using the chunking implementation
-            return null;
+            chunkCount = 0;
+            return false;
         }
+        
+        private bool SecretRequiresChunking(string secret, out int chunkSize)
+        {
+            // If a secret is bigger than the credentialStore's valid configured chunk size - we have to chunk it.
+            chunkSize = _context.CredentialStore.MaxCredentialSize;
+            return chunkSize > 0 && secret?.Length > chunkSize;
+        }
+        
         
         private ICredential GetCredential(string service, string account)
         {   
@@ -512,11 +526,9 @@ namespace Atlassian.Bitbucket
             {
                 return null;
             }
-
-            var optionalChunkCount = GetChunkCount(credential);
-            if (optionalChunkCount.HasValue)
+            
+            if (SecretRequiresDechunking(credential.Password, out var chunkCount))
             {
-                var chunkCount = optionalChunkCount.Value;
                 // We will be using the Account stored in the located credential to build the chunk identifiers and
                 // return the stitched together final Credential.
                 var credentialAccount = credential.Account;
@@ -525,7 +537,7 @@ namespace Atlassian.Bitbucket
                     $" stored against account: {credentialAccount}"
                 );
                 
-                var chunkedPassword = "";
+                var chunkedPasswordBuilder = new StringBuilder();
                 var chunkedService = GetChunkServiceName(service);
                 for (var index = 0; index < chunkCount; index++)
                 {  
@@ -540,10 +552,10 @@ namespace Atlassian.Bitbucket
                         $"Found chunk for service: {chunkedService} and account: {chunkAccount}: {{0}}", 
                         new object[] { chunk.Password }
                     );
-                    chunkedPassword += chunk.Password;
+                    chunkedPasswordBuilder.Append(chunk.Password);
                 }
                 // We've stitched together all the chunks into a singular secret - return it with the original account.
-                return new GitCredential(credentialAccount, chunkedPassword);
+                return new GitCredential(credentialAccount, chunkedPasswordBuilder.ToString());
             }
             _context.Trace.WriteLine(
                 $"Found non-chunked credential for service: {service} and account: {account} stored against " +
@@ -588,13 +600,6 @@ namespace Atlassian.Bitbucket
         {
             _restApiRegistry.Dispose();
             _bitbucketAuth.Dispose();
-        }
-    }
-    static class CredentialStoreExtensions
-    {
-        public static bool SupportsChunking(this ICredentialStore store)
-        {
-            return store.MaxCredentialSize.HasValue;
         }
     }
 }

--- a/src/Atlassian.Bitbucket/BitbucketHostProvider.cs
+++ b/src/Atlassian.Bitbucket/BitbucketHostProvider.cs
@@ -6,7 +6,8 @@ using System.Threading.Tasks;
 using Atlassian.Bitbucket.Cloud;
 using GitCredentialManager;
 using GitCredentialManager.Authentication.OAuth;
-using Spectre.Console;
+using System.Text.RegularExpressions;
+using GitCredentialManager.Interop.Windows;
 
 namespace Atlassian.Bitbucket
 {
@@ -15,6 +16,7 @@ namespace Atlassian.Bitbucket
         private readonly ICommandContext _context;
         private readonly IBitbucketAuthentication _bitbucketAuth;
         private readonly IRegistry<IBitbucketRestApi> _restApiRegistry;
+        private const string ChunkRegex = @"^chunks=(?'count'\d+)$";
 
         public BitbucketHostProvider(ICommandContext context)
             : this(context, new BitbucketAuthentication(context), new BitbucketRestApiRegistry(context)) { }
@@ -112,8 +114,7 @@ namespace Atlassian.Bitbucket
             Uri remoteUri = request.GetRemoteUri();
             string credentialService = GetServiceName(remoteUri);
             _context.Trace.WriteLine($"Look for existing credentials under {credentialService} ...");
-
-            ICredential credentials = _context.CredentialStore.Get(credentialService, request.UserName);
+            ICredential credentials = GetCredential(credentialService, request.UserName);
 
             if (credentials == null)
             {
@@ -150,7 +151,7 @@ namespace Atlassian.Bitbucket
             // store.
             // If a refresh token is unable to be found a full OAuth authorization flow is initiated.
             ICredential refreshToken = SupportsOAuth(authModes)
-                ? _context.CredentialStore.Get(refreshTokenService, request.UserName)
+                ? GetCredential(refreshTokenService, request.UserName)
                 : null;
 
             if (refreshToken is null)
@@ -239,7 +240,7 @@ namespace Atlassian.Bitbucket
 
             // Store the new refresh token in the credential store against the resolved Bitbucket username
             _context.Trace.WriteLine($"Storing new refresh token against user: '{bitbucketUsername}'...");
-            _context.CredentialStore.AddOrUpdate(refreshTokenService, bitbucketUsername, tokenSet.RefreshToken);    
+            AddOrUpdateCredential(refreshTokenService, bitbucketUsername, tokenSet.RefreshToken);
             _context.Trace.WriteLine("Refresh token was successfully stored.");
 
             // Return the new AT as the credential
@@ -331,9 +332,8 @@ namespace Atlassian.Bitbucket
             string service = GetServiceName(remoteUri);
 
             _context.Trace.WriteLine("Storing credential...");
-            _context.CredentialStore.AddOrUpdate(service, request.UserName, request.Password);
+            AddOrUpdateCredential(service, request.UserName, request.Password);
             _context.Trace.WriteLine("Credential was successfully stored.");
-
             return Task.CompletedTask;
         }
 
@@ -448,7 +448,126 @@ namespace Atlassian.Bitbucket
             return true;
         }
 
-        private static string GetServiceName(Uri remoteUri)
+        private void AddOrUpdateCredential(string service, string account, string secret)
+        {
+            var chunkConfig = _context.CredentialStore.MaxCredentialSize;
+            
+            if (chunkConfig.HasValue && secret?.Length > chunkConfig.Value)
+            {
+                var chunks = secret
+                    .Chunk(chunkConfig.Value)
+                    .Select(x => new string(x)).ToList();
+                var chunkCount = chunks.Count;
+                _context.Trace.WriteLine(
+                    $"Storing credential of length {secret.Length} in {chunkCount} chunks for service: {service} and " +
+                    $"account: {account}"
+                );
+                // We're storing the chunks in a separate service (nested under the provided service). This ensures that
+                // retrieving credentials for the provided service cannot trip up on the chunks when looking up with a
+                // null account.
+                var chunkService = GetChunkServiceName(service);
+                foreach (var (secretChunk, index) in chunks.Select((value, i) => (value, i)))
+                {
+                    var chunkAccount = GetChunkAccount(account, index);
+                    _context.Trace.WriteLineSecrets(
+                        $"Storing chunk for service: {chunkService} and account: {chunkAccount}: {{0}}",
+                        new object[] { secretChunk });
+                    _context.CredentialStore.AddOrUpdate(chunkService, chunkAccount, secretChunk);
+                }
+                // When using the chunking implementation we store a chunk descriptor against the account in the usual
+                // service. This allows us to identify (on get) that we've stored chunks, and the number of chunks to
+                // query.
+                _context.CredentialStore.AddOrUpdate(service, account, GetChunkSecret(chunkCount));
+            }
+            else
+            {
+                _context.Trace.WriteLine(
+                    $"Storing credential of length {(secret ?? "").Length} for service: {service} and " +
+                    $"account: {account}"
+                );
+                // In the case we only have a single chunk (which will be the case on all credential managers except
+                // `wincredman`) we can store the secret as the old code used to.
+                _context.CredentialStore.AddOrUpdate(service, account, secret);
+            }
+        }
+
+        private int? GetChunkCount(ICredential credential)
+        {
+            if (_context.CredentialStore.SupportsChunking() && credential.Password is not null)
+            {
+                var isChunked = Regex.Match(credential.Password, ChunkRegex);
+                if (isChunked.Success)
+                {
+                    return int.Parse(isChunked.Groups["count"].Value);
+                }
+            }
+            // If the credentialStore does not support chunking, or the secret wasn't a chunk descriptor, we are
+            // returning null to indicate we shouldn't read using the chunking implementation
+            return null;
+        }
+        
+        private ICredential GetCredential(string service, string account)
+        {   
+            var credential = _context.CredentialStore.Get(service, account);
+            if (credential is null)
+            {
+                return null;
+            }
+
+            var optionalChunkCount = GetChunkCount(credential);
+            if (optionalChunkCount.HasValue)
+            {
+                var chunkCount = optionalChunkCount.Value;
+                // We will be using the Account stored in the located credential to build the chunk identifiers and
+                // return the stitched together final Credential.
+                var credentialAccount = credential.Account;
+                _context.Trace.WriteLine(
+                    $"Found chunked credential (chunks={chunkCount}) for service: {service} and account: {account} " +
+                    $" stored against account: {credentialAccount}"
+                );
+                
+                var chunkedPassword = "";
+                var chunkedService = GetChunkServiceName(service);
+                for (var index = 0; index < chunkCount; index++)
+                {  
+                    // Build the chunk identifier using the username stored in the chunk descriptor we looked up.
+                    var chunkAccount = GetChunkAccount(credentialAccount, index);
+                    var chunk = _context.CredentialStore.Get(chunkedService, chunkAccount);
+                    if(chunk == null){
+                        _context.Trace.WriteLine($"Chunk {index} was unexpectedly null");
+                        return null;
+                    }
+                    _context.Trace.WriteLineSecrets(
+                        $"Found chunk for service: {chunkedService} and account: {chunkAccount}: {{0}}", 
+                        new object[] { chunk.Password }
+                    );
+                    chunkedPassword += chunk.Password;
+                }
+                // We've stitched together all the chunks into a singular secret - return it with the original account.
+                return new GitCredential(credentialAccount, chunkedPassword);
+            }
+            _context.Trace.WriteLine(
+                $"Found non-chunked credential for service: {service} and account: {account} stored against " +
+                $"account: {credential.Account}"
+            );
+            return credential;
+        }
+         
+        internal /* for testing */ static  string GetChunkAccount(string account, int chunkIndex)
+        {
+            return $"{account}_{chunkIndex}";
+        }
+        internal /* for testing */ static  string GetChunkSecret(int chunkCount)
+        {
+            return $"chunks={chunkCount}";
+        }
+        
+        internal /* for testing */ static  string GetChunkServiceName(string service)
+        {
+            return $"{service}/chunks";
+        }
+        
+        internal /* for testing */ static string GetServiceName(Uri remoteUri)
         {
             return remoteUri.WithoutUserInfo().AbsoluteUri.TrimEnd('/');
         }
@@ -470,6 +589,13 @@ namespace Atlassian.Bitbucket
         {
             _restApiRegistry.Dispose();
             _bitbucketAuth.Dispose();
+        }
+    }
+    static class CredentialStoreExtensions
+    {
+        public static bool SupportsChunking(this ICredentialStore store)
+        {
+            return store.MaxCredentialSize.HasValue;
         }
     }
 }

--- a/src/Atlassian.Bitbucket/BitbucketHostProvider.cs
+++ b/src/Atlassian.Bitbucket/BitbucketHostProvider.cs
@@ -7,7 +7,6 @@ using Atlassian.Bitbucket.Cloud;
 using GitCredentialManager;
 using GitCredentialManager.Authentication.OAuth;
 using System.Text.RegularExpressions;
-using GitCredentialManager.Interop.Windows;
 
 namespace Atlassian.Bitbucket
 {
@@ -533,7 +532,7 @@ namespace Atlassian.Bitbucket
                     // Build the chunk identifier using the username stored in the chunk descriptor we looked up.
                     var chunkAccount = GetChunkAccount(credentialAccount, index);
                     var chunk = _context.CredentialStore.Get(chunkedService, chunkAccount);
-                    if(chunk == null){
+                    if (chunk == null){
                         _context.Trace.WriteLine($"Chunk {index} was unexpectedly null");
                         return null;
                     }

--- a/src/Core.Tests/Interop/Linux/SecretServiceCollectionTests.cs
+++ b/src/Core.Tests/Interop/Linux/SecretServiceCollectionTests.cs
@@ -60,5 +60,12 @@ namespace GitCredentialManager.Tests.Interop.Linux
             bool result = collection.Remove(service, account: null);
             Assert.False(result);
         }
+        
+        [LinuxFact(Skip = "Cannot run headless")]
+        public void SecretServiceCollection_MaxCredentialSize_ReturnsNull()
+        {
+            ICredentialStore credentialStore = new SecretServiceCollection(TestNamespace);
+            Assert.False(credentialStore.MaxCredentialSize.HasValue);
+        }
     }
 }

--- a/src/Core.Tests/Interop/Linux/SecretServiceCollectionTests.cs
+++ b/src/Core.Tests/Interop/Linux/SecretServiceCollectionTests.cs
@@ -62,10 +62,10 @@ namespace GitCredentialManager.Tests.Interop.Linux
         }
         
         [LinuxFact(Skip = "Cannot run headless")]
-        public void SecretServiceCollection_MaxCredentialSize_ReturnsNull()
+        public void SecretServiceCollection_MaxCredentialSize_ReturnsZero()
         {
             ICredentialStore credentialStore = new SecretServiceCollection(TestNamespace);
-            Assert.False(credentialStore.MaxCredentialSize.HasValue);
+            Assert.Equal(0, credentialStore.MaxCredentialSize);
         }
     }
 }

--- a/src/Core.Tests/Interop/MacOS/MacOSKeychainTests.cs
+++ b/src/Core.Tests/Interop/MacOS/MacOSKeychainTests.cs
@@ -75,5 +75,12 @@ namespace GitCredentialManager.Tests.Interop.MacOS
             bool result = keychain.Remove(service, account: null);
             Assert.False(result);
         }
+        
+        [MacOSFact]
+        public void MacOSKeychain_MaxCredentialSize_ReturnsNull()
+        {
+            ICredentialStore credentialStore = new MacOSKeychain(TestNamespace);
+            Assert.False(credentialStore.MaxCredentialSize.HasValue);
+        }
     }
 }

--- a/src/Core.Tests/Interop/MacOS/MacOSKeychainTests.cs
+++ b/src/Core.Tests/Interop/MacOS/MacOSKeychainTests.cs
@@ -77,10 +77,10 @@ namespace GitCredentialManager.Tests.Interop.MacOS
         }
         
         [MacOSFact]
-        public void MacOSKeychain_MaxCredentialSize_ReturnsNull()
+        public void MacOSKeychain_MaxCredentialSize_ReturnsZero()
         {
             ICredentialStore credentialStore = new MacOSKeychain(TestNamespace);
-            Assert.False(credentialStore.MaxCredentialSize.HasValue);
+            Assert.Equal(0, credentialStore.MaxCredentialSize);
         }
     }
 }

--- a/src/Core.Tests/Interop/Posix/GnuPassCredentialStoreTests.cs
+++ b/src/Core.Tests/Interop/Posix/GnuPassCredentialStoreTests.cs
@@ -181,6 +181,17 @@ namespace GitCredentialManager.Tests.Interop.Posix
                 collection.Remove(service, userName);
             }
         }
+        
+        [PosixFact]
+        public void GpgPassCredentialStore_MaxCredentialSize_ReturnsNull()
+        {
+            var fs = new TestFileSystem();
+            var gpg = new TestGpg(fs);
+            string storeRoot = InitializePasswordStore(fs, gpg);
+
+            ICredentialStore credentialStore = new GpgPassCredentialStore(fs, gpg, storeRoot, TestNamespace);
+            Assert.False(credentialStore.MaxCredentialSize.HasValue);
+        }
 
         private static string InitializePasswordStore(TestFileSystem fs, TestGpg gpg)
         {

--- a/src/Core.Tests/Interop/Posix/GnuPassCredentialStoreTests.cs
+++ b/src/Core.Tests/Interop/Posix/GnuPassCredentialStoreTests.cs
@@ -183,14 +183,14 @@ namespace GitCredentialManager.Tests.Interop.Posix
         }
         
         [PosixFact]
-        public void GpgPassCredentialStore_MaxCredentialSize_ReturnsNull()
+        public void GpgPassCredentialStore_MaxCredentialSize_ReturnsZero()
         {
             var fs = new TestFileSystem();
             var gpg = new TestGpg(fs);
             string storeRoot = InitializePasswordStore(fs, gpg);
 
             ICredentialStore credentialStore = new GpgPassCredentialStore(fs, gpg, storeRoot, TestNamespace);
-            Assert.False(credentialStore.MaxCredentialSize.HasValue);
+            Assert.Equal(0, credentialStore.MaxCredentialSize);
         }
 
         private static string InitializePasswordStore(TestFileSystem fs, TestGpg gpg)

--- a/src/Core.Tests/Interop/Windows/DpapiCredentialStoreTests.cs
+++ b/src/Core.Tests/Interop/Windows/DpapiCredentialStoreTests.cs
@@ -109,5 +109,13 @@ namespace GitCredentialManager.Tests.Interop.Windows
             bool result = store.Remove(service, account: null);
             Assert.False(result);
         }
+        
+        [WindowsFact]
+        public void DpapiCredentialStore_MaxCredentialSize_ReturnsNull()
+        {
+            var fs = new TestFileSystem();
+            ICredentialStore credentialStore = new DpapiCredentialStore(fs, TestStoreRoot, TestNamespace);
+            Assert.False(credentialStore.MaxCredentialSize.HasValue);
+        }
     }
 }

--- a/src/Core.Tests/Interop/Windows/DpapiCredentialStoreTests.cs
+++ b/src/Core.Tests/Interop/Windows/DpapiCredentialStoreTests.cs
@@ -111,11 +111,11 @@ namespace GitCredentialManager.Tests.Interop.Windows
         }
         
         [WindowsFact]
-        public void DpapiCredentialStore_MaxCredentialSize_ReturnsNull()
+        public void DpapiCredentialStore_MaxCredentialSize_ReturnsZero()
         {
             var fs = new TestFileSystem();
             ICredentialStore credentialStore = new DpapiCredentialStore(fs, TestStoreRoot, TestNamespace);
-            Assert.False(credentialStore.MaxCredentialSize.HasValue);
+            Assert.Equal(0, credentialStore.MaxCredentialSize);
         }
     }
 }

--- a/src/Core.Tests/Interop/Windows/WindowsCredentialManagerTests.cs
+++ b/src/Core.Tests/Interop/Windows/WindowsCredentialManagerTests.cs
@@ -374,8 +374,7 @@ namespace GitCredentialManager.Tests.Interop.Windows
         public void WindowsCredentialManager_MaxCredentialSize_Returns_1280()
         {
             ICredentialStore credentialStore = new WindowsCredentialManager(TestNamespace);
-            Assert.True(credentialStore.MaxCredentialSize.HasValue);
-            Assert.Equal(1_280, credentialStore.MaxCredentialSize.Value);
+            Assert.Equal(1_280, credentialStore.MaxCredentialSize);
         }
     }
 }

--- a/src/Core.Tests/Interop/Windows/WindowsCredentialManagerTests.cs
+++ b/src/Core.Tests/Interop/Windows/WindowsCredentialManagerTests.cs
@@ -368,5 +368,14 @@ namespace GitCredentialManager.Tests.Interop.Windows
 
             Assert.Equal(expected, actual);
         }
+        
+        
+        [WindowsFact]
+        public void WindowsCredentialManager_MaxCredentialSize_Returns_1280()
+        {
+            ICredentialStore credentialStore = new WindowsCredentialManager(TestNamespace);
+            Assert.True(credentialStore.MaxCredentialSize.HasValue);
+            Assert.Equal(1_280, credentialStore.MaxCredentialSize.Value);
+        }
     }
 }

--- a/src/Core.Tests/PlaintextCredentialStoreTests.cs
+++ b/src/Core.Tests/PlaintextCredentialStoreTests.cs
@@ -86,11 +86,11 @@ namespace GitCredentialManager.Tests
         }
         
         [Fact]
-        public void PlaintextCredentialStore_MaxCredentialSize_ReturnsNull()
+        public void PlaintextCredentialStore_MaxCredentialSize_ReturnsZero()
         {
             var fs = new TestFileSystem();
             ICredentialStore credentialStore = new PlaintextCredentialStore(fs, StoreRoot, TestNamespace);
-            Assert.False(credentialStore.MaxCredentialSize.HasValue);
+            Assert.Equal(0, credentialStore.MaxCredentialSize);
         }
     }
 }

--- a/src/Core.Tests/PlaintextCredentialStoreTests.cs
+++ b/src/Core.Tests/PlaintextCredentialStoreTests.cs
@@ -84,5 +84,13 @@ namespace GitCredentialManager.Tests
             bool result = collection.Remove(service, account: null);
             Assert.False(result);
         }
+        
+        [Fact]
+        public void PlaintextCredentialStore_MaxCredentialSize_ReturnsNull()
+        {
+            var fs = new TestFileSystem();
+            ICredentialStore credentialStore = new PlaintextCredentialStore(fs, StoreRoot, TestNamespace);
+            Assert.False(credentialStore.MaxCredentialSize.HasValue);
+        }
     }
 }

--- a/src/Core/CredentialStore.cs
+++ b/src/Core/CredentialStore.cs
@@ -33,6 +33,14 @@ namespace GitCredentialManager
                 return _backingStore.Name;
             }
         }
+        public int? MaxCredentialSize
+        {
+            get
+            {
+                EnsureBackingStore();
+                return _backingStore.MaxCredentialSize;
+            }
+        }
 
         public IList<string> GetAccounts(string service)
         {

--- a/src/Core/CredentialStore.cs
+++ b/src/Core/CredentialStore.cs
@@ -33,7 +33,7 @@ namespace GitCredentialManager
                 return _backingStore.Name;
             }
         }
-        public int? MaxCredentialSize
+        public int MaxCredentialSize
         {
             get
             {

--- a/src/Core/ICredentialStore.cs
+++ b/src/Core/ICredentialStore.cs
@@ -11,7 +11,13 @@ namespace GitCredentialManager
         /// Get the name of the credential store.
         /// </summary>
         string Name { get; }
-
+        
+        /// <summary>
+        /// Gets the maximum width of a secret that can be stored by this CredentialStore.
+        /// A value of null (the default) indicates there is no limits on the size of credential storage
+        /// </summary>
+        public int? MaxCredentialSize => null;
+        
         /// <summary>
         /// Get all accounts from the store for the given service.
         /// </summary>

--- a/src/Core/ICredentialStore.cs
+++ b/src/Core/ICredentialStore.cs
@@ -13,10 +13,15 @@ namespace GitCredentialManager
         string Name { get; }
         
         /// <summary>
-        /// Gets the maximum width of a secret that can be stored by this CredentialStore.
-        /// A value of null (the default) indicates there is no limits on the size of credential storage
+        /// Gets the maximum width of a secret that can be stored by this CredentialStore. When set allows credentials
+        /// to be stored in chunks of at most the size configured.
+        /// 
+        /// A value of LTE 0 (default of 0) indicates there is no limits set by the CredentialStore
         /// </summary>
-        public int? MaxCredentialSize => null;
+        /// <remarks>
+        /// The size represented here is the number of characters (<see langword="char"/>) of the string.
+        /// </remarks>
+        int MaxCredentialSize => 0;
         
         /// <summary>
         /// Get all accounts from the store for the given service.

--- a/src/Core/Interop/Windows/WindowsCredentialManager.cs
+++ b/src/Core/Interop/Windows/WindowsCredentialManager.cs
@@ -25,6 +25,10 @@ namespace GitCredentialManager.Interop.Windows
         }
 
         public string Name => "Windows Credential Manager";
+        
+        // The underlying Windows Credential Manager is only able to 2,560 bytes per secret. This is 1280 characters in
+        // Unicode encoding.
+        public int? MaxCredentialSize => 1_280;
 
         public IList<string> GetAccounts(string service)
         {

--- a/src/Core/Interop/Windows/WindowsCredentialManager.cs
+++ b/src/Core/Interop/Windows/WindowsCredentialManager.cs
@@ -28,7 +28,7 @@ namespace GitCredentialManager.Interop.Windows
         
         // The underlying Windows Credential Manager is only able to 2,560 bytes per secret. This is 1280 characters in
         // Unicode encoding.
-        public int? MaxCredentialSize => 1_280;
+        public int MaxCredentialSize => 1_280;
 
         public IList<string> GetAccounts(string service)
         {

--- a/src/TestInfrastructure/Objects/TestCredentialStore.cs
+++ b/src/TestInfrastructure/Objects/TestCredentialStore.cs
@@ -16,10 +16,7 @@ namespace GitCredentialManager.Tests.Objects
 
         public string Name => "Test Credential Store";
         
-        public int? MaxCredentialSize
-        {
-            get;set;
-        }
+        public int MaxCredentialSize { get; set; }
 
         public IList<string> GetAccounts(string service)
         {

--- a/src/TestInfrastructure/Objects/TestCredentialStore.cs
+++ b/src/TestInfrastructure/Objects/TestCredentialStore.cs
@@ -15,6 +15,11 @@ namespace GitCredentialManager.Tests.Objects
         #region ICredentialStore
 
         public string Name => "Test Credential Store";
+        
+        public int? MaxCredentialSize
+        {
+            get;set;
+        }
 
         public IList<string> GetAccounts(string service)
         {


### PR DESCRIPTION
# Problem
As stated here: https://github.com/git-ecosystem/git-credential-manager/issues/2428

Bitbucket Cloud will start generating tokens which are in excess of 2,000 character wide strings. This causes problems for our Windows users which have the `wincredman` CredentialStore configured (the default for GCM on windows). Windows underlying credential manager is only able to store 2,560 bytes per secret. 

See: https://learn.microsoft.com/en-us/windows/win32/api/wincred/ns-wincred-credentiala

> CredentialBlobSize
> 
> The size, in bytes, of the CredentialBlob member. This member cannot be larger than CRED_MAX_CREDENTIAL_BLOB_SIZE (5*512) bytes.

This is a 1280 character long unicode string (Validated on my windows 10 laptop).

## Solutions to this Problem
After some back and forth, I decided there was was two options:
1. Force windows users to change their configured `credentialStore` to `dpapi`, so that there isn't a limitation on the size of tokens. This required user action, and meant that any other stored credentials would be lost, and would require re-entry / re-authorization (I know that it's possible to configure different credential stores for different hosts but still)

2. Implement some form of chunking algorithm that allows Windows users to continue to use the same default `CredentialStore` but would get around the size constraints on the Windows Credential Manager. This solution is massively preferable as it means the only action we'd need users to take for us to migrate the OAuth token format would will be to upgrade to the GCM version containing the changes.

# This PR
This PR implements the second option above. This implements the changes isolated within the `BitbucketHostProvider`. It will chunk both `access_tokens` and `refresh_tokens` which are larger than the available space in the underlying `CredentialStore` into the appropriate number of chunks. 

The implementation defines a new overridable property on the `ICredentialStore` which defines the `CredentialStores` maximum credential (when stored as a string) size. The default value for this is `0` which means that the `CredentialStore` does not impose any restrictions. The only `CredentialStore` implementation which sets a max size is the `WindowsCredentialManager`.

## The chunking implementation
The actual chunking implementation is relatively trivial and maintains backwards compatibility for existing stored credentials. This allows backwards compatibility with existing stored secrets.

Consider the following credential to store (length 13)

```
service: bitbucket.org
Account: danielrfraser
Password: a-01234567890
```
Normally this would be stored like this:
```
bitbucket.org/danielrfraser => a-01234567890
```
But let's say we wish to store it in a `CredentialStore` with a limit of **5 characters per credential**. We'd have to break it into 3 chunks (2 complete and 1 partial) which would be stored like this:
```
bitbucket.org/chunks/danielrfraser_0 => a-012
bitbucket.org/chunks/danielrfraser_1 => 34567
bitbucket.org/chunks/danielrfraser_2 => 890
bitbucket.org/danielrfraser => chunks=3
```
We store a chunk descriptor (for lack of better name) against the `account` in the `service`. This means that when we read an existing secret for a given `account`, we would either a **chunk descriptor** or a **regular secret** (which is not chunked).

We can then use regex to detect if the credential is "chunked" or a regular secret. The format of the chunk descriptor: `chunks=<NUMBER_OF_CHUNKS>` is impossible to collide with a real Bitbucket issued PAT or OAuth token - `=` is not an allowed character in our token set, and the width is smaller than we'd ever mint.

If we encounter a chunked descriptor (on Get) we then use the stored credential's `Account`, coupled with the extracted `chunk count` to retrieve the `n` chunks and stitch the full secret together.

Note: If we encounter a missing chunk, we return `null` which would treat it the same as if there was no credential (or an expired credential) and the auth behaviour would continue on.

## Why this solution is good?
* It functions exactly the same as it used to for all other distros / backends.
* It also only chunks if it needs to, so for PAT authentication (even on Windows), the chunking code is not exercised as the tokens are not wide enough to trigger the chunking mechanism.
* It doesn't require any user intervention (outside of updating to this version of GCM) to support our new Access token / refresh tokens.
* It's contained to where it's needed (for now)


# What could be better?
* Potentially this chunking could be lifted (and hidden) into the underlying `WindowsCredentialManager` implementation. This would mean all `HostProviders` could use the behaviour. This seemed like a fair chunk more effort than I can realistically spend. If there is a long term desire that this could be the direction we need to go - we should ensure that we're happy with the "shape" of the implementation so that a future change could be rolled out without impacting the Bitbucket stored secrets.

# Testing
* Tested the build (using a different OAuth client which generates large access tokens / refresh tokens) on Windows 10 / MacOS
